### PR TITLE
Update Public API & Fix Bugs

### DIFF
--- a/FixUndeclaredAPIs.ps1
+++ b/FixUndeclaredAPIs.ps1
@@ -1,6 +1,6 @@
 $numTargetFrameworks = 5
 $command = "dotnet"
-$arguments = @("format", "analyzers", ".\NexusMods.Archives.Nx.sln", "--diagnostics", "RS0037", "RS0016")
+$arguments = @("format", "analyzers", "./NexusMods.Archives.Nx.sln", "--diagnostics", "RS0037", "RS0016")
 
 for ($i = 1; $i -le $numTargetFrameworks; $i++)
 {

--- a/NexusMods.Archives.Nx.Benchmarks/Benchmarks/ParsingTableOfContents.cs
+++ b/NexusMods.Archives.Nx.Benchmarks/Benchmarks/ParsingTableOfContents.cs
@@ -62,7 +62,7 @@ public class ParsingTableOfContents
     {
         fixed (byte* dataPtr = PrebuiltData)
         {
-            return TableOfContents.Deserialize<TableOfContents>(dataPtr, PrebuiltData.Length, Builder.Version);
+            return TableOfContents.Deserialize<TableOfContents>(dataPtr, 0, PrebuiltData.Length, Builder.Version);
         }
     }
 
@@ -95,7 +95,7 @@ public class ParsingTableOfContents
         PrebuiltData = new byte[tocSize];
         fixed (byte* dataPtr = PrebuiltData)
         {
-            return Builder.Build(dataPtr, tocSize);
+            return Builder.Build(dataPtr, 0, tocSize);
         }
     }
 }

--- a/NexusMods.Archives.Nx.Tests/Tests/TableOfContentsSerializationTests.cs
+++ b/NexusMods.Archives.Nx.Tests/Tests/TableOfContentsSerializationTests.cs
@@ -54,11 +54,11 @@ public class TableOfContentsSerializationTests
         var data = new byte[tableOfContents.CalculateTableSize()];
         fixed (byte* dataPtr = data)
         {
-            var bytesWritten = tableOfContents.Build(dataPtr, data.Length);
+            var bytesWritten = tableOfContents.Build(dataPtr, 0, data.Length);
             bytesWritten.Should().Be(data.Length); // We calculated correct size.
 
             // Deserialize
-            var newTable = TableOfContents.Deserialize<TableOfContents>(dataPtr, data.Length, tableOfContents.Version);
+            var newTable = TableOfContents.Deserialize<TableOfContents>(dataPtr, 0, data.Length, tableOfContents.Version);
             newTable.Should().Be(tableOfContents.Toc);
         }
     }

--- a/NexusMods.Archives.Nx/Headers/HeaderParser.cs
+++ b/NexusMods.Archives.Nx/Headers/HeaderParser.cs
@@ -92,7 +92,9 @@ public static class HeaderParser
                 return new HeaderParserResult { Header = null, HeaderSize = header->HeaderPageBytes };
 
             var parsedHeader =
-                TableOfContents.Deserialize<ParsedHeader>(data + sizeof(NativeFileHeader), header->TocSize, (ArchiveVersion)header->Version);
+                TableOfContents.Deserialize<ParsedHeader>(data + sizeof(NativeFileHeader), sizeof(NativeFileHeader), header->TocSize,
+                    (ArchiveVersion)header->Version);
+
             parsedHeader.Header = *header;
             parsedHeader.Init();
 

--- a/NexusMods.Archives.Nx/Headers/TableOfContentsBuilder.cs
+++ b/NexusMods.Archives.Nx/Headers/TableOfContentsBuilder.cs
@@ -145,12 +145,13 @@ internal class TableOfContentsBuilder<T> : IDisposable where T : IHasRelativePat
     /// <summary>
     ///     Serializes the ToC to allow reading from binary.
     /// </summary>
-    /// <param name="dataPtr">Memory where to serialize to.</param>
-    /// <param name="tocSize">Size of table of contents.</param>
+    /// <param name="dataPtr">Address of the table of contents.</param>
+    /// <param name="offsetInFile">Offset of the table of contents in the .nx file.</param>
+    /// <param name="tocSize">Size of table of contents..</param>
     /// <returns>Number of bytes written.</returns>
     /// <remarks>
     ///     To determine needed size of <paramref name="dataPtr" /> and <paramref name="tocSize" />, call
     ///     <see cref="CalculateTableSize" />.
     /// </remarks>
-    public unsafe int Build(byte* dataPtr, int tocSize) => Toc.Serialize(dataPtr, tocSize, Version, _poolData.Span);
+    public unsafe int Build(byte* dataPtr, int offsetInFile, int tocSize) => Toc.Serialize(dataPtr, offsetInFile, tocSize, Version, _poolData.Span);
 }

--- a/NexusMods.Archives.Nx/Packing/NxPacker.cs
+++ b/NexusMods.Archives.Nx/Packing/NxPacker.cs
@@ -67,7 +67,7 @@ public static class NxPacker
             // Write headers.
             stream.Seek(0, SeekOrigin.Begin);
             NativeFileHeader.Init((NativeFileHeader*)headerDataPtr, toc.Version, settings.BlockSize, settings.ChunkSize, headerData.Length);
-            toc.Build(headerDataPtr + sizeof(NativeFileHeader), tocSize);
+            toc.Build(headerDataPtr + sizeof(NativeFileHeader), sizeof(NativeFileHeader), tocSize);
             stream.Write(headerData, 0, headerData.Length);
         }
     }

--- a/NexusMods.Archives.Nx/PublicAPI/net5.0/PublicAPI.Unshipped.txt
+++ b/NexusMods.Archives.Nx/PublicAPI/net5.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
-﻿const NexusMods.Archives.Nx.Headers.StringPool.MaxCompressedSize = 33550336 -> int
+﻿const NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.Length = 4 -> int
+const NexusMods.Archives.Nx.Headers.StringPool.MaxCompressedSize = 33550336 -> int
 NexusMods.Archives.Nx.Enums.CompressionPreference
 NexusMods.Archives.Nx.Enums.CompressionPreference.Copy = 0 -> NexusMods.Archives.Nx.Enums.CompressionPreference
 NexusMods.Archives.Nx.Enums.CompressionPreference.Lz4 = 2 -> NexusMods.Archives.Nx.Enums.CompressionPreference
@@ -362,6 +363,20 @@ override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.Equals(object? o
 override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.GetHashCode() -> int
 override NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.Equals(object? obj) -> bool
 override NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.GetHashCode() -> int
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.GetNames() -> string![]!
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.GetValues() -> NexusMods.Archives.Nx.Enums.CompressionPreference[]!
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.IsDefined(in System.ReadOnlySpan<char> name) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.IsDefined(in System.ReadOnlySpan<char> name, bool allowMatchingMetadataAttribute) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.IsDefined(NexusMods.Archives.Nx.Enums.CompressionPreference value) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.IsDefined(string! name) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.IsDefined(string! name, bool allowMatchingMetadataAttribute) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.ToStringFast(this NexusMods.Archives.Nx.Enums.CompressionPreference value) -> string!
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(in System.ReadOnlySpan<char> name, out NexusMods.Archives.Nx.Enums.CompressionPreference result, bool ignoreCase, bool allowMatchingMetadataAttribute) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(in System.ReadOnlySpan<char> name, out NexusMods.Archives.Nx.Enums.CompressionPreference value) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(in System.ReadOnlySpan<char> name, out NexusMods.Archives.Nx.Enums.CompressionPreference value, bool ignoreCase) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(string? name, out NexusMods.Archives.Nx.Enums.CompressionPreference value) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(string? name, out NexusMods.Archives.Nx.Enums.CompressionPreference value, bool ignoreCase) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(string? name, out NexusMods.Archives.Nx.Enums.CompressionPreference value, bool ignoreCase, bool allowMatchingMetadataAttribute) -> bool
 static NexusMods.Archives.Nx.Headers.HeaderParser.ParseHeader(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> NexusMods.Archives.Nx.Headers.Managed.ParsedHeader!
 static NexusMods.Archives.Nx.Headers.HeaderParser.TryParseHeader(byte* data, int dataSize) -> NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult
 static NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Deserialize<T>(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> T!

--- a/NexusMods.Archives.Nx/PublicAPI/net5.0/PublicAPI.Unshipped.txt
+++ b/NexusMods.Archives.Nx/PublicAPI/net5.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,382 @@
-﻿
+﻿const NexusMods.Archives.Nx.Headers.StringPool.MaxCompressedSize = 33550336 -> int
+NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreference.Copy = 0 -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreference.Lz4 = 2 -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreference.NoPreference = 255 -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreference.ZStandard = 1 -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions
+NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Enums.SolidPreference.Default = 0 -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Enums.SolidPreference.NoSolid = 1 -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData.ArrayFileData(byte[]! data, long start, uint length) -> void
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData.Data.get -> byte*
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.Data.get -> byte*
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.MemoryMappedFileData(string! filePath, long start, uint length) -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.MemoryMappedFileData(string! filePath, long start, uint length, bool readOnly) -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData.Data.get -> byte*
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData.MemoryMappedOutputFileData(System.IO.MemoryMappedFiles.MemoryMappedFile! file, long start, uint length) -> void
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData.Data.get -> byte*
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData.RentedArrayFileData(NexusMods.Archives.Nx.Utilities.ArrayRentalSlice data) -> void
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider.Data.get -> byte[]!
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider.Data.init -> void
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider.FromArrayProvider() -> void
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.Directory.get -> string!
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.Directory.init -> void
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.FromDirectoryDataProvider() -> void
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.RelativePath.get -> string!
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.RelativePath.init -> void
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider.FromStreamProvider(System.IO.Stream! stream) -> void
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider.Stream.get -> System.IO.Stream!
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider.StreamStart.get -> long
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.Data.get -> byte[]!
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.Entry.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.Entry.init -> void
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.OutputArrayProvider(string! relativePath, NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.RelativePath.get -> string!
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.RelativePath.init -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.Entry.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.Entry.init -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.FullPath.get -> string!
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.FullPath.init -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.OutputFileProvider(string! outputFolder, string! relativePath, NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.RelativePath.get -> string!
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.RelativePath.init -> void
+NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion
+NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion.V0 = 0 -> NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion
+NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion.V1 = 1 -> NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion
+NexusMods.Archives.Nx.Headers.HeaderParser
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.Header.get -> NexusMods.Archives.Nx.Headers.Managed.ParsedHeader?
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.Header.init -> void
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.HeaderParserResult() -> void
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.HeaderSize.get -> int
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.HeaderSize.init -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.DecompressedBlockOffset -> int
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.DecompressedSize -> ulong
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FileEntry() -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FilePathIndex -> int
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FirstBlockIndex -> int
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FromReaderV0(ref NexusMods.Archives.Nx.Utilities.LittleEndianReader reader) -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FromReaderV1(ref NexusMods.Archives.Nx.Utilities.LittleEndianReader reader) -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.GetChunkCount(int chunkSizeBytes) -> int
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.Hash -> ulong
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.WriteAsV0(ref NexusMods.Archives.Nx.Utilities.LittleEndianWriter writer) -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.WriteAsV1(ref NexusMods.Archives.Nx.Utilities.LittleEndianWriter writer) -> void
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader.BlockOffsets -> long[]!
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader.Header -> NexusMods.Archives.Nx.Headers.Native.NativeFileHeader
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader.Init() -> void
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader.ParsedHeader() -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.BlockCompressions.get -> NexusMods.Archives.Nx.Enums.CompressionPreference[]!
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.BlockCompressions.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Blocks.get -> NexusMods.Archives.Nx.Headers.Structs.BlockSize[]!
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Blocks.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.CalculateTableSize(NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> int
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Entries.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry[]!
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Entries.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Equals(NexusMods.Archives.Nx.Headers.Managed.TableOfContents? other) -> bool
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Pool.get -> string![]!
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Pool.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.PoolSize.get -> int
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.PoolSize.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Serialize(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version, System.Span<byte> stringPoolData) -> int
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.TableOfContents() -> void
+NexusMods.Archives.Nx.Headers.Native.INativeFileEntry
+NexusMods.Archives.Nx.Headers.Native.INativeFileEntry.CopyFrom(in NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.INativeFileEntry.CopyTo(ref NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.CopyFrom(in NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.CopyTo(ref NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.DecompressedBlockOffset.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.DecompressedBlockOffset.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.DecompressedSize -> uint
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.Equals(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 other) -> bool
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.FilePathIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.FilePathIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.FirstBlockIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.FirstBlockIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.Hash -> ulong
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.NativeFileEntryV0() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.CopyFrom(in NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.CopyTo(ref NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.DecompressedBlockOffset.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.DecompressedBlockOffset.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.DecompressedSize -> ulong
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.Equals(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 other) -> bool
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.FilePathIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.FilePathIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.FirstBlockIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.FirstBlockIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.Hash -> ulong
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.NativeFileEntryV1() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.BlockSize.get -> byte
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.BlockSize.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.BlockSizeBytes.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.BlockSizeBytes.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ChunkSize.get -> byte
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ChunkSize.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ChunkSizeBytes.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ChunkSizeBytes.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.FeatureFlags -> byte
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.HeaderPageBytes.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.HeaderPageBytes.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.HeaderPageCount.get -> ushort
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.HeaderPageCount.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.IsValidMagicHeader() -> bool
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.Magic -> uint
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.NativeFileHeader() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ReverseEndianIfNeeded() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.SetMagic() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.TocSize.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.Version.get -> byte
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.Version.set -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.CopyTo(ref NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.DecompressedBlockOffset.get -> int
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.DecompressedBlockOffset.set -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.Equals(NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple other) -> bool
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.FilePathIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.FilePathIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.FirstBlockIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.FirstBlockIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.OffsetPathIndexTuple() -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.OffsetPathIndexTuple(int decompressedBlockOffset, int filePathIndex, int firstBlockIndex) -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.OffsetPathIndexTuple(long data) -> void
+NexusMods.Archives.Nx.Headers.StringPool
+NexusMods.Archives.Nx.Headers.StringPool.StringPool() -> void
+NexusMods.Archives.Nx.Headers.Structs.BlockSize
+NexusMods.Archives.Nx.Headers.Structs.BlockSize.BlockSize() -> void
+NexusMods.Archives.Nx.Headers.Structs.BlockSize.CompressedSize -> int
+NexusMods.Archives.Nx.Interfaces.IFileData
+NexusMods.Archives.Nx.Interfaces.IFileData.Data.get -> byte*
+NexusMods.Archives.Nx.Interfaces.IFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.Interfaces.IFileDataProvider
+NexusMods.Archives.Nx.Interfaces.IFileDataProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.Interfaces.IOutputDataProvider
+NexusMods.Archives.Nx.Interfaces.IOutputDataProvider.Entry.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.Interfaces.IOutputDataProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.Interfaces.IOutputDataProvider.RelativePath.get -> string!
+NexusMods.Archives.Nx.Packing.AddFileParams
+NexusMods.Archives.Nx.Packing.AddFileParams.AddFileParams() -> void
+NexusMods.Archives.Nx.Packing.AddFileParams.CompressionPreference.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Packing.AddFileParams.CompressionPreference.set -> void
+NexusMods.Archives.Nx.Packing.AddFileParams.RelativePath.get -> string!
+NexusMods.Archives.Nx.Packing.AddFileParams.RelativePath.init -> void
+NexusMods.Archives.Nx.Packing.AddFileParams.SolidType.get -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Packing.AddFileParams.SolidType.set -> void
+NexusMods.Archives.Nx.Packing.NxPacker
+NexusMods.Archives.Nx.Packing.NxPackerBuilder
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFile(byte[]! data, NexusMods.Archives.Nx.Packing.AddFileParams options) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFile(string! filePath, NexusMods.Archives.Nx.Packing.AddFileParams options) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFile(System.IO.Stream! stream, long length, NexusMods.Archives.Nx.Packing.AddFileParams options) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFile(System.IO.Stream! stream, NexusMods.Archives.Nx.Packing.AddFileParams options) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFolder(string! folder) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.Build(bool disposeOutput = true) -> System.IO.Stream!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.Files.get -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.NxPackerBuilder() -> void
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.Settings.get -> NexusMods.Archives.Nx.Structs.PackerSettings!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithBlockSize(int blockSize) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithChunkedFileAlgorithm(NexusMods.Archives.Nx.Enums.CompressionPreference chunkedFileAlgorithm) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithChunkedLevel(int level) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithChunkSize(int chunkSize) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithMaxNumThreads(int maxNumThreads) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithOutput(System.IO.Stream! output) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithPreset(NexusMods.Archives.Nx.Packing.PackerPreset preset) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithProgress(System.IProgress<double>? progress) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithSolidBlockAlgorithm(NexusMods.Archives.Nx.Enums.CompressionPreference solidBlockAlgorithm) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithSolidCompressionLevel(int level) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpacker
+NexusMods.Archives.Nx.Packing.NxUnpacker.ExtractFiles(NexusMods.Archives.Nx.Interfaces.IOutputDataProvider![]! outputs, NexusMods.Archives.Nx.Structs.UnpackerSettings! settings) -> void
+NexusMods.Archives.Nx.Packing.NxUnpacker.ExtractFilesInMemory(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, NexusMods.Archives.Nx.Structs.UnpackerSettings! settings) -> NexusMods.Archives.Nx.FileProviders.OutputArrayProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.ExtractFilesToDisk(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, string! outputFolder, NexusMods.Archives.Nx.Structs.UnpackerSettings! settings) -> NexusMods.Archives.Nx.FileProviders.OutputFileProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.GetFileEntriesRaw() -> System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry>
+NexusMods.Archives.Nx.Packing.NxUnpacker.GetFilePath(NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> string!
+NexusMods.Archives.Nx.Packing.NxUnpacker.GetPathedFileEntries() -> NexusMods.Archives.Nx.Packing.PathedFileEntry![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.MakeArrayOutputProviders(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files) -> NexusMods.Archives.Nx.FileProviders.OutputArrayProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.MakeDiskOutputProviders(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, string! outputFolder) -> NexusMods.Archives.Nx.FileProviders.OutputFileProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.NxUnpacker(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> void
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.AddFilesWithArrayOutput(NexusMods.Archives.Nx.Packing.PathedFileEntry![]! files, out NexusMods.Archives.Nx.FileProviders.OutputArrayProvider![]! results) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.AddFilesWithArrayOutput(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, out NexusMods.Archives.Nx.FileProviders.OutputArrayProvider![]! results) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.AddFilesWithDiskOutput(NexusMods.Archives.Nx.Packing.PathedFileEntry![]! files, string! outputFolder) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.AddFilesWithDiskOutput(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, string! outputFolder) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.Extract() -> NexusMods.Archives.Nx.Interfaces.IOutputDataProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.GetFileEntriesRaw() -> System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry>
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.GetPathedFileEntries() -> NexusMods.Archives.Nx.Packing.PathedFileEntry![]!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.NxUnpackerBuilder(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> void
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.Outputs.get -> System.Collections.Generic.List<NexusMods.Archives.Nx.Interfaces.IOutputDataProvider!>!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.Settings.get -> NexusMods.Archives.Nx.Structs.UnpackerSettings!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.Unpacker.get -> NexusMods.Archives.Nx.Packing.NxUnpacker!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.WithMaxNumThreads(int maxNumThreads) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.WithProgress(System.IProgress<double>? progress) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.PackerPreset
+NexusMods.Archives.Nx.Packing.PackerPreset.Default = 0 -> NexusMods.Archives.Nx.Packing.PackerPreset
+NexusMods.Archives.Nx.Packing.PackerPreset.RandomAccess = 1 -> NexusMods.Archives.Nx.Packing.PackerPreset
+NexusMods.Archives.Nx.Packing.PathedFileEntry
+NexusMods.Archives.Nx.Packing.PathedFileEntry.Entry.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.Packing.PathedFileEntry.Entry.init -> void
+NexusMods.Archives.Nx.Packing.PathedFileEntry.FileName.get -> string!
+NexusMods.Archives.Nx.Packing.PathedFileEntry.FileName.init -> void
+NexusMods.Archives.Nx.Packing.PathedFileEntry.PathedFileEntry() -> void
+NexusMods.Archives.Nx.Structs.PackerFile
+NexusMods.Archives.Nx.Structs.PackerFile.CompressionPreference.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Structs.PackerFile.CompressionPreference.set -> void
+NexusMods.Archives.Nx.Structs.PackerFile.FileDataProvider.get -> NexusMods.Archives.Nx.Interfaces.IFileDataProvider!
+NexusMods.Archives.Nx.Structs.PackerFile.FileDataProvider.init -> void
+NexusMods.Archives.Nx.Structs.PackerFile.FileSize.get -> long
+NexusMods.Archives.Nx.Structs.PackerFile.FileSize.init -> void
+NexusMods.Archives.Nx.Structs.PackerFile.PackerFile() -> void
+NexusMods.Archives.Nx.Structs.PackerFile.RelativePath.get -> string!
+NexusMods.Archives.Nx.Structs.PackerFile.RelativePath.set -> void
+NexusMods.Archives.Nx.Structs.PackerFile.SolidType.get -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Structs.PackerFile.SolidType.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings
+NexusMods.Archives.Nx.Structs.PackerSettings.BlockSize.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.BlockSize.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkedCompressionLevel.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkedCompressionLevel.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkedFileAlgorithm.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkedFileAlgorithm.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkSize.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkSize.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.MaxNumThreads.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.MaxNumThreads.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.Output.get -> System.IO.Stream!
+NexusMods.Archives.Nx.Structs.PackerSettings.Output.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.PackerSettings() -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.Progress.get -> System.IProgress<double>?
+NexusMods.Archives.Nx.Structs.PackerSettings.Progress.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.Sanitize() -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.SolidBlockAlgorithm.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Structs.PackerSettings.SolidBlockAlgorithm.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.SolidCompressionLevel.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.SolidCompressionLevel.set -> void
+NexusMods.Archives.Nx.Structs.UnpackerSettings
+NexusMods.Archives.Nx.Structs.UnpackerSettings.MaxNumThreads.get -> int
+NexusMods.Archives.Nx.Structs.UnpackerSettings.MaxNumThreads.set -> void
+NexusMods.Archives.Nx.Structs.UnpackerSettings.Progress.get -> System.IProgress<double>?
+NexusMods.Archives.Nx.Structs.UnpackerSettings.Progress.set -> void
+NexusMods.Archives.Nx.Structs.UnpackerSettings.Sanitize() -> void
+NexusMods.Archives.Nx.Structs.UnpackerSettings.UnpackerSettings() -> void
+NexusMods.Archives.Nx.Traits.ICanConvertToLittleEndian
+NexusMods.Archives.Nx.Traits.ICanConvertToLittleEndian.ReverseEndianIfNeeded() -> void
+NexusMods.Archives.Nx.Traits.ICanProvideFileData
+NexusMods.Archives.Nx.Traits.ICanProvideFileData.FileDataProvider.get -> NexusMods.Archives.Nx.Interfaces.IFileDataProvider!
+NexusMods.Archives.Nx.Traits.IHasCompressionPreference
+NexusMods.Archives.Nx.Traits.IHasCompressionPreference.CompressionPreference.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Traits.IHasFileSize
+NexusMods.Archives.Nx.Traits.IHasFileSize.FileSize.get -> long
+NexusMods.Archives.Nx.Traits.IHasRelativePath
+NexusMods.Archives.Nx.Traits.IHasRelativePath.RelativePath.get -> string!
+NexusMods.Archives.Nx.Traits.IHasSolidType
+NexusMods.Archives.Nx.Traits.IHasSolidType.SolidType.get -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Utilities.ArrayRental
+NexusMods.Archives.Nx.Utilities.ArrayRental.Array.get -> byte[]!
+NexusMods.Archives.Nx.Utilities.ArrayRental.ArrayRental() -> void
+NexusMods.Archives.Nx.Utilities.ArrayRental.ArrayRental(int numBytes) -> void
+NexusMods.Archives.Nx.Utilities.ArrayRental.Dispose() -> void
+NexusMods.Archives.Nx.Utilities.ArrayRental.Span.get -> System.Span<byte>
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.ArrayRentalSlice() -> void
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.ArrayRentalSlice(NexusMods.Archives.Nx.Utilities.ArrayRental rental, int length) -> void
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.Dispose() -> void
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.Length.get -> int
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.Rental.get -> NexusMods.Archives.Nx.Utilities.ArrayRental
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.Span.get -> System.Span<byte>
+NexusMods.Archives.Nx.Utilities.FileFinder
+NexusMods.Archives.Nx.Utilities.InsufficientStringPoolSizeException
+NexusMods.Archives.Nx.Utilities.InsufficientStringPoolSizeException.InsufficientStringPoolSizeException(string? message) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianReader
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.LittleEndianReader() -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.LittleEndianReader(byte* ptr) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.Ptr -> byte*
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadInt() -> int
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadIntAtOffset(int offset) -> int
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadLongAtOffset(int offset) -> long
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadShort() -> short
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadShortAtOffset(int offset) -> short
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadUInt() -> uint
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadUIntAtOffset(int offset) -> uint
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadUlongAtOffset(int offset) -> ulong
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadUShort() -> ushort
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.Seek(int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.LittleEndianWriter() -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.LittleEndianWriter(byte* ptr) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Ptr -> byte*
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Seek(int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(int value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(long value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(short value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(System.Span<byte> data) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(uint value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(ulong value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(ushort value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.WriteAtOffset(int value, int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.WriteAtOffset(long value, int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.WriteAtOffset(short value, int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.WriteAtOffset(ulong value, int offset) -> void
+NexusMods.Archives.Nx.Utilities.NotANexusArchiveException
+NexusMods.Archives.Nx.Utilities.NotANexusArchiveException.NotANexusArchiveException() -> void
+NexusMods.Archives.Nx.Utilities.OutOfPackerPoolArraysException
+NexusMods.Archives.Nx.Utilities.OutOfPackerPoolArraysException.OutOfPackerPoolArraysException(string? message) -> void
+NexusMods.Archives.Nx.Utilities.TocVersionNotSupportedException
+NexusMods.Archives.Nx.Utilities.TocVersionNotSupportedException.TocVersionNotSupportedException(NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> void
+NexusMods.Archives.Nx.Utilities.TocVersionNotSupportedException.Version.get -> NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion
+NexusMods.Archives.Nx.Utilities.UnsupportedCompressionMethodException
+NexusMods.Archives.Nx.Utilities.UnsupportedCompressionMethodException.Method.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Utilities.UnsupportedCompressionMethodException.UnsupportedCompressionMethodException(NexusMods.Archives.Nx.Enums.CompressionPreference method) -> void
+override NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Equals(object? obj) -> bool
+override NexusMods.Archives.Nx.Headers.Managed.TableOfContents.GetHashCode() -> int
+override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.Equals(object? obj) -> bool
+override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.GetHashCode() -> int
+override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.Equals(object? obj) -> bool
+override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.GetHashCode() -> int
+override NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.Equals(object? obj) -> bool
+override NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.GetHashCode() -> int
+static NexusMods.Archives.Nx.Headers.HeaderParser.ParseHeader(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> NexusMods.Archives.Nx.Headers.Managed.ParsedHeader!
+static NexusMods.Archives.Nx.Headers.HeaderParser.TryParseHeader(byte* data, int dataSize) -> NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult
+static NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Deserialize<T>(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> T!
+static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.operator !=(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.operator ==(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.operator !=(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.operator ==(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.Init(NexusMods.Archives.Nx.Headers.Native.NativeFileHeader* header, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version, int blockSizeBytes, int chunkSizeBytes, int headerPageCountBytes) -> void
+static NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.operator !=(NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple left, NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.operator ==(NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple left, NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple right) -> bool
+static NexusMods.Archives.Nx.Headers.StringPool.Pack<T>(System.Span<T> items) -> NexusMods.Archives.Nx.Utilities.ArrayRentalSlice
+static NexusMods.Archives.Nx.Headers.StringPool.Unpack(byte* poolPtr, int compressedDataSize) -> string![]!
+static NexusMods.Archives.Nx.Headers.StringPool.Unpack(byte* poolPtr, int compressedDataSize, int fileCountHint) -> string![]!
+static NexusMods.Archives.Nx.Headers.StringPool.Unpack(System.Span<byte> poolSpan) -> string![]!
+static NexusMods.Archives.Nx.Headers.StringPool.Unpack(System.Span<byte> poolSpan, int fileCountHint) -> string![]!
+static NexusMods.Archives.Nx.Packing.NxPacker.Pack(NexusMods.Archives.Nx.Structs.PackerFile![]! files, NexusMods.Archives.Nx.Structs.PackerSettings! settings) -> void
+static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.EnumerationOptions! options) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
+static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.SearchOption searchOption = System.IO.SearchOption.AllDirectories) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!

--- a/NexusMods.Archives.Nx/PublicAPI/net5.0/PublicAPI.Unshipped.txt
+++ b/NexusMods.Archives.Nx/PublicAPI/net5.0/PublicAPI.Unshipped.txt
@@ -378,5 +378,6 @@ static NexusMods.Archives.Nx.Headers.StringPool.Unpack(byte* poolPtr, int compre
 static NexusMods.Archives.Nx.Headers.StringPool.Unpack(System.Span<byte> poolSpan) -> string![]!
 static NexusMods.Archives.Nx.Headers.StringPool.Unpack(System.Span<byte> poolSpan, int fileCountHint) -> string![]!
 static NexusMods.Archives.Nx.Packing.NxPacker.Pack(NexusMods.Archives.Nx.Structs.PackerFile![]! files, NexusMods.Archives.Nx.Structs.PackerSettings! settings) -> void
+static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
 static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.EnumerationOptions! options) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
-static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.SearchOption searchOption = System.IO.SearchOption.AllDirectories) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
+static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.SearchOption searchOption) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!

--- a/NexusMods.Archives.Nx/PublicAPI/net5.0/PublicAPI.Unshipped.txt
+++ b/NexusMods.Archives.Nx/PublicAPI/net5.0/PublicAPI.Unshipped.txt
@@ -106,7 +106,7 @@ NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Pool.get -> string![]!
 NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Pool.init -> void
 NexusMods.Archives.Nx.Headers.Managed.TableOfContents.PoolSize.get -> int
 NexusMods.Archives.Nx.Headers.Managed.TableOfContents.PoolSize.init -> void
-NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Serialize(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version, System.Span<byte> stringPoolData) -> int
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Serialize(byte* dataPtr, int tocOffset, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version, System.Span<byte> stringPoolData) -> int
 NexusMods.Archives.Nx.Headers.Managed.TableOfContents.TableOfContents() -> void
 NexusMods.Archives.Nx.Headers.Native.INativeFileEntry
 NexusMods.Archives.Nx.Headers.Native.INativeFileEntry.CopyFrom(in NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
@@ -379,7 +379,7 @@ static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(stri
 static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(string? name, out NexusMods.Archives.Nx.Enums.CompressionPreference value, bool ignoreCase, bool allowMatchingMetadataAttribute) -> bool
 static NexusMods.Archives.Nx.Headers.HeaderParser.ParseHeader(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> NexusMods.Archives.Nx.Headers.Managed.ParsedHeader!
 static NexusMods.Archives.Nx.Headers.HeaderParser.TryParseHeader(byte* data, int dataSize) -> NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult
-static NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Deserialize<T>(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> T!
+static NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Deserialize<T>(byte* dataPtr, int tocOffset, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> T!
 static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.operator !=(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 right) -> bool
 static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.operator ==(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 right) -> bool
 static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.operator !=(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 right) -> bool

--- a/NexusMods.Archives.Nx/PublicAPI/net7.0/PublicAPI.Unshipped.txt
+++ b/NexusMods.Archives.Nx/PublicAPI/net7.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
-﻿const NexusMods.Archives.Nx.Headers.StringPool.MaxCompressedSize = 33550336 -> int
+﻿const NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.Length = 4 -> int
+const NexusMods.Archives.Nx.Headers.StringPool.MaxCompressedSize = 33550336 -> int
 NexusMods.Archives.Nx.Enums.CompressionPreference
 NexusMods.Archives.Nx.Enums.CompressionPreference.Copy = 0 -> NexusMods.Archives.Nx.Enums.CompressionPreference
 NexusMods.Archives.Nx.Enums.CompressionPreference.Lz4 = 2 -> NexusMods.Archives.Nx.Enums.CompressionPreference
@@ -362,6 +363,20 @@ override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.Equals(object? o
 override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.GetHashCode() -> int
 override NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.Equals(object? obj) -> bool
 override NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.GetHashCode() -> int
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.GetNames() -> string![]!
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.GetValues() -> NexusMods.Archives.Nx.Enums.CompressionPreference[]!
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.IsDefined(in System.ReadOnlySpan<char> name) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.IsDefined(in System.ReadOnlySpan<char> name, bool allowMatchingMetadataAttribute) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.IsDefined(NexusMods.Archives.Nx.Enums.CompressionPreference value) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.IsDefined(string! name) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.IsDefined(string! name, bool allowMatchingMetadataAttribute) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.ToStringFast(this NexusMods.Archives.Nx.Enums.CompressionPreference value) -> string!
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(in System.ReadOnlySpan<char> name, out NexusMods.Archives.Nx.Enums.CompressionPreference result, bool ignoreCase, bool allowMatchingMetadataAttribute) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(in System.ReadOnlySpan<char> name, out NexusMods.Archives.Nx.Enums.CompressionPreference value) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(in System.ReadOnlySpan<char> name, out NexusMods.Archives.Nx.Enums.CompressionPreference value, bool ignoreCase) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(string? name, out NexusMods.Archives.Nx.Enums.CompressionPreference value) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(string? name, out NexusMods.Archives.Nx.Enums.CompressionPreference value, bool ignoreCase) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(string? name, out NexusMods.Archives.Nx.Enums.CompressionPreference value, bool ignoreCase, bool allowMatchingMetadataAttribute) -> bool
 static NexusMods.Archives.Nx.Headers.HeaderParser.ParseHeader(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> NexusMods.Archives.Nx.Headers.Managed.ParsedHeader!
 static NexusMods.Archives.Nx.Headers.HeaderParser.TryParseHeader(byte* data, int dataSize) -> NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult
 static NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Deserialize<T>(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> T!

--- a/NexusMods.Archives.Nx/PublicAPI/net7.0/PublicAPI.Unshipped.txt
+++ b/NexusMods.Archives.Nx/PublicAPI/net7.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,382 @@
-﻿
+﻿const NexusMods.Archives.Nx.Headers.StringPool.MaxCompressedSize = 33550336 -> int
+NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreference.Copy = 0 -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreference.Lz4 = 2 -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreference.NoPreference = 255 -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreference.ZStandard = 1 -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions
+NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Enums.SolidPreference.Default = 0 -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Enums.SolidPreference.NoSolid = 1 -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData.ArrayFileData(byte[]! data, long start, uint length) -> void
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData.Data.get -> byte*
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.Data.get -> byte*
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.MemoryMappedFileData(string! filePath, long start, uint length) -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.MemoryMappedFileData(string! filePath, long start, uint length, bool readOnly) -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData.Data.get -> byte*
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData.MemoryMappedOutputFileData(System.IO.MemoryMappedFiles.MemoryMappedFile! file, long start, uint length) -> void
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData.Data.get -> byte*
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData.RentedArrayFileData(NexusMods.Archives.Nx.Utilities.ArrayRentalSlice data) -> void
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider.Data.get -> byte[]!
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider.Data.init -> void
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider.FromArrayProvider() -> void
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.Directory.get -> string!
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.Directory.init -> void
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.FromDirectoryDataProvider() -> void
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.RelativePath.get -> string!
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.RelativePath.init -> void
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider.FromStreamProvider(System.IO.Stream! stream) -> void
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider.Stream.get -> System.IO.Stream!
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider.StreamStart.get -> long
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.Data.get -> byte[]!
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.Entry.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.Entry.init -> void
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.OutputArrayProvider(string! relativePath, NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.RelativePath.get -> string!
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.RelativePath.init -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.Entry.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.Entry.init -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.FullPath.get -> string!
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.FullPath.init -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.OutputFileProvider(string! outputFolder, string! relativePath, NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.RelativePath.get -> string!
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.RelativePath.init -> void
+NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion
+NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion.V0 = 0 -> NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion
+NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion.V1 = 1 -> NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion
+NexusMods.Archives.Nx.Headers.HeaderParser
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.Header.get -> NexusMods.Archives.Nx.Headers.Managed.ParsedHeader?
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.Header.init -> void
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.HeaderParserResult() -> void
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.HeaderSize.get -> int
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.HeaderSize.init -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.DecompressedBlockOffset -> int
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.DecompressedSize -> ulong
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FileEntry() -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FilePathIndex -> int
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FirstBlockIndex -> int
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FromReaderV0(ref NexusMods.Archives.Nx.Utilities.LittleEndianReader reader) -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FromReaderV1(ref NexusMods.Archives.Nx.Utilities.LittleEndianReader reader) -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.GetChunkCount(int chunkSizeBytes) -> int
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.Hash -> ulong
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.WriteAsV0(ref NexusMods.Archives.Nx.Utilities.LittleEndianWriter writer) -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.WriteAsV1(ref NexusMods.Archives.Nx.Utilities.LittleEndianWriter writer) -> void
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader.BlockOffsets -> long[]!
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader.Header -> NexusMods.Archives.Nx.Headers.Native.NativeFileHeader
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader.Init() -> void
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader.ParsedHeader() -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.BlockCompressions.get -> NexusMods.Archives.Nx.Enums.CompressionPreference[]!
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.BlockCompressions.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Blocks.get -> NexusMods.Archives.Nx.Headers.Structs.BlockSize[]!
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Blocks.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.CalculateTableSize(NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> int
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Entries.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry[]!
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Entries.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Equals(NexusMods.Archives.Nx.Headers.Managed.TableOfContents? other) -> bool
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Pool.get -> string![]!
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Pool.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.PoolSize.get -> int
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.PoolSize.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Serialize(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version, System.Span<byte> stringPoolData) -> int
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.TableOfContents() -> void
+NexusMods.Archives.Nx.Headers.Native.INativeFileEntry
+NexusMods.Archives.Nx.Headers.Native.INativeFileEntry.CopyFrom(in NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.INativeFileEntry.CopyTo(ref NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.CopyFrom(in NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.CopyTo(ref NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.DecompressedBlockOffset.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.DecompressedBlockOffset.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.DecompressedSize -> uint
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.Equals(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 other) -> bool
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.FilePathIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.FilePathIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.FirstBlockIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.FirstBlockIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.Hash -> ulong
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.NativeFileEntryV0() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.CopyFrom(in NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.CopyTo(ref NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.DecompressedBlockOffset.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.DecompressedBlockOffset.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.DecompressedSize -> ulong
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.Equals(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 other) -> bool
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.FilePathIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.FilePathIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.FirstBlockIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.FirstBlockIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.Hash -> ulong
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.NativeFileEntryV1() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.BlockSize.get -> byte
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.BlockSize.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.BlockSizeBytes.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.BlockSizeBytes.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ChunkSize.get -> byte
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ChunkSize.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ChunkSizeBytes.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ChunkSizeBytes.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.FeatureFlags -> byte
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.HeaderPageBytes.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.HeaderPageBytes.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.HeaderPageCount.get -> ushort
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.HeaderPageCount.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.IsValidMagicHeader() -> bool
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.Magic -> uint
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.NativeFileHeader() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ReverseEndianIfNeeded() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.SetMagic() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.TocSize.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.Version.get -> byte
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.Version.set -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.CopyTo(ref NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.DecompressedBlockOffset.get -> int
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.DecompressedBlockOffset.set -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.Equals(NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple other) -> bool
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.FilePathIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.FilePathIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.FirstBlockIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.FirstBlockIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.OffsetPathIndexTuple() -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.OffsetPathIndexTuple(int decompressedBlockOffset, int filePathIndex, int firstBlockIndex) -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.OffsetPathIndexTuple(long data) -> void
+NexusMods.Archives.Nx.Headers.StringPool
+NexusMods.Archives.Nx.Headers.StringPool.StringPool() -> void
+NexusMods.Archives.Nx.Headers.Structs.BlockSize
+NexusMods.Archives.Nx.Headers.Structs.BlockSize.BlockSize() -> void
+NexusMods.Archives.Nx.Headers.Structs.BlockSize.CompressedSize -> int
+NexusMods.Archives.Nx.Interfaces.IFileData
+NexusMods.Archives.Nx.Interfaces.IFileData.Data.get -> byte*
+NexusMods.Archives.Nx.Interfaces.IFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.Interfaces.IFileDataProvider
+NexusMods.Archives.Nx.Interfaces.IFileDataProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.Interfaces.IOutputDataProvider
+NexusMods.Archives.Nx.Interfaces.IOutputDataProvider.Entry.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.Interfaces.IOutputDataProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.Interfaces.IOutputDataProvider.RelativePath.get -> string!
+NexusMods.Archives.Nx.Packing.AddFileParams
+NexusMods.Archives.Nx.Packing.AddFileParams.AddFileParams() -> void
+NexusMods.Archives.Nx.Packing.AddFileParams.CompressionPreference.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Packing.AddFileParams.CompressionPreference.set -> void
+NexusMods.Archives.Nx.Packing.AddFileParams.RelativePath.get -> string!
+NexusMods.Archives.Nx.Packing.AddFileParams.RelativePath.init -> void
+NexusMods.Archives.Nx.Packing.AddFileParams.SolidType.get -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Packing.AddFileParams.SolidType.set -> void
+NexusMods.Archives.Nx.Packing.NxPacker
+NexusMods.Archives.Nx.Packing.NxPackerBuilder
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFile(byte[]! data, NexusMods.Archives.Nx.Packing.AddFileParams options) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFile(string! filePath, NexusMods.Archives.Nx.Packing.AddFileParams options) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFile(System.IO.Stream! stream, long length, NexusMods.Archives.Nx.Packing.AddFileParams options) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFile(System.IO.Stream! stream, NexusMods.Archives.Nx.Packing.AddFileParams options) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFolder(string! folder) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.Build(bool disposeOutput = true) -> System.IO.Stream!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.Files.get -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.NxPackerBuilder() -> void
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.Settings.get -> NexusMods.Archives.Nx.Structs.PackerSettings!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithBlockSize(int blockSize) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithChunkedFileAlgorithm(NexusMods.Archives.Nx.Enums.CompressionPreference chunkedFileAlgorithm) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithChunkedLevel(int level) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithChunkSize(int chunkSize) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithMaxNumThreads(int maxNumThreads) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithOutput(System.IO.Stream! output) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithPreset(NexusMods.Archives.Nx.Packing.PackerPreset preset) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithProgress(System.IProgress<double>? progress) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithSolidBlockAlgorithm(NexusMods.Archives.Nx.Enums.CompressionPreference solidBlockAlgorithm) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithSolidCompressionLevel(int level) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpacker
+NexusMods.Archives.Nx.Packing.NxUnpacker.ExtractFiles(NexusMods.Archives.Nx.Interfaces.IOutputDataProvider![]! outputs, NexusMods.Archives.Nx.Structs.UnpackerSettings! settings) -> void
+NexusMods.Archives.Nx.Packing.NxUnpacker.ExtractFilesInMemory(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, NexusMods.Archives.Nx.Structs.UnpackerSettings! settings) -> NexusMods.Archives.Nx.FileProviders.OutputArrayProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.ExtractFilesToDisk(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, string! outputFolder, NexusMods.Archives.Nx.Structs.UnpackerSettings! settings) -> NexusMods.Archives.Nx.FileProviders.OutputFileProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.GetFileEntriesRaw() -> System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry>
+NexusMods.Archives.Nx.Packing.NxUnpacker.GetFilePath(NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> string!
+NexusMods.Archives.Nx.Packing.NxUnpacker.GetPathedFileEntries() -> NexusMods.Archives.Nx.Packing.PathedFileEntry![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.MakeArrayOutputProviders(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files) -> NexusMods.Archives.Nx.FileProviders.OutputArrayProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.MakeDiskOutputProviders(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, string! outputFolder) -> NexusMods.Archives.Nx.FileProviders.OutputFileProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.NxUnpacker(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> void
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.AddFilesWithArrayOutput(NexusMods.Archives.Nx.Packing.PathedFileEntry![]! files, out NexusMods.Archives.Nx.FileProviders.OutputArrayProvider![]! results) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.AddFilesWithArrayOutput(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, out NexusMods.Archives.Nx.FileProviders.OutputArrayProvider![]! results) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.AddFilesWithDiskOutput(NexusMods.Archives.Nx.Packing.PathedFileEntry![]! files, string! outputFolder) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.AddFilesWithDiskOutput(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, string! outputFolder) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.Extract() -> NexusMods.Archives.Nx.Interfaces.IOutputDataProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.GetFileEntriesRaw() -> System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry>
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.GetPathedFileEntries() -> NexusMods.Archives.Nx.Packing.PathedFileEntry![]!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.NxUnpackerBuilder(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> void
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.Outputs.get -> System.Collections.Generic.List<NexusMods.Archives.Nx.Interfaces.IOutputDataProvider!>!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.Settings.get -> NexusMods.Archives.Nx.Structs.UnpackerSettings!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.Unpacker.get -> NexusMods.Archives.Nx.Packing.NxUnpacker!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.WithMaxNumThreads(int maxNumThreads) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.WithProgress(System.IProgress<double>? progress) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.PackerPreset
+NexusMods.Archives.Nx.Packing.PackerPreset.Default = 0 -> NexusMods.Archives.Nx.Packing.PackerPreset
+NexusMods.Archives.Nx.Packing.PackerPreset.RandomAccess = 1 -> NexusMods.Archives.Nx.Packing.PackerPreset
+NexusMods.Archives.Nx.Packing.PathedFileEntry
+NexusMods.Archives.Nx.Packing.PathedFileEntry.Entry.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.Packing.PathedFileEntry.Entry.init -> void
+NexusMods.Archives.Nx.Packing.PathedFileEntry.FileName.get -> string!
+NexusMods.Archives.Nx.Packing.PathedFileEntry.FileName.init -> void
+NexusMods.Archives.Nx.Packing.PathedFileEntry.PathedFileEntry() -> void
+NexusMods.Archives.Nx.Structs.PackerFile
+NexusMods.Archives.Nx.Structs.PackerFile.CompressionPreference.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Structs.PackerFile.CompressionPreference.set -> void
+NexusMods.Archives.Nx.Structs.PackerFile.FileDataProvider.get -> NexusMods.Archives.Nx.Interfaces.IFileDataProvider!
+NexusMods.Archives.Nx.Structs.PackerFile.FileDataProvider.init -> void
+NexusMods.Archives.Nx.Structs.PackerFile.FileSize.get -> long
+NexusMods.Archives.Nx.Structs.PackerFile.FileSize.init -> void
+NexusMods.Archives.Nx.Structs.PackerFile.PackerFile() -> void
+NexusMods.Archives.Nx.Structs.PackerFile.RelativePath.get -> string!
+NexusMods.Archives.Nx.Structs.PackerFile.RelativePath.set -> void
+NexusMods.Archives.Nx.Structs.PackerFile.SolidType.get -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Structs.PackerFile.SolidType.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings
+NexusMods.Archives.Nx.Structs.PackerSettings.BlockSize.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.BlockSize.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkedCompressionLevel.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkedCompressionLevel.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkedFileAlgorithm.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkedFileAlgorithm.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkSize.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkSize.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.MaxNumThreads.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.MaxNumThreads.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.Output.get -> System.IO.Stream!
+NexusMods.Archives.Nx.Structs.PackerSettings.Output.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.PackerSettings() -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.Progress.get -> System.IProgress<double>?
+NexusMods.Archives.Nx.Structs.PackerSettings.Progress.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.Sanitize() -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.SolidBlockAlgorithm.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Structs.PackerSettings.SolidBlockAlgorithm.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.SolidCompressionLevel.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.SolidCompressionLevel.set -> void
+NexusMods.Archives.Nx.Structs.UnpackerSettings
+NexusMods.Archives.Nx.Structs.UnpackerSettings.MaxNumThreads.get -> int
+NexusMods.Archives.Nx.Structs.UnpackerSettings.MaxNumThreads.set -> void
+NexusMods.Archives.Nx.Structs.UnpackerSettings.Progress.get -> System.IProgress<double>?
+NexusMods.Archives.Nx.Structs.UnpackerSettings.Progress.set -> void
+NexusMods.Archives.Nx.Structs.UnpackerSettings.Sanitize() -> void
+NexusMods.Archives.Nx.Structs.UnpackerSettings.UnpackerSettings() -> void
+NexusMods.Archives.Nx.Traits.ICanConvertToLittleEndian
+NexusMods.Archives.Nx.Traits.ICanConvertToLittleEndian.ReverseEndianIfNeeded() -> void
+NexusMods.Archives.Nx.Traits.ICanProvideFileData
+NexusMods.Archives.Nx.Traits.ICanProvideFileData.FileDataProvider.get -> NexusMods.Archives.Nx.Interfaces.IFileDataProvider!
+NexusMods.Archives.Nx.Traits.IHasCompressionPreference
+NexusMods.Archives.Nx.Traits.IHasCompressionPreference.CompressionPreference.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Traits.IHasFileSize
+NexusMods.Archives.Nx.Traits.IHasFileSize.FileSize.get -> long
+NexusMods.Archives.Nx.Traits.IHasRelativePath
+NexusMods.Archives.Nx.Traits.IHasRelativePath.RelativePath.get -> string!
+NexusMods.Archives.Nx.Traits.IHasSolidType
+NexusMods.Archives.Nx.Traits.IHasSolidType.SolidType.get -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Utilities.ArrayRental
+NexusMods.Archives.Nx.Utilities.ArrayRental.Array.get -> byte[]!
+NexusMods.Archives.Nx.Utilities.ArrayRental.ArrayRental() -> void
+NexusMods.Archives.Nx.Utilities.ArrayRental.ArrayRental(int numBytes) -> void
+NexusMods.Archives.Nx.Utilities.ArrayRental.Dispose() -> void
+NexusMods.Archives.Nx.Utilities.ArrayRental.Span.get -> System.Span<byte>
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.ArrayRentalSlice() -> void
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.ArrayRentalSlice(NexusMods.Archives.Nx.Utilities.ArrayRental rental, int length) -> void
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.Dispose() -> void
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.Length.get -> int
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.Rental.get -> NexusMods.Archives.Nx.Utilities.ArrayRental
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.Span.get -> System.Span<byte>
+NexusMods.Archives.Nx.Utilities.FileFinder
+NexusMods.Archives.Nx.Utilities.InsufficientStringPoolSizeException
+NexusMods.Archives.Nx.Utilities.InsufficientStringPoolSizeException.InsufficientStringPoolSizeException(string? message) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianReader
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.LittleEndianReader() -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.LittleEndianReader(byte* ptr) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.Ptr -> byte*
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadInt() -> int
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadIntAtOffset(int offset) -> int
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadLongAtOffset(int offset) -> long
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadShort() -> short
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadShortAtOffset(int offset) -> short
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadUInt() -> uint
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadUIntAtOffset(int offset) -> uint
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadUlongAtOffset(int offset) -> ulong
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadUShort() -> ushort
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.Seek(int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.LittleEndianWriter() -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.LittleEndianWriter(byte* ptr) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Ptr -> byte*
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Seek(int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(int value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(long value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(short value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(System.Span<byte> data) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(uint value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(ulong value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(ushort value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.WriteAtOffset(int value, int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.WriteAtOffset(long value, int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.WriteAtOffset(short value, int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.WriteAtOffset(ulong value, int offset) -> void
+NexusMods.Archives.Nx.Utilities.NotANexusArchiveException
+NexusMods.Archives.Nx.Utilities.NotANexusArchiveException.NotANexusArchiveException() -> void
+NexusMods.Archives.Nx.Utilities.OutOfPackerPoolArraysException
+NexusMods.Archives.Nx.Utilities.OutOfPackerPoolArraysException.OutOfPackerPoolArraysException(string? message) -> void
+NexusMods.Archives.Nx.Utilities.TocVersionNotSupportedException
+NexusMods.Archives.Nx.Utilities.TocVersionNotSupportedException.TocVersionNotSupportedException(NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> void
+NexusMods.Archives.Nx.Utilities.TocVersionNotSupportedException.Version.get -> NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion
+NexusMods.Archives.Nx.Utilities.UnsupportedCompressionMethodException
+NexusMods.Archives.Nx.Utilities.UnsupportedCompressionMethodException.Method.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Utilities.UnsupportedCompressionMethodException.UnsupportedCompressionMethodException(NexusMods.Archives.Nx.Enums.CompressionPreference method) -> void
+override NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Equals(object? obj) -> bool
+override NexusMods.Archives.Nx.Headers.Managed.TableOfContents.GetHashCode() -> int
+override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.Equals(object? obj) -> bool
+override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.GetHashCode() -> int
+override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.Equals(object? obj) -> bool
+override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.GetHashCode() -> int
+override NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.Equals(object? obj) -> bool
+override NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.GetHashCode() -> int
+static NexusMods.Archives.Nx.Headers.HeaderParser.ParseHeader(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> NexusMods.Archives.Nx.Headers.Managed.ParsedHeader!
+static NexusMods.Archives.Nx.Headers.HeaderParser.TryParseHeader(byte* data, int dataSize) -> NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult
+static NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Deserialize<T>(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> T!
+static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.operator !=(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.operator ==(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.operator !=(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.operator ==(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.Init(NexusMods.Archives.Nx.Headers.Native.NativeFileHeader* header, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version, int blockSizeBytes, int chunkSizeBytes, int headerPageCountBytes) -> void
+static NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.operator !=(NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple left, NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.operator ==(NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple left, NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple right) -> bool
+static NexusMods.Archives.Nx.Headers.StringPool.Pack<T>(System.Span<T> items) -> NexusMods.Archives.Nx.Utilities.ArrayRentalSlice
+static NexusMods.Archives.Nx.Headers.StringPool.Unpack(byte* poolPtr, int compressedDataSize) -> string![]!
+static NexusMods.Archives.Nx.Headers.StringPool.Unpack(byte* poolPtr, int compressedDataSize, int fileCountHint) -> string![]!
+static NexusMods.Archives.Nx.Headers.StringPool.Unpack(System.Span<byte> poolSpan) -> string![]!
+static NexusMods.Archives.Nx.Headers.StringPool.Unpack(System.Span<byte> poolSpan, int fileCountHint) -> string![]!
+static NexusMods.Archives.Nx.Packing.NxPacker.Pack(NexusMods.Archives.Nx.Structs.PackerFile![]! files, NexusMods.Archives.Nx.Structs.PackerSettings! settings) -> void
+static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.EnumerationOptions! options) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
+static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.SearchOption searchOption = System.IO.SearchOption.AllDirectories) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!

--- a/NexusMods.Archives.Nx/PublicAPI/net7.0/PublicAPI.Unshipped.txt
+++ b/NexusMods.Archives.Nx/PublicAPI/net7.0/PublicAPI.Unshipped.txt
@@ -378,5 +378,6 @@ static NexusMods.Archives.Nx.Headers.StringPool.Unpack(byte* poolPtr, int compre
 static NexusMods.Archives.Nx.Headers.StringPool.Unpack(System.Span<byte> poolSpan) -> string![]!
 static NexusMods.Archives.Nx.Headers.StringPool.Unpack(System.Span<byte> poolSpan, int fileCountHint) -> string![]!
 static NexusMods.Archives.Nx.Packing.NxPacker.Pack(NexusMods.Archives.Nx.Structs.PackerFile![]! files, NexusMods.Archives.Nx.Structs.PackerSettings! settings) -> void
+static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
 static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.EnumerationOptions! options) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
-static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.SearchOption searchOption = System.IO.SearchOption.AllDirectories) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
+static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.SearchOption searchOption) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!

--- a/NexusMods.Archives.Nx/PublicAPI/net7.0/PublicAPI.Unshipped.txt
+++ b/NexusMods.Archives.Nx/PublicAPI/net7.0/PublicAPI.Unshipped.txt
@@ -106,7 +106,7 @@ NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Pool.get -> string![]!
 NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Pool.init -> void
 NexusMods.Archives.Nx.Headers.Managed.TableOfContents.PoolSize.get -> int
 NexusMods.Archives.Nx.Headers.Managed.TableOfContents.PoolSize.init -> void
-NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Serialize(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version, System.Span<byte> stringPoolData) -> int
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Serialize(byte* dataPtr, int tocOffset, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version, System.Span<byte> stringPoolData) -> int
 NexusMods.Archives.Nx.Headers.Managed.TableOfContents.TableOfContents() -> void
 NexusMods.Archives.Nx.Headers.Native.INativeFileEntry
 NexusMods.Archives.Nx.Headers.Native.INativeFileEntry.CopyFrom(in NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
@@ -379,7 +379,7 @@ static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(stri
 static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(string? name, out NexusMods.Archives.Nx.Enums.CompressionPreference value, bool ignoreCase, bool allowMatchingMetadataAttribute) -> bool
 static NexusMods.Archives.Nx.Headers.HeaderParser.ParseHeader(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> NexusMods.Archives.Nx.Headers.Managed.ParsedHeader!
 static NexusMods.Archives.Nx.Headers.HeaderParser.TryParseHeader(byte* data, int dataSize) -> NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult
-static NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Deserialize<T>(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> T!
+static NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Deserialize<T>(byte* dataPtr, int tocOffset, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> T!
 static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.operator !=(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 right) -> bool
 static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.operator ==(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 right) -> bool
 static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.operator !=(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 right) -> bool

--- a/NexusMods.Archives.Nx/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/NexusMods.Archives.Nx/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
-﻿const NexusMods.Archives.Nx.Headers.StringPool.MaxCompressedSize = 33550336 -> int
+﻿const NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.Length = 4 -> int
+const NexusMods.Archives.Nx.Headers.StringPool.MaxCompressedSize = 33550336 -> int
 NexusMods.Archives.Nx.Enums.CompressionPreference
 NexusMods.Archives.Nx.Enums.CompressionPreference.Copy = 0 -> NexusMods.Archives.Nx.Enums.CompressionPreference
 NexusMods.Archives.Nx.Enums.CompressionPreference.Lz4 = 2 -> NexusMods.Archives.Nx.Enums.CompressionPreference
@@ -362,6 +363,20 @@ override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.Equals(object? o
 override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.GetHashCode() -> int
 override NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.Equals(object? obj) -> bool
 override NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.GetHashCode() -> int
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.GetNames() -> string![]!
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.GetValues() -> NexusMods.Archives.Nx.Enums.CompressionPreference[]!
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.IsDefined(in System.ReadOnlySpan<char> name) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.IsDefined(in System.ReadOnlySpan<char> name, bool allowMatchingMetadataAttribute) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.IsDefined(NexusMods.Archives.Nx.Enums.CompressionPreference value) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.IsDefined(string! name) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.IsDefined(string! name, bool allowMatchingMetadataAttribute) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.ToStringFast(this NexusMods.Archives.Nx.Enums.CompressionPreference value) -> string!
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(in System.ReadOnlySpan<char> name, out NexusMods.Archives.Nx.Enums.CompressionPreference result, bool ignoreCase, bool allowMatchingMetadataAttribute) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(in System.ReadOnlySpan<char> name, out NexusMods.Archives.Nx.Enums.CompressionPreference value) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(in System.ReadOnlySpan<char> name, out NexusMods.Archives.Nx.Enums.CompressionPreference value, bool ignoreCase) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(string? name, out NexusMods.Archives.Nx.Enums.CompressionPreference value) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(string? name, out NexusMods.Archives.Nx.Enums.CompressionPreference value, bool ignoreCase) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(string? name, out NexusMods.Archives.Nx.Enums.CompressionPreference value, bool ignoreCase, bool allowMatchingMetadataAttribute) -> bool
 static NexusMods.Archives.Nx.Headers.HeaderParser.ParseHeader(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> NexusMods.Archives.Nx.Headers.Managed.ParsedHeader!
 static NexusMods.Archives.Nx.Headers.HeaderParser.TryParseHeader(byte* data, int dataSize) -> NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult
 static NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Deserialize<T>(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> T!

--- a/NexusMods.Archives.Nx/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/NexusMods.Archives.Nx/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -1,1 +1,382 @@
-﻿
+﻿const NexusMods.Archives.Nx.Headers.StringPool.MaxCompressedSize = 33550336 -> int
+NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreference.Copy = 0 -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreference.Lz4 = 2 -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreference.NoPreference = 255 -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreference.ZStandard = 1 -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions
+NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Enums.SolidPreference.Default = 0 -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Enums.SolidPreference.NoSolid = 1 -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData.ArrayFileData(byte[]! data, long start, uint length) -> void
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData.Data.get -> byte*
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.Data.get -> byte*
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.MemoryMappedFileData(string! filePath, long start, uint length) -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.MemoryMappedFileData(string! filePath, long start, uint length, bool readOnly) -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData.Data.get -> byte*
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData.MemoryMappedOutputFileData(System.IO.MemoryMappedFiles.MemoryMappedFile! file, long start, uint length) -> void
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData.Data.get -> byte*
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData.RentedArrayFileData(NexusMods.Archives.Nx.Utilities.ArrayRentalSlice data) -> void
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider.Data.get -> byte[]!
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider.Data.init -> void
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider.FromArrayProvider() -> void
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.Directory.get -> string!
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.Directory.init -> void
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.FromDirectoryDataProvider() -> void
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.RelativePath.get -> string!
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.RelativePath.init -> void
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider.FromStreamProvider(System.IO.Stream! stream) -> void
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider.Stream.get -> System.IO.Stream!
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider.StreamStart.get -> long
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.Data.get -> byte[]!
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.Entry.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.Entry.init -> void
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.OutputArrayProvider(string! relativePath, NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.RelativePath.get -> string!
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.RelativePath.init -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.Entry.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.Entry.init -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.FullPath.get -> string!
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.FullPath.init -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.OutputFileProvider(string! outputFolder, string! relativePath, NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.RelativePath.get -> string!
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.RelativePath.init -> void
+NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion
+NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion.V0 = 0 -> NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion
+NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion.V1 = 1 -> NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion
+NexusMods.Archives.Nx.Headers.HeaderParser
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.Header.get -> NexusMods.Archives.Nx.Headers.Managed.ParsedHeader?
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.Header.init -> void
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.HeaderParserResult() -> void
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.HeaderSize.get -> int
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.HeaderSize.init -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.DecompressedBlockOffset -> int
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.DecompressedSize -> ulong
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FileEntry() -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FilePathIndex -> int
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FirstBlockIndex -> int
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FromReaderV0(ref NexusMods.Archives.Nx.Utilities.LittleEndianReader reader) -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FromReaderV1(ref NexusMods.Archives.Nx.Utilities.LittleEndianReader reader) -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.GetChunkCount(int chunkSizeBytes) -> int
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.Hash -> ulong
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.WriteAsV0(ref NexusMods.Archives.Nx.Utilities.LittleEndianWriter writer) -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.WriteAsV1(ref NexusMods.Archives.Nx.Utilities.LittleEndianWriter writer) -> void
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader.BlockOffsets -> long[]!
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader.Header -> NexusMods.Archives.Nx.Headers.Native.NativeFileHeader
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader.Init() -> void
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader.ParsedHeader() -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.BlockCompressions.get -> NexusMods.Archives.Nx.Enums.CompressionPreference[]!
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.BlockCompressions.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Blocks.get -> NexusMods.Archives.Nx.Headers.Structs.BlockSize[]!
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Blocks.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.CalculateTableSize(NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> int
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Entries.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry[]!
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Entries.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Equals(NexusMods.Archives.Nx.Headers.Managed.TableOfContents? other) -> bool
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Pool.get -> string![]!
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Pool.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.PoolSize.get -> int
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.PoolSize.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Serialize(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version, System.Span<byte> stringPoolData) -> int
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.TableOfContents() -> void
+NexusMods.Archives.Nx.Headers.Native.INativeFileEntry
+NexusMods.Archives.Nx.Headers.Native.INativeFileEntry.CopyFrom(in NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.INativeFileEntry.CopyTo(ref NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.CopyFrom(in NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.CopyTo(ref NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.DecompressedBlockOffset.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.DecompressedBlockOffset.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.DecompressedSize -> uint
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.Equals(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 other) -> bool
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.FilePathIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.FilePathIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.FirstBlockIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.FirstBlockIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.Hash -> ulong
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.NativeFileEntryV0() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.CopyFrom(in NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.CopyTo(ref NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.DecompressedBlockOffset.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.DecompressedBlockOffset.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.DecompressedSize -> ulong
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.Equals(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 other) -> bool
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.FilePathIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.FilePathIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.FirstBlockIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.FirstBlockIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.Hash -> ulong
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.NativeFileEntryV1() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.BlockSize.get -> byte
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.BlockSize.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.BlockSizeBytes.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.BlockSizeBytes.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ChunkSize.get -> byte
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ChunkSize.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ChunkSizeBytes.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ChunkSizeBytes.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.FeatureFlags -> byte
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.HeaderPageBytes.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.HeaderPageBytes.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.HeaderPageCount.get -> ushort
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.HeaderPageCount.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.IsValidMagicHeader() -> bool
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.Magic -> uint
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.NativeFileHeader() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ReverseEndianIfNeeded() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.SetMagic() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.TocSize.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.Version.get -> byte
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.Version.set -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.CopyTo(ref NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.DecompressedBlockOffset.get -> int
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.DecompressedBlockOffset.set -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.Equals(NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple other) -> bool
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.FilePathIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.FilePathIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.FirstBlockIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.FirstBlockIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.OffsetPathIndexTuple() -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.OffsetPathIndexTuple(int decompressedBlockOffset, int filePathIndex, int firstBlockIndex) -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.OffsetPathIndexTuple(long data) -> void
+NexusMods.Archives.Nx.Headers.StringPool
+NexusMods.Archives.Nx.Headers.StringPool.StringPool() -> void
+NexusMods.Archives.Nx.Headers.Structs.BlockSize
+NexusMods.Archives.Nx.Headers.Structs.BlockSize.BlockSize() -> void
+NexusMods.Archives.Nx.Headers.Structs.BlockSize.CompressedSize -> int
+NexusMods.Archives.Nx.Interfaces.IFileData
+NexusMods.Archives.Nx.Interfaces.IFileData.Data.get -> byte*
+NexusMods.Archives.Nx.Interfaces.IFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.Interfaces.IFileDataProvider
+NexusMods.Archives.Nx.Interfaces.IFileDataProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.Interfaces.IOutputDataProvider
+NexusMods.Archives.Nx.Interfaces.IOutputDataProvider.Entry.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.Interfaces.IOutputDataProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.Interfaces.IOutputDataProvider.RelativePath.get -> string!
+NexusMods.Archives.Nx.Packing.AddFileParams
+NexusMods.Archives.Nx.Packing.AddFileParams.AddFileParams() -> void
+NexusMods.Archives.Nx.Packing.AddFileParams.CompressionPreference.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Packing.AddFileParams.CompressionPreference.set -> void
+NexusMods.Archives.Nx.Packing.AddFileParams.RelativePath.get -> string!
+NexusMods.Archives.Nx.Packing.AddFileParams.RelativePath.init -> void
+NexusMods.Archives.Nx.Packing.AddFileParams.SolidType.get -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Packing.AddFileParams.SolidType.set -> void
+NexusMods.Archives.Nx.Packing.NxPacker
+NexusMods.Archives.Nx.Packing.NxPackerBuilder
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFile(byte[]! data, NexusMods.Archives.Nx.Packing.AddFileParams options) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFile(string! filePath, NexusMods.Archives.Nx.Packing.AddFileParams options) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFile(System.IO.Stream! stream, long length, NexusMods.Archives.Nx.Packing.AddFileParams options) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFile(System.IO.Stream! stream, NexusMods.Archives.Nx.Packing.AddFileParams options) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFolder(string! folder) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.Build(bool disposeOutput = true) -> System.IO.Stream!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.Files.get -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.NxPackerBuilder() -> void
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.Settings.get -> NexusMods.Archives.Nx.Structs.PackerSettings!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithBlockSize(int blockSize) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithChunkedFileAlgorithm(NexusMods.Archives.Nx.Enums.CompressionPreference chunkedFileAlgorithm) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithChunkedLevel(int level) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithChunkSize(int chunkSize) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithMaxNumThreads(int maxNumThreads) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithOutput(System.IO.Stream! output) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithPreset(NexusMods.Archives.Nx.Packing.PackerPreset preset) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithProgress(System.IProgress<double>? progress) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithSolidBlockAlgorithm(NexusMods.Archives.Nx.Enums.CompressionPreference solidBlockAlgorithm) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithSolidCompressionLevel(int level) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpacker
+NexusMods.Archives.Nx.Packing.NxUnpacker.ExtractFiles(NexusMods.Archives.Nx.Interfaces.IOutputDataProvider![]! outputs, NexusMods.Archives.Nx.Structs.UnpackerSettings! settings) -> void
+NexusMods.Archives.Nx.Packing.NxUnpacker.ExtractFilesInMemory(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, NexusMods.Archives.Nx.Structs.UnpackerSettings! settings) -> NexusMods.Archives.Nx.FileProviders.OutputArrayProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.ExtractFilesToDisk(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, string! outputFolder, NexusMods.Archives.Nx.Structs.UnpackerSettings! settings) -> NexusMods.Archives.Nx.FileProviders.OutputFileProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.GetFileEntriesRaw() -> System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry>
+NexusMods.Archives.Nx.Packing.NxUnpacker.GetFilePath(NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> string!
+NexusMods.Archives.Nx.Packing.NxUnpacker.GetPathedFileEntries() -> NexusMods.Archives.Nx.Packing.PathedFileEntry![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.MakeArrayOutputProviders(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files) -> NexusMods.Archives.Nx.FileProviders.OutputArrayProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.MakeDiskOutputProviders(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, string! outputFolder) -> NexusMods.Archives.Nx.FileProviders.OutputFileProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.NxUnpacker(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> void
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.AddFilesWithArrayOutput(NexusMods.Archives.Nx.Packing.PathedFileEntry![]! files, out NexusMods.Archives.Nx.FileProviders.OutputArrayProvider![]! results) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.AddFilesWithArrayOutput(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, out NexusMods.Archives.Nx.FileProviders.OutputArrayProvider![]! results) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.AddFilesWithDiskOutput(NexusMods.Archives.Nx.Packing.PathedFileEntry![]! files, string! outputFolder) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.AddFilesWithDiskOutput(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, string! outputFolder) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.Extract() -> NexusMods.Archives.Nx.Interfaces.IOutputDataProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.GetFileEntriesRaw() -> System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry>
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.GetPathedFileEntries() -> NexusMods.Archives.Nx.Packing.PathedFileEntry![]!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.NxUnpackerBuilder(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> void
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.Outputs.get -> System.Collections.Generic.List<NexusMods.Archives.Nx.Interfaces.IOutputDataProvider!>!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.Settings.get -> NexusMods.Archives.Nx.Structs.UnpackerSettings!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.Unpacker.get -> NexusMods.Archives.Nx.Packing.NxUnpacker!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.WithMaxNumThreads(int maxNumThreads) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.WithProgress(System.IProgress<double>? progress) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.PackerPreset
+NexusMods.Archives.Nx.Packing.PackerPreset.Default = 0 -> NexusMods.Archives.Nx.Packing.PackerPreset
+NexusMods.Archives.Nx.Packing.PackerPreset.RandomAccess = 1 -> NexusMods.Archives.Nx.Packing.PackerPreset
+NexusMods.Archives.Nx.Packing.PathedFileEntry
+NexusMods.Archives.Nx.Packing.PathedFileEntry.Entry.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.Packing.PathedFileEntry.Entry.init -> void
+NexusMods.Archives.Nx.Packing.PathedFileEntry.FileName.get -> string!
+NexusMods.Archives.Nx.Packing.PathedFileEntry.FileName.init -> void
+NexusMods.Archives.Nx.Packing.PathedFileEntry.PathedFileEntry() -> void
+NexusMods.Archives.Nx.Structs.PackerFile
+NexusMods.Archives.Nx.Structs.PackerFile.CompressionPreference.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Structs.PackerFile.CompressionPreference.set -> void
+NexusMods.Archives.Nx.Structs.PackerFile.FileDataProvider.get -> NexusMods.Archives.Nx.Interfaces.IFileDataProvider!
+NexusMods.Archives.Nx.Structs.PackerFile.FileDataProvider.init -> void
+NexusMods.Archives.Nx.Structs.PackerFile.FileSize.get -> long
+NexusMods.Archives.Nx.Structs.PackerFile.FileSize.init -> void
+NexusMods.Archives.Nx.Structs.PackerFile.PackerFile() -> void
+NexusMods.Archives.Nx.Structs.PackerFile.RelativePath.get -> string!
+NexusMods.Archives.Nx.Structs.PackerFile.RelativePath.set -> void
+NexusMods.Archives.Nx.Structs.PackerFile.SolidType.get -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Structs.PackerFile.SolidType.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings
+NexusMods.Archives.Nx.Structs.PackerSettings.BlockSize.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.BlockSize.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkedCompressionLevel.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkedCompressionLevel.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkedFileAlgorithm.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkedFileAlgorithm.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkSize.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkSize.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.MaxNumThreads.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.MaxNumThreads.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.Output.get -> System.IO.Stream!
+NexusMods.Archives.Nx.Structs.PackerSettings.Output.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.PackerSettings() -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.Progress.get -> System.IProgress<double>?
+NexusMods.Archives.Nx.Structs.PackerSettings.Progress.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.Sanitize() -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.SolidBlockAlgorithm.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Structs.PackerSettings.SolidBlockAlgorithm.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.SolidCompressionLevel.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.SolidCompressionLevel.set -> void
+NexusMods.Archives.Nx.Structs.UnpackerSettings
+NexusMods.Archives.Nx.Structs.UnpackerSettings.MaxNumThreads.get -> int
+NexusMods.Archives.Nx.Structs.UnpackerSettings.MaxNumThreads.set -> void
+NexusMods.Archives.Nx.Structs.UnpackerSettings.Progress.get -> System.IProgress<double>?
+NexusMods.Archives.Nx.Structs.UnpackerSettings.Progress.set -> void
+NexusMods.Archives.Nx.Structs.UnpackerSettings.Sanitize() -> void
+NexusMods.Archives.Nx.Structs.UnpackerSettings.UnpackerSettings() -> void
+NexusMods.Archives.Nx.Traits.ICanConvertToLittleEndian
+NexusMods.Archives.Nx.Traits.ICanConvertToLittleEndian.ReverseEndianIfNeeded() -> void
+NexusMods.Archives.Nx.Traits.ICanProvideFileData
+NexusMods.Archives.Nx.Traits.ICanProvideFileData.FileDataProvider.get -> NexusMods.Archives.Nx.Interfaces.IFileDataProvider!
+NexusMods.Archives.Nx.Traits.IHasCompressionPreference
+NexusMods.Archives.Nx.Traits.IHasCompressionPreference.CompressionPreference.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Traits.IHasFileSize
+NexusMods.Archives.Nx.Traits.IHasFileSize.FileSize.get -> long
+NexusMods.Archives.Nx.Traits.IHasRelativePath
+NexusMods.Archives.Nx.Traits.IHasRelativePath.RelativePath.get -> string!
+NexusMods.Archives.Nx.Traits.IHasSolidType
+NexusMods.Archives.Nx.Traits.IHasSolidType.SolidType.get -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Utilities.ArrayRental
+NexusMods.Archives.Nx.Utilities.ArrayRental.Array.get -> byte[]!
+NexusMods.Archives.Nx.Utilities.ArrayRental.ArrayRental() -> void
+NexusMods.Archives.Nx.Utilities.ArrayRental.ArrayRental(int numBytes) -> void
+NexusMods.Archives.Nx.Utilities.ArrayRental.Dispose() -> void
+NexusMods.Archives.Nx.Utilities.ArrayRental.Span.get -> System.Span<byte>
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.ArrayRentalSlice() -> void
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.ArrayRentalSlice(NexusMods.Archives.Nx.Utilities.ArrayRental rental, int length) -> void
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.Dispose() -> void
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.Length.get -> int
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.Rental.get -> NexusMods.Archives.Nx.Utilities.ArrayRental
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.Span.get -> System.Span<byte>
+NexusMods.Archives.Nx.Utilities.FileFinder
+NexusMods.Archives.Nx.Utilities.InsufficientStringPoolSizeException
+NexusMods.Archives.Nx.Utilities.InsufficientStringPoolSizeException.InsufficientStringPoolSizeException(string? message) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianReader
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.LittleEndianReader() -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.LittleEndianReader(byte* ptr) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.Ptr -> byte*
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadInt() -> int
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadIntAtOffset(int offset) -> int
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadLongAtOffset(int offset) -> long
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadShort() -> short
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadShortAtOffset(int offset) -> short
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadUInt() -> uint
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadUIntAtOffset(int offset) -> uint
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadUlongAtOffset(int offset) -> ulong
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadUShort() -> ushort
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.Seek(int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.LittleEndianWriter() -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.LittleEndianWriter(byte* ptr) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Ptr -> byte*
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Seek(int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(int value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(long value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(short value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(System.Span<byte> data) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(uint value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(ulong value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(ushort value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.WriteAtOffset(int value, int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.WriteAtOffset(long value, int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.WriteAtOffset(short value, int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.WriteAtOffset(ulong value, int offset) -> void
+NexusMods.Archives.Nx.Utilities.NotANexusArchiveException
+NexusMods.Archives.Nx.Utilities.NotANexusArchiveException.NotANexusArchiveException() -> void
+NexusMods.Archives.Nx.Utilities.OutOfPackerPoolArraysException
+NexusMods.Archives.Nx.Utilities.OutOfPackerPoolArraysException.OutOfPackerPoolArraysException(string? message) -> void
+NexusMods.Archives.Nx.Utilities.TocVersionNotSupportedException
+NexusMods.Archives.Nx.Utilities.TocVersionNotSupportedException.TocVersionNotSupportedException(NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> void
+NexusMods.Archives.Nx.Utilities.TocVersionNotSupportedException.Version.get -> NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion
+NexusMods.Archives.Nx.Utilities.UnsupportedCompressionMethodException
+NexusMods.Archives.Nx.Utilities.UnsupportedCompressionMethodException.Method.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Utilities.UnsupportedCompressionMethodException.UnsupportedCompressionMethodException(NexusMods.Archives.Nx.Enums.CompressionPreference method) -> void
+override NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Equals(object? obj) -> bool
+override NexusMods.Archives.Nx.Headers.Managed.TableOfContents.GetHashCode() -> int
+override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.Equals(object? obj) -> bool
+override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.GetHashCode() -> int
+override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.Equals(object? obj) -> bool
+override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.GetHashCode() -> int
+override NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.Equals(object? obj) -> bool
+override NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.GetHashCode() -> int
+static NexusMods.Archives.Nx.Headers.HeaderParser.ParseHeader(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> NexusMods.Archives.Nx.Headers.Managed.ParsedHeader!
+static NexusMods.Archives.Nx.Headers.HeaderParser.TryParseHeader(byte* data, int dataSize) -> NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult
+static NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Deserialize<T>(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> T!
+static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.operator !=(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.operator ==(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.operator !=(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.operator ==(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.Init(NexusMods.Archives.Nx.Headers.Native.NativeFileHeader* header, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version, int blockSizeBytes, int chunkSizeBytes, int headerPageCountBytes) -> void
+static NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.operator !=(NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple left, NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.operator ==(NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple left, NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple right) -> bool
+static NexusMods.Archives.Nx.Headers.StringPool.Pack<T>(System.Span<T> items) -> NexusMods.Archives.Nx.Utilities.ArrayRentalSlice
+static NexusMods.Archives.Nx.Headers.StringPool.Unpack(byte* poolPtr, int compressedDataSize) -> string![]!
+static NexusMods.Archives.Nx.Headers.StringPool.Unpack(byte* poolPtr, int compressedDataSize, int fileCountHint) -> string![]!
+static NexusMods.Archives.Nx.Headers.StringPool.Unpack(System.Span<byte> poolSpan) -> string![]!
+static NexusMods.Archives.Nx.Headers.StringPool.Unpack(System.Span<byte> poolSpan, int fileCountHint) -> string![]!
+static NexusMods.Archives.Nx.Packing.NxPacker.Pack(NexusMods.Archives.Nx.Structs.PackerFile![]! files, NexusMods.Archives.Nx.Structs.PackerSettings! settings) -> void
+static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.EnumerationOptions! options) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
+static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.SearchOption searchOption = System.IO.SearchOption.AllDirectories) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!

--- a/NexusMods.Archives.Nx/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/NexusMods.Archives.Nx/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -378,5 +378,6 @@ static NexusMods.Archives.Nx.Headers.StringPool.Unpack(byte* poolPtr, int compre
 static NexusMods.Archives.Nx.Headers.StringPool.Unpack(System.Span<byte> poolSpan) -> string![]!
 static NexusMods.Archives.Nx.Headers.StringPool.Unpack(System.Span<byte> poolSpan, int fileCountHint) -> string![]!
 static NexusMods.Archives.Nx.Packing.NxPacker.Pack(NexusMods.Archives.Nx.Structs.PackerFile![]! files, NexusMods.Archives.Nx.Structs.PackerSettings! settings) -> void
+static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
 static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.EnumerationOptions! options) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
-static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.SearchOption searchOption = System.IO.SearchOption.AllDirectories) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
+static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.SearchOption searchOption) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!

--- a/NexusMods.Archives.Nx/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/NexusMods.Archives.Nx/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -106,7 +106,7 @@ NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Pool.get -> string![]!
 NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Pool.init -> void
 NexusMods.Archives.Nx.Headers.Managed.TableOfContents.PoolSize.get -> int
 NexusMods.Archives.Nx.Headers.Managed.TableOfContents.PoolSize.init -> void
-NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Serialize(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version, System.Span<byte> stringPoolData) -> int
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Serialize(byte* dataPtr, int tocOffset, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version, System.Span<byte> stringPoolData) -> int
 NexusMods.Archives.Nx.Headers.Managed.TableOfContents.TableOfContents() -> void
 NexusMods.Archives.Nx.Headers.Native.INativeFileEntry
 NexusMods.Archives.Nx.Headers.Native.INativeFileEntry.CopyFrom(in NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
@@ -379,7 +379,7 @@ static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(stri
 static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(string? name, out NexusMods.Archives.Nx.Enums.CompressionPreference value, bool ignoreCase, bool allowMatchingMetadataAttribute) -> bool
 static NexusMods.Archives.Nx.Headers.HeaderParser.ParseHeader(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> NexusMods.Archives.Nx.Headers.Managed.ParsedHeader!
 static NexusMods.Archives.Nx.Headers.HeaderParser.TryParseHeader(byte* data, int dataSize) -> NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult
-static NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Deserialize<T>(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> T!
+static NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Deserialize<T>(byte* dataPtr, int tocOffset, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> T!
 static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.operator !=(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 right) -> bool
 static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.operator ==(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 right) -> bool
 static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.operator !=(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 right) -> bool

--- a/NexusMods.Archives.Nx/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NexusMods.Archives.Nx/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -106,7 +106,7 @@ NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Pool.get -> string![]!
 NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Pool.init -> void
 NexusMods.Archives.Nx.Headers.Managed.TableOfContents.PoolSize.get -> int
 NexusMods.Archives.Nx.Headers.Managed.TableOfContents.PoolSize.init -> void
-NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Serialize(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version, System.Span<byte> stringPoolData) -> int
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Serialize(byte* dataPtr, int tocOffset, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version, System.Span<byte> stringPoolData) -> int
 NexusMods.Archives.Nx.Headers.Managed.TableOfContents.TableOfContents() -> void
 NexusMods.Archives.Nx.Headers.Native.INativeFileEntry
 NexusMods.Archives.Nx.Headers.Native.INativeFileEntry.CopyFrom(in NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
@@ -374,7 +374,7 @@ static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(stri
 static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(string? name, out NexusMods.Archives.Nx.Enums.CompressionPreference value, bool ignoreCase, bool allowMatchingMetadataAttribute) -> bool
 static NexusMods.Archives.Nx.Headers.HeaderParser.ParseHeader(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> NexusMods.Archives.Nx.Headers.Managed.ParsedHeader!
 static NexusMods.Archives.Nx.Headers.HeaderParser.TryParseHeader(byte* data, int dataSize) -> NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult
-static NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Deserialize<T>(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> T!
+static NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Deserialize<T>(byte* dataPtr, int tocOffset, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> T!
 static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.operator !=(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 right) -> bool
 static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.operator ==(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 right) -> bool
 static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.operator !=(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 right) -> bool

--- a/NexusMods.Archives.Nx/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NexusMods.Archives.Nx/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -378,4 +378,5 @@ static NexusMods.Archives.Nx.Headers.StringPool.Unpack(byte* poolPtr, int compre
 static NexusMods.Archives.Nx.Headers.StringPool.Unpack(System.Span<byte> poolSpan) -> string![]!
 static NexusMods.Archives.Nx.Headers.StringPool.Unpack(System.Span<byte> poolSpan, int fileCountHint) -> string![]!
 static NexusMods.Archives.Nx.Packing.NxPacker.Pack(NexusMods.Archives.Nx.Structs.PackerFile![]! files, NexusMods.Archives.Nx.Structs.PackerSettings! settings) -> void
-static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.SearchOption searchOption = System.IO.SearchOption.AllDirectories) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
+static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
+static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.SearchOption searchOption) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!

--- a/NexusMods.Archives.Nx/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NexusMods.Archives.Nx/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,381 @@
-﻿
+﻿const NexusMods.Archives.Nx.Headers.StringPool.MaxCompressedSize = 33550336 -> int
+NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreference.Copy = 0 -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreference.Lz4 = 2 -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreference.NoPreference = 255 -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreference.ZStandard = 1 -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions
+NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Enums.SolidPreference.Default = 0 -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Enums.SolidPreference.NoSolid = 1 -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData.ArrayFileData(byte[]! data, long start, uint length) -> void
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData.Data.get -> byte*
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.Data.get -> byte*
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.MemoryMappedFileData(string! filePath, long start, uint length) -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.MemoryMappedFileData(string! filePath, long start, uint length, bool readOnly) -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData.Data.get -> byte*
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData.MemoryMappedOutputFileData(System.IO.MemoryMappedFiles.MemoryMappedFile! file, long start, uint length) -> void
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData.Data.get -> byte*
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData.RentedArrayFileData(NexusMods.Archives.Nx.Utilities.ArrayRentalSlice data) -> void
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider.Data.get -> byte[]!
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider.Data.init -> void
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider.FromArrayProvider() -> void
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.Directory.get -> string!
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.Directory.init -> void
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.FromDirectoryDataProvider() -> void
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.RelativePath.get -> string!
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.RelativePath.init -> void
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider.FromStreamProvider(System.IO.Stream! stream) -> void
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider.Stream.get -> System.IO.Stream!
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider.StreamStart.get -> long
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.Data.get -> byte[]!
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.Entry.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.Entry.init -> void
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.OutputArrayProvider(string! relativePath, NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.RelativePath.get -> string!
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.RelativePath.init -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.Entry.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.Entry.init -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.FullPath.get -> string!
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.FullPath.init -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.OutputFileProvider(string! outputFolder, string! relativePath, NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.RelativePath.get -> string!
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.RelativePath.init -> void
+NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion
+NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion.V0 = 0 -> NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion
+NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion.V1 = 1 -> NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion
+NexusMods.Archives.Nx.Headers.HeaderParser
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.Header.get -> NexusMods.Archives.Nx.Headers.Managed.ParsedHeader?
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.Header.init -> void
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.HeaderParserResult() -> void
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.HeaderSize.get -> int
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.HeaderSize.init -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.DecompressedBlockOffset -> int
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.DecompressedSize -> ulong
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FileEntry() -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FilePathIndex -> int
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FirstBlockIndex -> int
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FromReaderV0(ref NexusMods.Archives.Nx.Utilities.LittleEndianReader reader) -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FromReaderV1(ref NexusMods.Archives.Nx.Utilities.LittleEndianReader reader) -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.GetChunkCount(int chunkSizeBytes) -> int
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.Hash -> ulong
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.WriteAsV0(ref NexusMods.Archives.Nx.Utilities.LittleEndianWriter writer) -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.WriteAsV1(ref NexusMods.Archives.Nx.Utilities.LittleEndianWriter writer) -> void
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader.BlockOffsets -> long[]!
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader.Header -> NexusMods.Archives.Nx.Headers.Native.NativeFileHeader
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader.Init() -> void
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader.ParsedHeader() -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.BlockCompressions.get -> NexusMods.Archives.Nx.Enums.CompressionPreference[]!
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.BlockCompressions.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Blocks.get -> NexusMods.Archives.Nx.Headers.Structs.BlockSize[]!
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Blocks.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.CalculateTableSize(NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> int
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Entries.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry[]!
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Entries.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Equals(NexusMods.Archives.Nx.Headers.Managed.TableOfContents? other) -> bool
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Pool.get -> string![]!
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Pool.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.PoolSize.get -> int
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.PoolSize.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Serialize(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version, System.Span<byte> stringPoolData) -> int
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.TableOfContents() -> void
+NexusMods.Archives.Nx.Headers.Native.INativeFileEntry
+NexusMods.Archives.Nx.Headers.Native.INativeFileEntry.CopyFrom(in NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.INativeFileEntry.CopyTo(ref NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.CopyFrom(in NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.CopyTo(ref NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.DecompressedBlockOffset.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.DecompressedBlockOffset.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.DecompressedSize -> uint
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.Equals(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 other) -> bool
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.FilePathIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.FilePathIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.FirstBlockIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.FirstBlockIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.Hash -> ulong
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.NativeFileEntryV0() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.CopyFrom(in NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.CopyTo(ref NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.DecompressedBlockOffset.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.DecompressedBlockOffset.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.DecompressedSize -> ulong
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.Equals(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 other) -> bool
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.FilePathIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.FilePathIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.FirstBlockIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.FirstBlockIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.Hash -> ulong
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.NativeFileEntryV1() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.BlockSize.get -> byte
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.BlockSize.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.BlockSizeBytes.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.BlockSizeBytes.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ChunkSize.get -> byte
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ChunkSize.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ChunkSizeBytes.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ChunkSizeBytes.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.FeatureFlags -> byte
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.HeaderPageBytes.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.HeaderPageBytes.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.HeaderPageCount.get -> ushort
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.HeaderPageCount.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.IsValidMagicHeader() -> bool
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.Magic -> uint
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.NativeFileHeader() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ReverseEndianIfNeeded() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.SetMagic() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.TocSize.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.Version.get -> byte
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.Version.set -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.CopyTo(ref NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.DecompressedBlockOffset.get -> int
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.DecompressedBlockOffset.set -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.Equals(NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple other) -> bool
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.FilePathIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.FilePathIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.FirstBlockIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.FirstBlockIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.OffsetPathIndexTuple() -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.OffsetPathIndexTuple(int decompressedBlockOffset, int filePathIndex, int firstBlockIndex) -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.OffsetPathIndexTuple(long data) -> void
+NexusMods.Archives.Nx.Headers.StringPool
+NexusMods.Archives.Nx.Headers.StringPool.StringPool() -> void
+NexusMods.Archives.Nx.Headers.Structs.BlockSize
+NexusMods.Archives.Nx.Headers.Structs.BlockSize.BlockSize() -> void
+NexusMods.Archives.Nx.Headers.Structs.BlockSize.CompressedSize -> int
+NexusMods.Archives.Nx.Interfaces.IFileData
+NexusMods.Archives.Nx.Interfaces.IFileData.Data.get -> byte*
+NexusMods.Archives.Nx.Interfaces.IFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.Interfaces.IFileDataProvider
+NexusMods.Archives.Nx.Interfaces.IFileDataProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.Interfaces.IOutputDataProvider
+NexusMods.Archives.Nx.Interfaces.IOutputDataProvider.Entry.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.Interfaces.IOutputDataProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.Interfaces.IOutputDataProvider.RelativePath.get -> string!
+NexusMods.Archives.Nx.Packing.AddFileParams
+NexusMods.Archives.Nx.Packing.AddFileParams.AddFileParams() -> void
+NexusMods.Archives.Nx.Packing.AddFileParams.CompressionPreference.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Packing.AddFileParams.CompressionPreference.set -> void
+NexusMods.Archives.Nx.Packing.AddFileParams.RelativePath.get -> string!
+NexusMods.Archives.Nx.Packing.AddFileParams.RelativePath.init -> void
+NexusMods.Archives.Nx.Packing.AddFileParams.SolidType.get -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Packing.AddFileParams.SolidType.set -> void
+NexusMods.Archives.Nx.Packing.NxPacker
+NexusMods.Archives.Nx.Packing.NxPackerBuilder
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFile(byte[]! data, NexusMods.Archives.Nx.Packing.AddFileParams options) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFile(string! filePath, NexusMods.Archives.Nx.Packing.AddFileParams options) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFile(System.IO.Stream! stream, long length, NexusMods.Archives.Nx.Packing.AddFileParams options) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFile(System.IO.Stream! stream, NexusMods.Archives.Nx.Packing.AddFileParams options) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFolder(string! folder) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.Build(bool disposeOutput = true) -> System.IO.Stream!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.Files.get -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.NxPackerBuilder() -> void
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.Settings.get -> NexusMods.Archives.Nx.Structs.PackerSettings!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithBlockSize(int blockSize) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithChunkedFileAlgorithm(NexusMods.Archives.Nx.Enums.CompressionPreference chunkedFileAlgorithm) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithChunkedLevel(int level) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithChunkSize(int chunkSize) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithMaxNumThreads(int maxNumThreads) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithOutput(System.IO.Stream! output) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithPreset(NexusMods.Archives.Nx.Packing.PackerPreset preset) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithProgress(System.IProgress<double>? progress) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithSolidBlockAlgorithm(NexusMods.Archives.Nx.Enums.CompressionPreference solidBlockAlgorithm) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithSolidCompressionLevel(int level) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpacker
+NexusMods.Archives.Nx.Packing.NxUnpacker.ExtractFiles(NexusMods.Archives.Nx.Interfaces.IOutputDataProvider![]! outputs, NexusMods.Archives.Nx.Structs.UnpackerSettings! settings) -> void
+NexusMods.Archives.Nx.Packing.NxUnpacker.ExtractFilesInMemory(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, NexusMods.Archives.Nx.Structs.UnpackerSettings! settings) -> NexusMods.Archives.Nx.FileProviders.OutputArrayProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.ExtractFilesToDisk(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, string! outputFolder, NexusMods.Archives.Nx.Structs.UnpackerSettings! settings) -> NexusMods.Archives.Nx.FileProviders.OutputFileProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.GetFileEntriesRaw() -> System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry>
+NexusMods.Archives.Nx.Packing.NxUnpacker.GetFilePath(NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> string!
+NexusMods.Archives.Nx.Packing.NxUnpacker.GetPathedFileEntries() -> NexusMods.Archives.Nx.Packing.PathedFileEntry![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.MakeArrayOutputProviders(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files) -> NexusMods.Archives.Nx.FileProviders.OutputArrayProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.MakeDiskOutputProviders(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, string! outputFolder) -> NexusMods.Archives.Nx.FileProviders.OutputFileProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.NxUnpacker(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> void
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.AddFilesWithArrayOutput(NexusMods.Archives.Nx.Packing.PathedFileEntry![]! files, out NexusMods.Archives.Nx.FileProviders.OutputArrayProvider![]! results) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.AddFilesWithArrayOutput(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, out NexusMods.Archives.Nx.FileProviders.OutputArrayProvider![]! results) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.AddFilesWithDiskOutput(NexusMods.Archives.Nx.Packing.PathedFileEntry![]! files, string! outputFolder) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.AddFilesWithDiskOutput(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, string! outputFolder) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.Extract() -> NexusMods.Archives.Nx.Interfaces.IOutputDataProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.GetFileEntriesRaw() -> System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry>
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.GetPathedFileEntries() -> NexusMods.Archives.Nx.Packing.PathedFileEntry![]!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.NxUnpackerBuilder(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> void
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.Outputs.get -> System.Collections.Generic.List<NexusMods.Archives.Nx.Interfaces.IOutputDataProvider!>!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.Settings.get -> NexusMods.Archives.Nx.Structs.UnpackerSettings!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.Unpacker.get -> NexusMods.Archives.Nx.Packing.NxUnpacker!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.WithMaxNumThreads(int maxNumThreads) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.WithProgress(System.IProgress<double>? progress) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.PackerPreset
+NexusMods.Archives.Nx.Packing.PackerPreset.Default = 0 -> NexusMods.Archives.Nx.Packing.PackerPreset
+NexusMods.Archives.Nx.Packing.PackerPreset.RandomAccess = 1 -> NexusMods.Archives.Nx.Packing.PackerPreset
+NexusMods.Archives.Nx.Packing.PathedFileEntry
+NexusMods.Archives.Nx.Packing.PathedFileEntry.Entry.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.Packing.PathedFileEntry.Entry.init -> void
+NexusMods.Archives.Nx.Packing.PathedFileEntry.FileName.get -> string!
+NexusMods.Archives.Nx.Packing.PathedFileEntry.FileName.init -> void
+NexusMods.Archives.Nx.Packing.PathedFileEntry.PathedFileEntry() -> void
+NexusMods.Archives.Nx.Structs.PackerFile
+NexusMods.Archives.Nx.Structs.PackerFile.CompressionPreference.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Structs.PackerFile.CompressionPreference.set -> void
+NexusMods.Archives.Nx.Structs.PackerFile.FileDataProvider.get -> NexusMods.Archives.Nx.Interfaces.IFileDataProvider!
+NexusMods.Archives.Nx.Structs.PackerFile.FileDataProvider.init -> void
+NexusMods.Archives.Nx.Structs.PackerFile.FileSize.get -> long
+NexusMods.Archives.Nx.Structs.PackerFile.FileSize.init -> void
+NexusMods.Archives.Nx.Structs.PackerFile.PackerFile() -> void
+NexusMods.Archives.Nx.Structs.PackerFile.RelativePath.get -> string!
+NexusMods.Archives.Nx.Structs.PackerFile.RelativePath.set -> void
+NexusMods.Archives.Nx.Structs.PackerFile.SolidType.get -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Structs.PackerFile.SolidType.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings
+NexusMods.Archives.Nx.Structs.PackerSettings.BlockSize.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.BlockSize.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkedCompressionLevel.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkedCompressionLevel.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkedFileAlgorithm.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkedFileAlgorithm.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkSize.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkSize.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.MaxNumThreads.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.MaxNumThreads.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.Output.get -> System.IO.Stream!
+NexusMods.Archives.Nx.Structs.PackerSettings.Output.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.PackerSettings() -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.Progress.get -> System.IProgress<double>?
+NexusMods.Archives.Nx.Structs.PackerSettings.Progress.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.Sanitize() -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.SolidBlockAlgorithm.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Structs.PackerSettings.SolidBlockAlgorithm.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.SolidCompressionLevel.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.SolidCompressionLevel.set -> void
+NexusMods.Archives.Nx.Structs.UnpackerSettings
+NexusMods.Archives.Nx.Structs.UnpackerSettings.MaxNumThreads.get -> int
+NexusMods.Archives.Nx.Structs.UnpackerSettings.MaxNumThreads.set -> void
+NexusMods.Archives.Nx.Structs.UnpackerSettings.Progress.get -> System.IProgress<double>?
+NexusMods.Archives.Nx.Structs.UnpackerSettings.Progress.set -> void
+NexusMods.Archives.Nx.Structs.UnpackerSettings.Sanitize() -> void
+NexusMods.Archives.Nx.Structs.UnpackerSettings.UnpackerSettings() -> void
+NexusMods.Archives.Nx.Traits.ICanConvertToLittleEndian
+NexusMods.Archives.Nx.Traits.ICanConvertToLittleEndian.ReverseEndianIfNeeded() -> void
+NexusMods.Archives.Nx.Traits.ICanProvideFileData
+NexusMods.Archives.Nx.Traits.ICanProvideFileData.FileDataProvider.get -> NexusMods.Archives.Nx.Interfaces.IFileDataProvider!
+NexusMods.Archives.Nx.Traits.IHasCompressionPreference
+NexusMods.Archives.Nx.Traits.IHasCompressionPreference.CompressionPreference.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Traits.IHasFileSize
+NexusMods.Archives.Nx.Traits.IHasFileSize.FileSize.get -> long
+NexusMods.Archives.Nx.Traits.IHasRelativePath
+NexusMods.Archives.Nx.Traits.IHasRelativePath.RelativePath.get -> string!
+NexusMods.Archives.Nx.Traits.IHasSolidType
+NexusMods.Archives.Nx.Traits.IHasSolidType.SolidType.get -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Utilities.ArrayRental
+NexusMods.Archives.Nx.Utilities.ArrayRental.Array.get -> byte[]!
+NexusMods.Archives.Nx.Utilities.ArrayRental.ArrayRental() -> void
+NexusMods.Archives.Nx.Utilities.ArrayRental.ArrayRental(int numBytes) -> void
+NexusMods.Archives.Nx.Utilities.ArrayRental.Dispose() -> void
+NexusMods.Archives.Nx.Utilities.ArrayRental.Span.get -> System.Span<byte>
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.ArrayRentalSlice() -> void
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.ArrayRentalSlice(NexusMods.Archives.Nx.Utilities.ArrayRental rental, int length) -> void
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.Dispose() -> void
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.Length.get -> int
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.Rental.get -> NexusMods.Archives.Nx.Utilities.ArrayRental
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.Span.get -> System.Span<byte>
+NexusMods.Archives.Nx.Utilities.FileFinder
+NexusMods.Archives.Nx.Utilities.InsufficientStringPoolSizeException
+NexusMods.Archives.Nx.Utilities.InsufficientStringPoolSizeException.InsufficientStringPoolSizeException(string? message) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianReader
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.LittleEndianReader() -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.LittleEndianReader(byte* ptr) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.Ptr -> byte*
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadInt() -> int
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadIntAtOffset(int offset) -> int
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadLongAtOffset(int offset) -> long
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadShort() -> short
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadShortAtOffset(int offset) -> short
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadUInt() -> uint
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadUIntAtOffset(int offset) -> uint
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadUlongAtOffset(int offset) -> ulong
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadUShort() -> ushort
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.Seek(int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.LittleEndianWriter() -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.LittleEndianWriter(byte* ptr) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Ptr -> byte*
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Seek(int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(int value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(long value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(short value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(System.Span<byte> data) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(uint value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(ulong value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(ushort value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.WriteAtOffset(int value, int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.WriteAtOffset(long value, int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.WriteAtOffset(short value, int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.WriteAtOffset(ulong value, int offset) -> void
+NexusMods.Archives.Nx.Utilities.NotANexusArchiveException
+NexusMods.Archives.Nx.Utilities.NotANexusArchiveException.NotANexusArchiveException() -> void
+NexusMods.Archives.Nx.Utilities.OutOfPackerPoolArraysException
+NexusMods.Archives.Nx.Utilities.OutOfPackerPoolArraysException.OutOfPackerPoolArraysException(string? message) -> void
+NexusMods.Archives.Nx.Utilities.TocVersionNotSupportedException
+NexusMods.Archives.Nx.Utilities.TocVersionNotSupportedException.TocVersionNotSupportedException(NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> void
+NexusMods.Archives.Nx.Utilities.TocVersionNotSupportedException.Version.get -> NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion
+NexusMods.Archives.Nx.Utilities.UnsupportedCompressionMethodException
+NexusMods.Archives.Nx.Utilities.UnsupportedCompressionMethodException.Method.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Utilities.UnsupportedCompressionMethodException.UnsupportedCompressionMethodException(NexusMods.Archives.Nx.Enums.CompressionPreference method) -> void
+override NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Equals(object? obj) -> bool
+override NexusMods.Archives.Nx.Headers.Managed.TableOfContents.GetHashCode() -> int
+override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.Equals(object? obj) -> bool
+override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.GetHashCode() -> int
+override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.Equals(object? obj) -> bool
+override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.GetHashCode() -> int
+override NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.Equals(object? obj) -> bool
+override NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.GetHashCode() -> int
+static NexusMods.Archives.Nx.Headers.HeaderParser.ParseHeader(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> NexusMods.Archives.Nx.Headers.Managed.ParsedHeader!
+static NexusMods.Archives.Nx.Headers.HeaderParser.TryParseHeader(byte* data, int dataSize) -> NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult
+static NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Deserialize<T>(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> T!
+static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.operator !=(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.operator ==(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.operator !=(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.operator ==(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.Init(NexusMods.Archives.Nx.Headers.Native.NativeFileHeader* header, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version, int blockSizeBytes, int chunkSizeBytes, int headerPageCountBytes) -> void
+static NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.operator !=(NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple left, NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.operator ==(NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple left, NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple right) -> bool
+static NexusMods.Archives.Nx.Headers.StringPool.Pack<T>(System.Span<T> items) -> NexusMods.Archives.Nx.Utilities.ArrayRentalSlice
+static NexusMods.Archives.Nx.Headers.StringPool.Unpack(byte* poolPtr, int compressedDataSize) -> string![]!
+static NexusMods.Archives.Nx.Headers.StringPool.Unpack(byte* poolPtr, int compressedDataSize, int fileCountHint) -> string![]!
+static NexusMods.Archives.Nx.Headers.StringPool.Unpack(System.Span<byte> poolSpan) -> string![]!
+static NexusMods.Archives.Nx.Headers.StringPool.Unpack(System.Span<byte> poolSpan, int fileCountHint) -> string![]!
+static NexusMods.Archives.Nx.Packing.NxPacker.Pack(NexusMods.Archives.Nx.Structs.PackerFile![]! files, NexusMods.Archives.Nx.Structs.PackerSettings! settings) -> void
+static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.SearchOption searchOption = System.IO.SearchOption.AllDirectories) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!

--- a/NexusMods.Archives.Nx/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/NexusMods.Archives.Nx/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
-﻿const NexusMods.Archives.Nx.Headers.StringPool.MaxCompressedSize = 33550336 -> int
+﻿const NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.Length = 4 -> int
+const NexusMods.Archives.Nx.Headers.StringPool.MaxCompressedSize = 33550336 -> int
 NexusMods.Archives.Nx.Enums.CompressionPreference
 NexusMods.Archives.Nx.Enums.CompressionPreference.Copy = 0 -> NexusMods.Archives.Nx.Enums.CompressionPreference
 NexusMods.Archives.Nx.Enums.CompressionPreference.Lz4 = 2 -> NexusMods.Archives.Nx.Enums.CompressionPreference
@@ -362,6 +363,15 @@ override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.Equals(object? o
 override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.GetHashCode() -> int
 override NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.Equals(object? obj) -> bool
 override NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.GetHashCode() -> int
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.GetNames() -> string![]!
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.GetValues() -> NexusMods.Archives.Nx.Enums.CompressionPreference[]!
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.IsDefined(NexusMods.Archives.Nx.Enums.CompressionPreference value) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.IsDefined(string! name) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.IsDefined(string! name, bool allowMatchingMetadataAttribute) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.ToStringFast(this NexusMods.Archives.Nx.Enums.CompressionPreference value) -> string!
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(string? name, out NexusMods.Archives.Nx.Enums.CompressionPreference value) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(string? name, out NexusMods.Archives.Nx.Enums.CompressionPreference value, bool ignoreCase) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(string? name, out NexusMods.Archives.Nx.Enums.CompressionPreference value, bool ignoreCase, bool allowMatchingMetadataAttribute) -> bool
 static NexusMods.Archives.Nx.Headers.HeaderParser.ParseHeader(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> NexusMods.Archives.Nx.Headers.Managed.ParsedHeader!
 static NexusMods.Archives.Nx.Headers.HeaderParser.TryParseHeader(byte* data, int dataSize) -> NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult
 static NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Deserialize<T>(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> T!

--- a/NexusMods.Archives.Nx/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/NexusMods.Archives.Nx/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -106,7 +106,7 @@ NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Pool.get -> string![]!
 NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Pool.init -> void
 NexusMods.Archives.Nx.Headers.Managed.TableOfContents.PoolSize.get -> int
 NexusMods.Archives.Nx.Headers.Managed.TableOfContents.PoolSize.init -> void
-NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Serialize(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version, System.Span<byte> stringPoolData) -> int
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Serialize(byte* dataPtr, int tocOffset, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version, System.Span<byte> stringPoolData) -> int
 NexusMods.Archives.Nx.Headers.Managed.TableOfContents.TableOfContents() -> void
 NexusMods.Archives.Nx.Headers.Native.INativeFileEntry
 NexusMods.Archives.Nx.Headers.Native.INativeFileEntry.CopyFrom(in NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
@@ -374,7 +374,7 @@ static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(stri
 static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(string? name, out NexusMods.Archives.Nx.Enums.CompressionPreference value, bool ignoreCase, bool allowMatchingMetadataAttribute) -> bool
 static NexusMods.Archives.Nx.Headers.HeaderParser.ParseHeader(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> NexusMods.Archives.Nx.Headers.Managed.ParsedHeader!
 static NexusMods.Archives.Nx.Headers.HeaderParser.TryParseHeader(byte* data, int dataSize) -> NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult
-static NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Deserialize<T>(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> T!
+static NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Deserialize<T>(byte* dataPtr, int tocOffset, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> T!
 static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.operator !=(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 right) -> bool
 static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.operator ==(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 right) -> bool
 static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.operator !=(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 right) -> bool

--- a/NexusMods.Archives.Nx/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/NexusMods.Archives.Nx/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,1 +1,382 @@
-﻿
+﻿const NexusMods.Archives.Nx.Headers.StringPool.MaxCompressedSize = 33550336 -> int
+NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreference.Copy = 0 -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreference.Lz4 = 2 -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreference.NoPreference = 255 -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreference.ZStandard = 1 -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions
+NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Enums.SolidPreference.Default = 0 -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Enums.SolidPreference.NoSolid = 1 -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData.ArrayFileData(byte[]! data, long start, uint length) -> void
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData.Data.get -> byte*
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.FileProviders.FileData.ArrayFileData.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.Data.get -> byte*
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.MemoryMappedFileData(string! filePath, long start, uint length) -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedFileData.MemoryMappedFileData(string! filePath, long start, uint length, bool readOnly) -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData.Data.get -> byte*
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.FileData.MemoryMappedOutputFileData.MemoryMappedOutputFileData(System.IO.MemoryMappedFiles.MemoryMappedFile! file, long start, uint length) -> void
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData.Data.get -> byte*
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.FileData.RentedArrayFileData.RentedArrayFileData(NexusMods.Archives.Nx.Utilities.ArrayRentalSlice data) -> void
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider.Data.get -> byte[]!
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider.Data.init -> void
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider.FromArrayProvider() -> void
+NexusMods.Archives.Nx.FileProviders.FromArrayProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.Directory.get -> string!
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.Directory.init -> void
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.FromDirectoryDataProvider() -> void
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.RelativePath.get -> string!
+NexusMods.Archives.Nx.FileProviders.FromDirectoryDataProvider.RelativePath.init -> void
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider.FromStreamProvider(System.IO.Stream! stream) -> void
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider.Stream.get -> System.IO.Stream!
+NexusMods.Archives.Nx.FileProviders.FromStreamProvider.StreamStart.get -> long
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.Data.get -> byte[]!
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.Entry.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.Entry.init -> void
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.OutputArrayProvider(string! relativePath, NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.RelativePath.get -> string!
+NexusMods.Archives.Nx.FileProviders.OutputArrayProvider.RelativePath.init -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.Dispose() -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.Entry.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.Entry.init -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.FullPath.get -> string!
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.FullPath.init -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.OutputFileProvider(string! outputFolder, string! relativePath, NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.RelativePath.get -> string!
+NexusMods.Archives.Nx.FileProviders.OutputFileProvider.RelativePath.init -> void
+NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion
+NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion.V0 = 0 -> NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion
+NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion.V1 = 1 -> NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion
+NexusMods.Archives.Nx.Headers.HeaderParser
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.Header.get -> NexusMods.Archives.Nx.Headers.Managed.ParsedHeader?
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.Header.init -> void
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.HeaderParserResult() -> void
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.HeaderSize.get -> int
+NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult.HeaderSize.init -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.DecompressedBlockOffset -> int
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.DecompressedSize -> ulong
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FileEntry() -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FilePathIndex -> int
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FirstBlockIndex -> int
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FromReaderV0(ref NexusMods.Archives.Nx.Utilities.LittleEndianReader reader) -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.FromReaderV1(ref NexusMods.Archives.Nx.Utilities.LittleEndianReader reader) -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.GetChunkCount(int chunkSizeBytes) -> int
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.Hash -> ulong
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.WriteAsV0(ref NexusMods.Archives.Nx.Utilities.LittleEndianWriter writer) -> void
+NexusMods.Archives.Nx.Headers.Managed.FileEntry.WriteAsV1(ref NexusMods.Archives.Nx.Utilities.LittleEndianWriter writer) -> void
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader.BlockOffsets -> long[]!
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader.Header -> NexusMods.Archives.Nx.Headers.Native.NativeFileHeader
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader.Init() -> void
+NexusMods.Archives.Nx.Headers.Managed.ParsedHeader.ParsedHeader() -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.BlockCompressions.get -> NexusMods.Archives.Nx.Enums.CompressionPreference[]!
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.BlockCompressions.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Blocks.get -> NexusMods.Archives.Nx.Headers.Structs.BlockSize[]!
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Blocks.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.CalculateTableSize(NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> int
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Entries.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry[]!
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Entries.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Equals(NexusMods.Archives.Nx.Headers.Managed.TableOfContents? other) -> bool
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Pool.get -> string![]!
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Pool.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.PoolSize.get -> int
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.PoolSize.init -> void
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Serialize(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version, System.Span<byte> stringPoolData) -> int
+NexusMods.Archives.Nx.Headers.Managed.TableOfContents.TableOfContents() -> void
+NexusMods.Archives.Nx.Headers.Native.INativeFileEntry
+NexusMods.Archives.Nx.Headers.Native.INativeFileEntry.CopyFrom(in NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.INativeFileEntry.CopyTo(ref NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.CopyFrom(in NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.CopyTo(ref NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.DecompressedBlockOffset.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.DecompressedBlockOffset.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.DecompressedSize -> uint
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.Equals(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 other) -> bool
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.FilePathIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.FilePathIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.FirstBlockIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.FirstBlockIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.Hash -> ulong
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.NativeFileEntryV0() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.CopyFrom(in NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.CopyTo(ref NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.DecompressedBlockOffset.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.DecompressedBlockOffset.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.DecompressedSize -> ulong
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.Equals(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 other) -> bool
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.FilePathIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.FilePathIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.FirstBlockIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.FirstBlockIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.Hash -> ulong
+NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.NativeFileEntryV1() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.BlockSize.get -> byte
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.BlockSize.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.BlockSizeBytes.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.BlockSizeBytes.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ChunkSize.get -> byte
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ChunkSize.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ChunkSizeBytes.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ChunkSizeBytes.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.FeatureFlags -> byte
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.HeaderPageBytes.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.HeaderPageBytes.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.HeaderPageCount.get -> ushort
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.HeaderPageCount.set -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.IsValidMagicHeader() -> bool
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.Magic -> uint
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.NativeFileHeader() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.ReverseEndianIfNeeded() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.SetMagic() -> void
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.TocSize.get -> int
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.Version.get -> byte
+NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.Version.set -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.CopyTo(ref NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.DecompressedBlockOffset.get -> int
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.DecompressedBlockOffset.set -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.Equals(NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple other) -> bool
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.FilePathIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.FilePathIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.FirstBlockIndex.get -> int
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.FirstBlockIndex.set -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.OffsetPathIndexTuple() -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.OffsetPathIndexTuple(int decompressedBlockOffset, int filePathIndex, int firstBlockIndex) -> void
+NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.OffsetPathIndexTuple(long data) -> void
+NexusMods.Archives.Nx.Headers.StringPool
+NexusMods.Archives.Nx.Headers.StringPool.StringPool() -> void
+NexusMods.Archives.Nx.Headers.Structs.BlockSize
+NexusMods.Archives.Nx.Headers.Structs.BlockSize.BlockSize() -> void
+NexusMods.Archives.Nx.Headers.Structs.BlockSize.CompressedSize -> int
+NexusMods.Archives.Nx.Interfaces.IFileData
+NexusMods.Archives.Nx.Interfaces.IFileData.Data.get -> byte*
+NexusMods.Archives.Nx.Interfaces.IFileData.DataLength.get -> nuint
+NexusMods.Archives.Nx.Interfaces.IFileDataProvider
+NexusMods.Archives.Nx.Interfaces.IFileDataProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.Interfaces.IOutputDataProvider
+NexusMods.Archives.Nx.Interfaces.IOutputDataProvider.Entry.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.Interfaces.IOutputDataProvider.GetFileData(long start, uint length) -> NexusMods.Archives.Nx.Interfaces.IFileData!
+NexusMods.Archives.Nx.Interfaces.IOutputDataProvider.RelativePath.get -> string!
+NexusMods.Archives.Nx.Packing.AddFileParams
+NexusMods.Archives.Nx.Packing.AddFileParams.AddFileParams() -> void
+NexusMods.Archives.Nx.Packing.AddFileParams.CompressionPreference.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Packing.AddFileParams.CompressionPreference.set -> void
+NexusMods.Archives.Nx.Packing.AddFileParams.RelativePath.get -> string!
+NexusMods.Archives.Nx.Packing.AddFileParams.RelativePath.init -> void
+NexusMods.Archives.Nx.Packing.AddFileParams.SolidType.get -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Packing.AddFileParams.SolidType.set -> void
+NexusMods.Archives.Nx.Packing.NxPacker
+NexusMods.Archives.Nx.Packing.NxPackerBuilder
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFile(byte[]! data, NexusMods.Archives.Nx.Packing.AddFileParams options) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFile(string! filePath, NexusMods.Archives.Nx.Packing.AddFileParams options) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFile(System.IO.Stream! stream, long length, NexusMods.Archives.Nx.Packing.AddFileParams options) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFile(System.IO.Stream! stream, NexusMods.Archives.Nx.Packing.AddFileParams options) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.AddFolder(string! folder) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.Build(bool disposeOutput = true) -> System.IO.Stream!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.Files.get -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.NxPackerBuilder() -> void
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.Settings.get -> NexusMods.Archives.Nx.Structs.PackerSettings!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithBlockSize(int blockSize) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithChunkedFileAlgorithm(NexusMods.Archives.Nx.Enums.CompressionPreference chunkedFileAlgorithm) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithChunkedLevel(int level) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithChunkSize(int chunkSize) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithMaxNumThreads(int maxNumThreads) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithOutput(System.IO.Stream! output) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithPreset(NexusMods.Archives.Nx.Packing.PackerPreset preset) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithProgress(System.IProgress<double>? progress) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithSolidBlockAlgorithm(NexusMods.Archives.Nx.Enums.CompressionPreference solidBlockAlgorithm) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxPackerBuilder.WithSolidCompressionLevel(int level) -> NexusMods.Archives.Nx.Packing.NxPackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpacker
+NexusMods.Archives.Nx.Packing.NxUnpacker.ExtractFiles(NexusMods.Archives.Nx.Interfaces.IOutputDataProvider![]! outputs, NexusMods.Archives.Nx.Structs.UnpackerSettings! settings) -> void
+NexusMods.Archives.Nx.Packing.NxUnpacker.ExtractFilesInMemory(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, NexusMods.Archives.Nx.Structs.UnpackerSettings! settings) -> NexusMods.Archives.Nx.FileProviders.OutputArrayProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.ExtractFilesToDisk(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, string! outputFolder, NexusMods.Archives.Nx.Structs.UnpackerSettings! settings) -> NexusMods.Archives.Nx.FileProviders.OutputFileProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.GetFileEntriesRaw() -> System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry>
+NexusMods.Archives.Nx.Packing.NxUnpacker.GetFilePath(NexusMods.Archives.Nx.Headers.Managed.FileEntry entry) -> string!
+NexusMods.Archives.Nx.Packing.NxUnpacker.GetPathedFileEntries() -> NexusMods.Archives.Nx.Packing.PathedFileEntry![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.MakeArrayOutputProviders(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files) -> NexusMods.Archives.Nx.FileProviders.OutputArrayProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.MakeDiskOutputProviders(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, string! outputFolder) -> NexusMods.Archives.Nx.FileProviders.OutputFileProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpacker.NxUnpacker(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> void
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.AddFilesWithArrayOutput(NexusMods.Archives.Nx.Packing.PathedFileEntry![]! files, out NexusMods.Archives.Nx.FileProviders.OutputArrayProvider![]! results) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.AddFilesWithArrayOutput(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, out NexusMods.Archives.Nx.FileProviders.OutputArrayProvider![]! results) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.AddFilesWithDiskOutput(NexusMods.Archives.Nx.Packing.PathedFileEntry![]! files, string! outputFolder) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.AddFilesWithDiskOutput(System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry> files, string! outputFolder) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.Extract() -> NexusMods.Archives.Nx.Interfaces.IOutputDataProvider![]!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.GetFileEntriesRaw() -> System.Span<NexusMods.Archives.Nx.Headers.Managed.FileEntry>
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.GetPathedFileEntries() -> NexusMods.Archives.Nx.Packing.PathedFileEntry![]!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.NxUnpackerBuilder(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> void
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.Outputs.get -> System.Collections.Generic.List<NexusMods.Archives.Nx.Interfaces.IOutputDataProvider!>!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.Settings.get -> NexusMods.Archives.Nx.Structs.UnpackerSettings!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.Unpacker.get -> NexusMods.Archives.Nx.Packing.NxUnpacker!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.WithMaxNumThreads(int maxNumThreads) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.NxUnpackerBuilder.WithProgress(System.IProgress<double>? progress) -> NexusMods.Archives.Nx.Packing.NxUnpackerBuilder!
+NexusMods.Archives.Nx.Packing.PackerPreset
+NexusMods.Archives.Nx.Packing.PackerPreset.Default = 0 -> NexusMods.Archives.Nx.Packing.PackerPreset
+NexusMods.Archives.Nx.Packing.PackerPreset.RandomAccess = 1 -> NexusMods.Archives.Nx.Packing.PackerPreset
+NexusMods.Archives.Nx.Packing.PathedFileEntry
+NexusMods.Archives.Nx.Packing.PathedFileEntry.Entry.get -> NexusMods.Archives.Nx.Headers.Managed.FileEntry
+NexusMods.Archives.Nx.Packing.PathedFileEntry.Entry.init -> void
+NexusMods.Archives.Nx.Packing.PathedFileEntry.FileName.get -> string!
+NexusMods.Archives.Nx.Packing.PathedFileEntry.FileName.init -> void
+NexusMods.Archives.Nx.Packing.PathedFileEntry.PathedFileEntry() -> void
+NexusMods.Archives.Nx.Structs.PackerFile
+NexusMods.Archives.Nx.Structs.PackerFile.CompressionPreference.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Structs.PackerFile.CompressionPreference.set -> void
+NexusMods.Archives.Nx.Structs.PackerFile.FileDataProvider.get -> NexusMods.Archives.Nx.Interfaces.IFileDataProvider!
+NexusMods.Archives.Nx.Structs.PackerFile.FileDataProvider.init -> void
+NexusMods.Archives.Nx.Structs.PackerFile.FileSize.get -> long
+NexusMods.Archives.Nx.Structs.PackerFile.FileSize.init -> void
+NexusMods.Archives.Nx.Structs.PackerFile.PackerFile() -> void
+NexusMods.Archives.Nx.Structs.PackerFile.RelativePath.get -> string!
+NexusMods.Archives.Nx.Structs.PackerFile.RelativePath.set -> void
+NexusMods.Archives.Nx.Structs.PackerFile.SolidType.get -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Structs.PackerFile.SolidType.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings
+NexusMods.Archives.Nx.Structs.PackerSettings.BlockSize.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.BlockSize.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkedCompressionLevel.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkedCompressionLevel.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkedFileAlgorithm.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkedFileAlgorithm.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkSize.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.ChunkSize.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.MaxNumThreads.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.MaxNumThreads.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.Output.get -> System.IO.Stream!
+NexusMods.Archives.Nx.Structs.PackerSettings.Output.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.PackerSettings() -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.Progress.get -> System.IProgress<double>?
+NexusMods.Archives.Nx.Structs.PackerSettings.Progress.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.Sanitize() -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.SolidBlockAlgorithm.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Structs.PackerSettings.SolidBlockAlgorithm.set -> void
+NexusMods.Archives.Nx.Structs.PackerSettings.SolidCompressionLevel.get -> int
+NexusMods.Archives.Nx.Structs.PackerSettings.SolidCompressionLevel.set -> void
+NexusMods.Archives.Nx.Structs.UnpackerSettings
+NexusMods.Archives.Nx.Structs.UnpackerSettings.MaxNumThreads.get -> int
+NexusMods.Archives.Nx.Structs.UnpackerSettings.MaxNumThreads.set -> void
+NexusMods.Archives.Nx.Structs.UnpackerSettings.Progress.get -> System.IProgress<double>?
+NexusMods.Archives.Nx.Structs.UnpackerSettings.Progress.set -> void
+NexusMods.Archives.Nx.Structs.UnpackerSettings.Sanitize() -> void
+NexusMods.Archives.Nx.Structs.UnpackerSettings.UnpackerSettings() -> void
+NexusMods.Archives.Nx.Traits.ICanConvertToLittleEndian
+NexusMods.Archives.Nx.Traits.ICanConvertToLittleEndian.ReverseEndianIfNeeded() -> void
+NexusMods.Archives.Nx.Traits.ICanProvideFileData
+NexusMods.Archives.Nx.Traits.ICanProvideFileData.FileDataProvider.get -> NexusMods.Archives.Nx.Interfaces.IFileDataProvider!
+NexusMods.Archives.Nx.Traits.IHasCompressionPreference
+NexusMods.Archives.Nx.Traits.IHasCompressionPreference.CompressionPreference.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Traits.IHasFileSize
+NexusMods.Archives.Nx.Traits.IHasFileSize.FileSize.get -> long
+NexusMods.Archives.Nx.Traits.IHasRelativePath
+NexusMods.Archives.Nx.Traits.IHasRelativePath.RelativePath.get -> string!
+NexusMods.Archives.Nx.Traits.IHasSolidType
+NexusMods.Archives.Nx.Traits.IHasSolidType.SolidType.get -> NexusMods.Archives.Nx.Enums.SolidPreference
+NexusMods.Archives.Nx.Utilities.ArrayRental
+NexusMods.Archives.Nx.Utilities.ArrayRental.Array.get -> byte[]!
+NexusMods.Archives.Nx.Utilities.ArrayRental.ArrayRental() -> void
+NexusMods.Archives.Nx.Utilities.ArrayRental.ArrayRental(int numBytes) -> void
+NexusMods.Archives.Nx.Utilities.ArrayRental.Dispose() -> void
+NexusMods.Archives.Nx.Utilities.ArrayRental.Span.get -> System.Span<byte>
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.ArrayRentalSlice() -> void
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.ArrayRentalSlice(NexusMods.Archives.Nx.Utilities.ArrayRental rental, int length) -> void
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.Dispose() -> void
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.Length.get -> int
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.Rental.get -> NexusMods.Archives.Nx.Utilities.ArrayRental
+NexusMods.Archives.Nx.Utilities.ArrayRentalSlice.Span.get -> System.Span<byte>
+NexusMods.Archives.Nx.Utilities.FileFinder
+NexusMods.Archives.Nx.Utilities.InsufficientStringPoolSizeException
+NexusMods.Archives.Nx.Utilities.InsufficientStringPoolSizeException.InsufficientStringPoolSizeException(string? message) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianReader
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.LittleEndianReader() -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.LittleEndianReader(byte* ptr) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.Ptr -> byte*
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadInt() -> int
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadIntAtOffset(int offset) -> int
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadLongAtOffset(int offset) -> long
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadShort() -> short
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadShortAtOffset(int offset) -> short
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadUInt() -> uint
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadUIntAtOffset(int offset) -> uint
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadUlongAtOffset(int offset) -> ulong
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.ReadUShort() -> ushort
+NexusMods.Archives.Nx.Utilities.LittleEndianReader.Seek(int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.LittleEndianWriter() -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.LittleEndianWriter(byte* ptr) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Ptr -> byte*
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Seek(int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(int value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(long value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(short value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(System.Span<byte> data) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(uint value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(ulong value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.Write(ushort value) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.WriteAtOffset(int value, int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.WriteAtOffset(long value, int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.WriteAtOffset(short value, int offset) -> void
+NexusMods.Archives.Nx.Utilities.LittleEndianWriter.WriteAtOffset(ulong value, int offset) -> void
+NexusMods.Archives.Nx.Utilities.NotANexusArchiveException
+NexusMods.Archives.Nx.Utilities.NotANexusArchiveException.NotANexusArchiveException() -> void
+NexusMods.Archives.Nx.Utilities.OutOfPackerPoolArraysException
+NexusMods.Archives.Nx.Utilities.OutOfPackerPoolArraysException.OutOfPackerPoolArraysException(string? message) -> void
+NexusMods.Archives.Nx.Utilities.TocVersionNotSupportedException
+NexusMods.Archives.Nx.Utilities.TocVersionNotSupportedException.TocVersionNotSupportedException(NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> void
+NexusMods.Archives.Nx.Utilities.TocVersionNotSupportedException.Version.get -> NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion
+NexusMods.Archives.Nx.Utilities.UnsupportedCompressionMethodException
+NexusMods.Archives.Nx.Utilities.UnsupportedCompressionMethodException.Method.get -> NexusMods.Archives.Nx.Enums.CompressionPreference
+NexusMods.Archives.Nx.Utilities.UnsupportedCompressionMethodException.UnsupportedCompressionMethodException(NexusMods.Archives.Nx.Enums.CompressionPreference method) -> void
+override NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Equals(object? obj) -> bool
+override NexusMods.Archives.Nx.Headers.Managed.TableOfContents.GetHashCode() -> int
+override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.Equals(object? obj) -> bool
+override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.GetHashCode() -> int
+override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.Equals(object? obj) -> bool
+override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.GetHashCode() -> int
+override NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.Equals(object? obj) -> bool
+override NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.GetHashCode() -> int
+static NexusMods.Archives.Nx.Headers.HeaderParser.ParseHeader(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> NexusMods.Archives.Nx.Headers.Managed.ParsedHeader!
+static NexusMods.Archives.Nx.Headers.HeaderParser.TryParseHeader(byte* data, int dataSize) -> NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult
+static NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Deserialize<T>(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> T!
+static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.operator !=(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0.operator ==(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV0 right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.operator !=(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.operator ==(NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 left, NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1 right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.NativeFileHeader.Init(NexusMods.Archives.Nx.Headers.Native.NativeFileHeader* header, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version, int blockSizeBytes, int chunkSizeBytes, int headerPageCountBytes) -> void
+static NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.operator !=(NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple left, NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple right) -> bool
+static NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.operator ==(NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple left, NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple right) -> bool
+static NexusMods.Archives.Nx.Headers.StringPool.Pack<T>(System.Span<T> items) -> NexusMods.Archives.Nx.Utilities.ArrayRentalSlice
+static NexusMods.Archives.Nx.Headers.StringPool.Unpack(byte* poolPtr, int compressedDataSize) -> string![]!
+static NexusMods.Archives.Nx.Headers.StringPool.Unpack(byte* poolPtr, int compressedDataSize, int fileCountHint) -> string![]!
+static NexusMods.Archives.Nx.Headers.StringPool.Unpack(System.Span<byte> poolSpan) -> string![]!
+static NexusMods.Archives.Nx.Headers.StringPool.Unpack(System.Span<byte> poolSpan, int fileCountHint) -> string![]!
+static NexusMods.Archives.Nx.Packing.NxPacker.Pack(NexusMods.Archives.Nx.Structs.PackerFile![]! files, NexusMods.Archives.Nx.Structs.PackerSettings! settings) -> void
+static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.EnumerationOptions! options) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
+static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.SearchOption searchOption = System.IO.SearchOption.AllDirectories) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!

--- a/NexusMods.Archives.Nx/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/NexusMods.Archives.Nx/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -378,5 +378,6 @@ static NexusMods.Archives.Nx.Headers.StringPool.Unpack(byte* poolPtr, int compre
 static NexusMods.Archives.Nx.Headers.StringPool.Unpack(System.Span<byte> poolSpan) -> string![]!
 static NexusMods.Archives.Nx.Headers.StringPool.Unpack(System.Span<byte> poolSpan, int fileCountHint) -> string![]!
 static NexusMods.Archives.Nx.Packing.NxPacker.Pack(NexusMods.Archives.Nx.Structs.PackerFile![]! files, NexusMods.Archives.Nx.Structs.PackerSettings! settings) -> void
+static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
 static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.EnumerationOptions! options) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
-static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.SearchOption searchOption = System.IO.SearchOption.AllDirectories) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!
+static NexusMods.Archives.Nx.Utilities.FileFinder.GetFiles(string! directoryPath, System.IO.SearchOption searchOption) -> System.Collections.Generic.List<NexusMods.Archives.Nx.Structs.PackerFile!>!

--- a/NexusMods.Archives.Nx/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/NexusMods.Archives.Nx/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
-﻿const NexusMods.Archives.Nx.Headers.StringPool.MaxCompressedSize = 33550336 -> int
+﻿const NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.Length = 4 -> int
+const NexusMods.Archives.Nx.Headers.StringPool.MaxCompressedSize = 33550336 -> int
 NexusMods.Archives.Nx.Enums.CompressionPreference
 NexusMods.Archives.Nx.Enums.CompressionPreference.Copy = 0 -> NexusMods.Archives.Nx.Enums.CompressionPreference
 NexusMods.Archives.Nx.Enums.CompressionPreference.Lz4 = 2 -> NexusMods.Archives.Nx.Enums.CompressionPreference
@@ -362,6 +363,15 @@ override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.Equals(object? o
 override NexusMods.Archives.Nx.Headers.Native.NativeFileEntryV1.GetHashCode() -> int
 override NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.Equals(object? obj) -> bool
 override NexusMods.Archives.Nx.Headers.Native.Structs.OffsetPathIndexTuple.GetHashCode() -> int
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.GetNames() -> string![]!
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.GetValues() -> NexusMods.Archives.Nx.Enums.CompressionPreference[]!
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.IsDefined(NexusMods.Archives.Nx.Enums.CompressionPreference value) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.IsDefined(string! name) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.IsDefined(string! name, bool allowMatchingMetadataAttribute) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.ToStringFast(this NexusMods.Archives.Nx.Enums.CompressionPreference value) -> string!
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(string? name, out NexusMods.Archives.Nx.Enums.CompressionPreference value) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(string? name, out NexusMods.Archives.Nx.Enums.CompressionPreference value, bool ignoreCase) -> bool
+static NexusMods.Archives.Nx.Enums.CompressionPreferenceExtensions.TryParse(string? name, out NexusMods.Archives.Nx.Enums.CompressionPreference value, bool ignoreCase, bool allowMatchingMetadataAttribute) -> bool
 static NexusMods.Archives.Nx.Headers.HeaderParser.ParseHeader(NexusMods.Archives.Nx.Interfaces.IFileDataProvider! provider, bool hasLotsOfFiles = false) -> NexusMods.Archives.Nx.Headers.Managed.ParsedHeader!
 static NexusMods.Archives.Nx.Headers.HeaderParser.TryParseHeader(byte* data, int dataSize) -> NexusMods.Archives.Nx.Headers.HeaderParser.HeaderParserResult
 static NexusMods.Archives.Nx.Headers.Managed.TableOfContents.Deserialize<T>(byte* dataPtr, int tocSize, NexusMods.Archives.Nx.Headers.Enums.ArchiveVersion version) -> T!

--- a/NexusMods.Archives.Nx/Utilities/FileFinder.cs
+++ b/NexusMods.Archives.Nx/Utilities/FileFinder.cs
@@ -17,12 +17,17 @@ public static class FileFinder
     ///     Retrieves all packable files from within a given directory.
     /// </summary>
     /// <param name="directoryPath">The relative or absolute path to the directory to search.</param>
+    public static List<PackerFile> GetFiles(string directoryPath) => GetFiles(directoryPath, SearchOption.AllDirectories);
+
+    /// <summary>
+    ///     Retrieves all packable files from within a given directory.
+    /// </summary>
+    /// <param name="directoryPath">The relative or absolute path to the directory to search.</param>
     /// <param name="searchOption">
     ///     One of the enumeration values that specifies whether the search operation
     ///     should include all subdirectories or only the current directory.
     /// </param>
-    public static List<PackerFile> GetFiles(string directoryPath, SearchOption searchOption =
-        SearchOption.AllDirectories)
+    public static List<PackerFile> GetFiles(string directoryPath, SearchOption searchOption)
     {
 #if NETSTANDARD2_0
         return GetFilesOld(directoryPath, SearchOption.AllDirectories);

--- a/docs/Specification/Table-Of-Contents.md
+++ b/docs/Specification/Table-Of-Contents.md
@@ -1,4 +1,4 @@
-﻿# Table of Contents (TOC)
+# Table of Contents (TOC)
 
 - `u32`: FileCount [[limited to 1 million due to FilePathIndex](./File-Header.md#versionvariant)]
 - `u18`: BlockCount
@@ -63,17 +63,25 @@ Size: `3 bits` (0-7)
 
     Stores the amount of padding that was applied to the table during serialization.  
 
-This is needed to calculate the end position of the [String Pool](#string-pool) without using more space in ToC.  
+This is needed to calculate the end position of the [String Pool](#string-pool) without using more space in ToC.
 
-This value is encoded as: 
+This value is encoded as:
+
 ```csharp
 // FileHeader is just the 8 byte header.
-var paddingOffset = (tocSize + sizeof(FileHeader)).RoundUp4096() - tocSize;
+// tocOffset is offset of the ToC from the start of the file.
+tocOffset %= 4096;
+var paddingOffset = (tocSize + sizeof(FileHeader)).RoundUp4096() - tocSize - tocOffset;
 ```
 
 And decoded as:
 
 ```csharp
+tocOffset %= 4096;
+
+// blockCountAndPoolSize is packed value in header
+var paddingOffset = ((blockCountAndPoolSize >> 2) & 0xFFF) + (tocOffset);
+
 tocSize = (tocSize + sizeof(FileHeader)).RoundUp4096();
 var paddingSize = tocSize - paddingOffset;
 ```


### PR DESCRIPTION
# This PR Contains the Following Changes

- Changes how [Table Padding](https://nexus-mods.github.io/NexusMods.Archives.Nx/Specification/Table-Of-Contents/#table-padding) is encoded and decoded to fix a bug.

- Added `Public API` annotations, as our API is stable.

- Fixed: Script to update Undeclared APIs on Linux.

- Fixed: A code backwards compatibility warning related to multiple overloads.

# Testing

This version was brute forced to ensure stability. Aside from file content (which was deterministically generated and then checked upon extraction); everything from file count to size to names were competely random between different runs.

![20230713_21h47m20s_grim](https://github.com/Nexus-Mods/NexusMods.Archives.Nx/assets/6697380/fd3916e3-11de-4b24-8d2e-d8593bf2512c)

You can find that code in 8e109af72ef3807a8222ed3ce98f865f369f7286 on another branch.

# Breaking Change

Fixing the bug in .nx header required making a change to the spec; due to an oversight.
Existing archives are therefore rendered incompatible.