### PR TITLE
Miscellaneous Docs Fixes

### DIFF
--- a/docs/Library/FileProviders/Interfaces.md
+++ b/docs/Library/FileProviders/Interfaces.md
@@ -1,12 +1,11 @@
 ﻿# Interfaces
 
-These interfaces define the structure for providing access to underlying file data and creating instances of file data, 
+These interfaces define the structure for providing access to underlying file data and creating instances of file data,
 particularly useful for unpacking purposes.
 
 ## IFileData Interface
 
-!!! info "The `IFileData` interface provides access to underlying file data. This is particularly useful for read 
-operations where the entire file is not yet available, such as over a network; you should stall until you can provide enough data."
+!!! info "The `IFileData` interface provides access to underlying file data. This is particularly useful for read operations where the entire file is not yet available, such as over a network; you should stall until you can provide enough data."
 
 ### Properties
 

--- a/docs/Specification/Table-Of-Contents.md
+++ b/docs/Specification/Table-Of-Contents.md
@@ -90,6 +90,8 @@ This way the decoding logic can work when given either a padded or unpadded size
 
 ## String Pool
 
+!!! note "Nx archives should only use '/' as the path delimiter."
+
 Raw buffer of UTF-8 deduplicated strings of file paths. Each string is null terminated.
 The strings in this pool are first lexicographically sorted (to group similar paths together); and then compressed using ZStd.
 As for decompression, size of this pool is unknown until after decompression is done; file header should specify sufficient buffer size.


### PR DESCRIPTION
Minor changes to docs:

- Docs now mention that '/' is the only supported path delimiter.
- Fixed broken formatting of an info box.