### PR TITLE
[2 line PR] Fixed: Out of bounds when Decompressing copy blocks

### DIFF
--- a/NexusMods.Archives.Nx/Utilities/Compression.cs
+++ b/NexusMods.Archives.Nx/Utilities/Compression.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using K4os.Compression.LZ4;
@@ -114,7 +115,8 @@ internal static class Compression
         switch (method)
         {
             case CompressionPreference.Copy:
-                Buffer.MemoryCopy(source, destination, (uint)sourceLength, (uint)sourceLength);
+                Debug.Assert(sourceLength >= destinationLength);
+                Buffer.MemoryCopy(source, destination, (uint)destinationLength, (uint)destinationLength);
                 return;
             case CompressionPreference.ZStandard:
             {


### PR DESCRIPTION
This PR fixes an absolutely, otherworldly catastrophic error which shattered boundaries and brought about the fall of civilizations... or at least, that's how it felt when my program crashed. So here I am, your humble software engineer, with a cape fluttering in the digital wind, saving the day once again.

It seems that my mighty software, not content with mere earthly constraints, decided to take a detour to the land of 'out of bounds'. Yes, my algorithm had aspired to transcend the usual limits and explore the digital wilderness. But like Icarus flying too close to the sun, it quickly learnt that venturing too far can have 'crashingly' serious consequences.

What you'll find in this PR is the simple but effective fix I've implemented: a leash on our audacious decompressing copy blocks. They've been gently but firmly pulled back into their designated playground, ensuring my code runs smoothly and your experience remains frustration-free.

So go ahead, give it a whirl. Your software should now be as crash-proof as a rubber bumper car, gliding smoothly through its tasks without any unexpected visits to the 'Out of Bounds' dimension.

I seriously can't believe that out of all places , with all that manual packing, multithreading, unrolling etc.; I introduced a bug here, out of all places. :sweat_smile: 