### PR TITLE
Fixed: Packing and Unpacking of Empty Archives

### DIFF
--- a/NexusMods.Archives.Nx.Tests/Tests/Packing/PackingTests.cs
+++ b/NexusMods.Archives.Nx.Tests/Tests/Packing/PackingTests.cs
@@ -40,7 +40,9 @@ public class PackingTests
 
         // Test succeeds if it doesn't throw.
         var unpacker = new NxUnpacker(streamProvider);
-        var extracted = unpacker.ExtractFilesInMemory(unpacker.GetFileEntriesRaw(), new UnpackerSettings() { MaxNumThreads = Environment.ProcessorCount }); // 1 = easier to debug.
+        var extracted =
+            unpacker.ExtractFilesInMemory(unpacker.GetFileEntriesRaw(),
+                new UnpackerSettings() { MaxNumThreads = Environment.ProcessorCount }); // 1 = easier to debug.
 
         // Verify data.
         AssertExtracted(extracted);
@@ -59,7 +61,9 @@ public class PackingTests
 
         // Test succeeds if it doesn't throw.
         var unpacker = new NxUnpacker(streamProvider);
-        var extracted = unpacker.ExtractFilesInMemory(unpacker.GetFileEntriesRaw(), new UnpackerSettings() { MaxNumThreads = Environment.ProcessorCount }); // 1 = easier to debug.
+        var extracted =
+            unpacker.ExtractFilesInMemory(unpacker.GetFileEntriesRaw(),
+                new UnpackerSettings() { MaxNumThreads = Environment.ProcessorCount }); // 1 = easier to debug.
 
         // Verify data.
         AssertExtracted(extracted);
@@ -77,7 +81,9 @@ public class PackingTests
 
         // Test succeeds if it doesn't throw.
         var unpacker = new NxUnpacker(streamProvider);
-        var extracted = unpacker.ExtractFilesInMemory(unpacker.GetFileEntriesRaw(), new UnpackerSettings() { MaxNumThreads = Environment.ProcessorCount }); // 1 = easier to debug.
+        var extracted =
+            unpacker.ExtractFilesInMemory(unpacker.GetFileEntriesRaw(),
+                new UnpackerSettings() { MaxNumThreads = Environment.ProcessorCount }); // 1 = easier to debug.
 
         // Verify data.
         AssertExtracted(extracted);
@@ -95,7 +101,29 @@ public class PackingTests
 
         // Test succeeds if it doesn't throw.
         var unpacker = new NxUnpacker(streamProvider);
-        var extracted = unpacker.ExtractFilesInMemory(unpacker.GetFileEntriesRaw(), new UnpackerSettings() { MaxNumThreads = Environment.ProcessorCount }); // 1 = easier to debug.
+        var extracted =
+            unpacker.ExtractFilesInMemory(unpacker.GetFileEntriesRaw(),
+                new UnpackerSettings() { MaxNumThreads = Environment.ProcessorCount }); // 1 = easier to debug.
+
+        // Verify data.
+        AssertExtracted(extracted);
+    }
+
+    [Theory]
+    [AutoData]
+    public void Can_Pack_And_Unpack_EmptyArchive(IFixture fixture)
+    {
+        // Act
+        var files = GetRandomDummyFiles(fixture, 0, 0, 0, out var settings);
+        NxPacker.Pack(files, settings);
+        settings.Output.Position = 0;
+        var streamProvider = new FromStreamProvider(settings.Output);
+
+        // Test succeeds if it doesn't throw.
+        var unpacker = new NxUnpacker(streamProvider);
+        var extracted =
+            unpacker.ExtractFilesInMemory(unpacker.GetFileEntriesRaw(),
+                new UnpackerSettings() { MaxNumThreads = Environment.ProcessorCount }); // 1 = easier to debug.
 
         // Verify data.
         AssertExtracted(extracted);
@@ -114,7 +142,8 @@ public class PackingTests
         // Test succeeds if it doesn't throw.
         using var temporaryFilePath = new TemporaryDirectory();
         var unpacker = new NxUnpacker(streamProvider);
-        var extracted = unpacker.ExtractFilesToDisk(unpacker.GetFileEntriesRaw(), temporaryFilePath.FolderPath, new UnpackerSettings() { MaxNumThreads = Environment.ProcessorCount }); // 1 = easier to debug.
+        var extracted = unpacker.ExtractFilesToDisk(unpacker.GetFileEntriesRaw(), temporaryFilePath.FolderPath,
+            new UnpackerSettings() { MaxNumThreads = Environment.ProcessorCount }); // 1 = easier to debug.
 
         // Verify data.
         foreach (var item in extracted)
@@ -172,6 +201,7 @@ public class PackingTests
 
         return result;
     }
+
     private static void AssertExtracted(OutputArrayProvider[] extracted)
     {
         for (var index = 0; index < extracted.Length; index++)

--- a/NexusMods.Archives.Nx/Headers/Managed/ParsedHeader.cs
+++ b/NexusMods.Archives.Nx/Headers/Managed/ParsedHeader.cs
@@ -27,6 +27,8 @@ public class ParsedHeader : TableOfContents
         long currentOffset = Header.HeaderPageBytes;
         var numBlocks = Blocks.Length;
         BlockOffsets = Polyfills.AllocateUninitializedArray<long>(numBlocks);
+        if (numBlocks <= 0)
+            return;
 
         ref var blockOffsetsRef = ref BlockOffsets[0];
         blockOffsetsRef = Header.HeaderPageBytes; // pre-init first one.

--- a/NexusMods.Archives.Nx/Headers/StringPool.cs
+++ b/NexusMods.Archives.Nx/Headers/StringPool.cs
@@ -120,7 +120,7 @@ public struct StringPool
         // Okay time to deconstruct the pool.
         using var decompressed = Compression.DecompressZStd(poolPtr, compressedDataSize);
         var decompressedSpan = decompressed.Span;
-        var offsets = decompressedSpan.FindAllOffsetsOfByte(0, fileCountHint);
+        var offsets = decompressedSpan.Length > 0 ? decompressedSpan.FindAllOffsetsOfByte(0, fileCountHint) : new List<int>();
         var items = Polyfills.AllocateUninitializedArray<string>(offsets.Count);
 
         var currentOffset = 0;


### PR DESCRIPTION
No further explanation needed. 
Just added some error handling for when 0 files were packed; should no longer throw errors back to the user.