### PR TITLE
Let's Fix Hashing Again (Damn)

### DIFF
--- a/NexusMods.Archives.Nx.Tests/Assets/SMIM SE 2-08-659-2-08-Hashes.txt
+++ b/NexusMods.Archives.Nx.Tests/Assets/SMIM SE 2-08-659-2-08-Hashes.txt
@@ -1,2223 +1,2223 @@
---- Screenshots ---/3D Chains Misc.jpg,823FAA976FFFA5A7
---- Screenshots ---/3D Chains Pull Levers.jpg,531C1D59BDBB5BC
---- Screenshots ---/3D Chains Signs.jpg,1B8BAEE8FE4793D2
---- Screenshots ---/3D Chains Whiterun.jpg,BE5A218AEE811065
---- Screenshots ---/3DDungeonRopes.jpg,C87C16E91E7928D1
---- Screenshots ---/barrels.jpg,D4374F386D555C2B
---- Screenshots ---/Barrels_NewTextures.jpg,DA5CF5A08BB97BEE
---- Screenshots ---/Barrels_NewTexturesAnimate.jpg,3016E45DC86F94F9
---- Screenshots ---/Barrels_Rustic.jpg,9A0F9D7497693511
---- Screenshots ---/Barrels_VanillaTextures.jpg,7264B7AFF1B8F20B
---- Screenshots ---/Barrels_VanillaTexturesAnimate.jpg,BD68CFFB065EE737
---- Screenshots ---/Blurry.jpg,626D3A4D61716945
---- Screenshots ---/Bonemeal.jpg,F299A646E185D524
---- Screenshots ---/BridgeSMIMComp.jpg,66E0F1621105883A
---- Screenshots ---/BridgesRealRoads.jpg,111846E6CAE49ED2
---- Screenshots ---/Bridges_Stonework_Comp.jpg,36AFCE964AAB2CBF
---- Screenshots ---/Candelabras.jpg,8B8668A7444770E3
---- Screenshots ---/CarriageSeat.jpg,954193044FD8A81D
---- Screenshots ---/Chandeliers.jpg,223A449F0318F0C7
---- Screenshots ---/Clothing _Fix.jpg,C27A1759505A2DF7
---- Screenshots ---/Custom.jpg,A7EA6C53E1DE0A16
---- Screenshots ---/CustomOS.jpg,7901FA5DEDF318CC
---- Screenshots ---/CustomSE.jpg,51CABA4F4056E89C
---- Screenshots ---/DraugrCorpses-Comp.jpg,A635C81F598CCE19
---- Screenshots ---/Dwemer Clutter Comp.jpg,D3E91981B8A917D7
---- Screenshots ---/DwemerAnimatedLifts.jpg,251C3088243A19FF
---- Screenshots ---/Empty.jpg,C6BE01A0A6B86518
---- Screenshots ---/Everything.jpg,7AA6E3BA7ED50F16
---- Screenshots ---/EverythingNoDragonborn.jpg,6B7CF3B1B6ADAC83
---- Screenshots ---/EverythingSE.jpg,D3CA67F825E473E2
---- Screenshots ---/EverythingWithDragonborn.jpg,5155795A895AFAA6
---- Screenshots ---/farmhouse.jpg,EBC6C9DB787A1973
---- Screenshots ---/FarmhouseWoodPost_Comp.jpg,8381705CCB259556
---- Screenshots ---/FarmhouseWovenFenceComp.jpg,54E19CD051680A03
---- Screenshots ---/FarmhouseWovenFenceGray.jpg,D06C59A36559CC49
---- Screenshots ---/FarmhouseWovenFenceLessFlicker.jpg,68B424A9B4639DD2
---- Screenshots ---/Farmhouse_3D_Ropes.jpg,CF1B48B89E85DF3E
---- Screenshots ---/food.jpg,7531B0682FBE8323
---- Screenshots ---/Food_SMIM.jpg,A79A093DC9D44B5F
---- Screenshots ---/Furniture_Chest_SMIM.jpg,5C576A34346B2FAD
---- Screenshots ---/Furniture_SMIM.jpg,E46B147AC95E080C
---- Screenshots ---/Hanging_Rings.jpg,727B072963DB4F24
---- Screenshots ---/Hawk.jpg,63827444AD072A6A
---- Screenshots ---/Hearthfire-Lock.jpg,B644B8E53DAF3AC9
---- Screenshots ---/Imperial_Jail.jpg,1FC5402428C3FE39
---- Screenshots ---/Imperial_Jail_Brighter.jpg,8F2B541C04B2B7F3
---- Screenshots ---/JuniperComp.jpg,CE59A31BB20771DE
---- Screenshots ---/Lantern-Comp.jpg,FDA0635626B18ECF
---- Screenshots ---/LiteNoDragonborn.jpg,A396B455A3EC56D1
---- Screenshots ---/LiteSE.jpg,7B0635358F71F8B4
---- Screenshots ---/LiteWithDragonborn.jpg,CEEF3B087AF7CF8E
---- Screenshots ---/MergedPlugin.jpg,9DCC9007175E0AE1
---- Screenshots ---/MinesRopesAndScaffolding.jpg,F96DA23B75D18EFD
---- Screenshots ---/NobleChairComp.jpg,F9C79C7263ADC1CF
---- Screenshots ---/Nordic_Marble_Comp.jpg,2ADD9A45A16795F4
---- Screenshots ---/OrcBeams.jpg,B74CBC114EC1A13
---- Screenshots ---/PoorCoffin.jpg,860039E4AC93F36F
---- Screenshots ---/PullLever_Full.jpg,2BC93913AA1045AC
---- Screenshots ---/PullLever_Full_Smaller_Chain.jpg,D29C109CEFC4B274
---- Screenshots ---/PullLever_Lite.jpg,1BCE8AFC618042D3
---- Screenshots ---/RabbitComp.jpg,15BBFE69862EE082
---- Screenshots ---/Raven_Rock_Ropes.jpg,91C23454B4DA80AE
---- Screenshots ---/RiftenRopes.jpg,13B2034932FFFBBF
---- Screenshots ---/RiftenRopesTextureComp.jpg,627EF15AF2AB7007
---- Screenshots ---/Rings.jpg,ED7E27E4AEC455D6
---- Screenshots ---/Rocks_Blackreach_Comp.jpg,DB4E94E262C4F445
---- Screenshots ---/Rocks_Render_Comp.jpg,146810D78C65894C
---- Screenshots ---/Sarcophagus.jpg,F6262D5DBF77F880
---- Screenshots ---/ShackRoof.jpg,451E4E69A7B765DE
---- Screenshots ---/Signs_SMIM.jpg,234E2F0088B88477
---- Screenshots ---/Skeleton-Comp.jpg,959861D4C6D42166
---- Screenshots ---/SkullFixComp.jpg,CDEAE9A314F5C807
---- Screenshots ---/Smelter-Full.jpg,6C52D3B212F96938
---- Screenshots ---/SMIM_CoverImage_Bnet-XBoxLite.jpg,4E8D954123286829
---- Screenshots ---/SnowSkirtFix.jpg,82AB313CE50C361D
---- Screenshots ---/SolitudeDocksRopes.jpg,1D1FC99CC59CEDE4
---- Screenshots ---/SolitudeGate.jpg,E1BFEA712176B8CC
---- Screenshots ---/Soulcairn_Comparison.jpg,8D17B4A96C110530
---- Screenshots ---/StockadePosts-Comp.jpg,42CD3D20C4AF5359
---- Screenshots ---/Table_SkyrimHD.jpg,9662948B53AE2285
---- Screenshots ---/Table_SkyrimHD_Weathered.jpg,58FD0810C42797E4
---- Screenshots ---/Table_SMIM_Default.jpg,13C7AE67A7168AFA
---- Screenshots ---/Tankard_Comp-4Way.jpg,F2CD3DDF3471A82
---- Screenshots ---/Tomato_Comparison.jpg,77B8D364E6EB3452
---- Screenshots ---/TundraTree.jpg,285C4AD97A9F8942
---- Screenshots ---/Whiterun_Wood_Carvings_Options.jpg,F35AD445E7377DD1
---- Screenshots ---/Windmills.jpg,95B0D9379ED41882
---- Screenshots ---/Windmill_Sails.jpg,BCE93A7590980369
---- Screenshots ---/WRDrawbridge_SMIM.jpg,F29FB6516D82689C
---- Screenshots ---/WR_Door_Comp.jpg,7A045C5AD1F2D78A
-00 Core/SMIM Readme.txt,8F34C1376BE4B69A
-00 Core/SMIM-FarmhouseFlickeringFix.esp,FFAF8DC7555D3FF3
-00 Core/SMIM-SE-FarmhouseFlickeringFix.esp,17B246D2153A68D4
-22 Solitude Docks Ropes SE/SMIM-SE-SolitudeDocksFixes.esp,4E8951763BCBB278
-28 Hawk Dragonborn Fix/SMIM-DragonbornTernFix.esp,5E5F5511A30A0B0C
-28 Hawk Dragonborn Fix/SMIM-SE-DragonbornTernFix.esp,51776BE736BB79BB
-35 Shack Kit/SMIM-SE-ShackRoofFixes.esp,84B9F970AB6F9A0
-35 Shack Kit/SMIM-ShackRoofFixes.esp,7FFA8B4B92EA1140
-36 Shack Kit Dragonborn/SMIM-SE-ShackRoofFixesDragonborn.esp,553D6132E9969F66
-36 Shack Kit Dragonborn/SMIM-ShackRoofFixesDragonborn.esp,814A12DD2D03B85E
-37 Riften 3D Ropes/SMIM-RiftenDocksRopesObjectFix.esp,9142C5043D3614FD
-37 Riften 3D Ropes/SMIM-SE-RiftenDocksRopesObjectFix.esp,68328AAC96350268
-40 Furniture Chests/SMIM-FurnitureChestSnowFix.esp,1596B36722855DF8
-40 Furniture Chests/SMIM-SE-FurnitureChestSnowFix.esp,171C2A9F0DF9C73E
-75 Dungeons Cliffs Snow Skirts/SMIM-DungeonsCliffsIceSkirts.esp,EC1BAAF462C2C80D
-75 Dungeons Cliffs Snow Skirts/SMIM-SE-DungeonsCliffsIceSkirts.esp,186AAF0A2BF39FB3
-95 Merged ESP SE All/SMIM-SE-Merged-All.esp,3991AEAFFA7987E2
-95 Merged ESP SE No Riften Ropes/SMIM-SE-Merged-NoRiftenRopes.esp,925A8C4DD0E451
-95 Merged ESP SE No Riften Ropes No Solitude Ropes/SMIM-SE-Merged-NoRiftenRopes-NoSolitudeRopes.esp,8B19D68D40F43C91
-95 Merged ESP SE No Solitude Ropes/SMIM-SE-Merged-NoSolitudeRopes.esp,CE39C71017244812
-FOMod/info.xml,35B62C81083EA6CE
-FOMod/ModuleConfig.xml,300275E81142A952
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_czech.DLSTRINGS,34C96ACDCADB1BBB
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_czech.ILSTRINGS,34C96ACDCADB1BBB
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_czech.STRINGS,2DC916B78DFD7EA4
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_English.DLSTRINGS,34C96ACDCADB1BBB
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_English.ILSTRINGS,34C96ACDCADB1BBB
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_English.STRINGS,1BDF42EC14490D28
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_french.DLSTRINGS,34C96ACDCADB1BBB
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_french.ILSTRINGS,34C96ACDCADB1BBB
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_french.STRINGS,1BDF42EC14490D28
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_german.DLSTRINGS,34C96ACDCADB1BBB
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_german.ILSTRINGS,34C96ACDCADB1BBB
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_german.STRINGS,583841AA43B62B88
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_italian.DLSTRINGS,34C96ACDCADB1BBB
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_italian.ILSTRINGS,34C96ACDCADB1BBB
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_italian.STRINGS,EC34F3C418EEB264
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_japanese.DLSTRINGS,34C96ACDCADB1BBB
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_japanese.ILSTRINGS,34C96ACDCADB1BBB
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_japanese.STRINGS,732774C1CD7E8112
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_polish.DLSTRINGS,34C96ACDCADB1BBB
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_polish.ILSTRINGS,34C96ACDCADB1BBB
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_polish.STRINGS,98132B34E81F6B80
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_russian.DLSTRINGS,34C96ACDCADB1BBB
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_russian.ILSTRINGS,34C96ACDCADB1BBB
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_russian.STRINGS,B38785282671EB92
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_spanish.DLSTRINGS,34C96ACDCADB1BBB
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_spanish.ILSTRINGS,34C96ACDCADB1BBB
-28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_spanish.STRINGS,20D9BB920FF1F8EB
-00 Core/meshes/animobjects/animobjectquill.nif,BE4440B2E235F5E5
-00 Core/meshes/clutter/brewerycasklargeclosed01.nif,FA891AD876AC93DA
-00 Core/meshes/clutter/brewerycasklargeclosed02.nif,E35809A16719F80
-00 Core/meshes/clutter/brewerycasklargeopen01.nif,DA93A6E8A3575120
-00 Core/meshes/clutter/cookingstone01.nif,8B4A66F0CAD81AD1
-00 Core/meshes/clutter/wallbasket02.nif,AB36ED26512A7747
-00 Core/meshes/clutter/wallbaskethex02.nif,DCA488156B9D3DC0
-00 Core/meshes/clutter/wallbaskethex03.nif,D5EBFD6B738FA619
-00 Core/meshes/clutter/wallbasketlarge01.nif,CEC8FA81C85C43BB
-00 Core/meshes/clutter/wallbasketlarge02.nif,1A001FE35AECAEB1
-00 Core/meshes/effects/fxcreekflatlong01.nif,2A8754ADD3C65796
-00 Core/meshes/furniture/blacksmithforgemarker.nif,D7905383221F7ABE
-00 Core/meshes/furniture/blacksmithforgemarkerwr.nif,4799F21A2E729A48
-00 Core/meshes/furniture/smeltermarker.nif,FB056A0A0541DA0F
-00 Core/meshes/loadscreenart/loadscreenadventure01.nif,84D478BBE1459BF8
-00 Core/meshes/loadscreenart/loadscreendragonpriest.nif,5120DAE821E1A056
-00 Core/meshes/loadscreenart/loadscreenhagraven01.nif,80B82F720CD87855
-00 Core/meshes/loadscreenart/loadscreenhagraven02.nif,9BADD8140536F3D2
-00 Core/meshes/loadscreenart/loadscreenmoney01.nif,4FF967B8A18BE713
-00 Core/meshes/loadscreenart/loadscreenpotions01.nif,94E5C6EF0D391AE6
-00 Core/meshes/loadscreenart/loadscreenreagent01.nif,5A12076D82DB8A72
-00 Core/meshes/loadscreenart/loadscreenshopsmagic01.nif,FAF4A2A1C6E4E13E
-00 Core/meshes/loadscreenart/loadscreenwrtempletree02.nif,1C796723B2D5AE5
-00 Core/meshes/plants/coinbaglarge.nif,35D91F8D507CE64F
-00 Core/meshes/plants/coinbagmed.nif,8802E164D563C503
-00 Core/meshes/plants/coinbagsmall.nif,E3598BF524424E8E
-00 Core/textures/dungeons/candles01.dds,AD5E42F32C9805AD
-00 Core/textures/dungeons/candles01_g.dds,4F7B7AA1F717EED4
-00 Core/textures/dungeons/candles01_n.dds,7F772E51A499DEE4
-01 Furniture/meshes/clutter/table01.nif,EF3A3F1B6757480A
-01 Furniture/meshes/furniture/commontableonebench.nif,589986D5B798AEB0
-01 Furniture/meshes/furniture/commontabletwobenches.nif,87774F6F4B8F994F
-01 Furniture/meshes/furniture/woodenchair01.nif,59FC51023FDEAF30
-01 Furniture/meshes/furniture/woodenchair01static.nif,FF960C7E8233F62D
-01 Furniture/textures/clutter/furniturewood01.dds,149BC3EE8F72ACE6
-01 Furniture/textures/clutter/furniturewood01_n.dds,94905A18D662740
-02 SMIM Barrel Textures Animations/meshes/clutter/barrel01.nif,E2A652958AADDC4
-02 SMIM Barrel Textures Animations/meshes/clutter/barrel02.nif,FEF06BEFFEDE5461
-02 SMIM Barrel Textures Animations/meshes/clutter/tgbarrel01.nif,690A842B09A38662
-02 SMIM Barrel Textures Animations Original Movement/meshes/clutter/barrel01.nif,8A658062CB5D0C1B
-02 SMIM Barrel Textures Animations Original Movement/meshes/clutter/barrel02.nif,FEF06BEFFEDE5461
-02 SMIM Barrel Textures Animations Original Movement/meshes/clutter/tgbarrel01.nif,51F1B76C277E5980
-02 SMIM Barrel Textures No Animations/meshes/clutter/barrel01.nif,44BDE7F95DFB31A8
-02 SMIM Barrel Textures No Animations/meshes/clutter/barrel02.nif,FEF06BEFFEDE5461
-02 SMIM Barrel Textures No Animations/meshes/clutter/tgbarrel01.nif,D1EBAA1A84DC7B21
-02 SMIM Rustic Barrel Textures Animations/meshes/clutter/barrel01.nif,E2A652958AADDC4
-02 SMIM Rustic Barrel Textures Animations/meshes/clutter/barrel02.nif,FEF06BEFFEDE5461
-02 SMIM Rustic Barrel Textures Animations/meshes/clutter/tgbarrel01.nif,690A842B09A38662
-02 SMIM Rustic Barrel Textures No Animations/meshes/clutter/barrel01.nif,44BDE7F95DFB31A8
-02 SMIM Rustic Barrel Textures No Animations/meshes/clutter/barrel02.nif,FEF06BEFFEDE5461
-02 SMIM Rustic Barrel Textures No Animations/meshes/clutter/tgbarrel01.nif,D1EBAA1A84DC7B21
-02 Vanilla Barrel Textures Animations/meshes/clutter/barrel01.nif,7388B387DA86B40E
-02 Vanilla Barrel Textures Animations/meshes/clutter/barrel02.nif,42ECAEC346B4E936
-02 Vanilla Barrel Textures Animations/meshes/clutter/tgbarrel01.nif,E6EA8C23176389DF
-02 Vanilla Barrel Textures No Animations/meshes/clutter/barrel01.nif,B29EA75F8EBC0212
-02 Vanilla Barrel Textures No Animations/meshes/clutter/barrel02.nif,42ECAEC346B4E936
-02 Vanilla Barrel Textures No Animations/meshes/clutter/tgbarrel01.nif,FA857FC2224A42A7
-03 Food/meshes/animobjects/animobjectbread.nif,64DCF9D31AC12C5
-03 Food/meshes/loadscreenart/loadscreenmarket01.nif,76A8893ECFCB5B82
-03 Food/meshes/plants/cabbage01.nif,36AED65AB194724A
-03 Food/meshes/plants/potato01.nif,5CCE73F93B2A01CB
-05 Chains 3D - Misc/meshes/loadscreenart/loadscreenmetalcage.nif,CF9E10F621B48EEA
-06 Chains 3D - Signs/meshes/loadscreenart/loadscreenblackbriar01.nif,DA6FDCF9E957748
-13 Lanterns/meshes/loadscreenart/loadscreenadventure01.nif,89DCE0F544656BB8
-13 Lanterns/meshes/loadscreenart/loadscreenshopsmagic01.nif,EBF6280041E899A7
-13 Lanterns/textures/effects/candleflame01.dds,312AFE2C4C66E0A0
-16 Tankard Bright Brushed Metal/meshes/animobjects/animobjectdrinkingtankard.nif,D0143111EB72189B
-16 Tankard Bright Brushed Metal/meshes/loadscreenart/loadscreenargonianbarkeep.nif,2E09BEF0E6DC129D
-16 Tankard Dark Brushed Metal/meshes/animobjects/animobjectdrinkingtankard.nif,D0143111EB72189B
-16 Tankard Dark Brushed Metal/meshes/loadscreenart/loadscreenargonianbarkeep.nif,2E09BEF0E6DC129D
-16 Tankard Pewter Metal/meshes/animobjects/animobjectdrinkingtankard.nif,A72C4B470A9467F7
-16 Tankard Pewter Metal/meshes/loadscreenart/loadscreenargonianbarkeep.nif,51C2781FA2682BE3
-17 Nordic Catacombs Skeletal Remains/textures/effects/candleflame01.dds,312AFE2C4C66E0A0
-19 Smelter/meshes/furniture/smeltermarker.nif,6647FF38E1B80318
-20 Furniture Skyrim HD Appearance/textures/clutter/furniturewood01.dds,9D4E12FBBAEB97BA
-20 Furniture Skyrim HD Appearance/textures/clutter/furniturewood01_n.dds,63088B73FA522C5E
-20 Furniture Skyrim HD Weathered Appearance/textures/clutter/furniturewood01.dds,87416DC77B621E85
-20 Furniture Skyrim HD Weathered Appearance/textures/clutter/furniturewood01_n.dds,DABD609DBA742A11
-26 Human Skull Fixes/meshes/loadscreenart/loadscreensinister01.nif,36E138D86F7F59CD
-26 Human Skull Fixes/meshes/loadscreenart/loadscreenskeleton.nif,BADF0A6352E5AF6
-26 Human Skull Fixes/meshes/loadscreenart/loadscreentrollclean.nif,73DC9F6E17AC5478
-27 Hawk/textures/effects/fxbird01.dds,A002A57DC431893A
-27 Hawk/textures/effects/fxbird01_n.dds,8248138F4BF5753D
-47 Juniper Tree/meshes/plants/florajuniper01.nif,F1BF343EC94401B9
-48 Juniper Tree Excessive Polycount Version/meshes/plants/florajuniper01.nif,CAEDD638AAB75B94
-71 Candelabras Sconces Walltorches/textures/effects/candleflame01.dds,312AFE2C4C66E0A0
-72 Chandeliers/textures/effects/candleflame01.dds,312AFE2C4C66E0A0
-80 Half-Sized Textures/textures/clutter/furniturewood01.dds,613640807230CFBF
-80 Half-Sized Textures/textures/clutter/furniturewood01_n.dds,EDB1CDEC54D8E740
-80 Half-Sized Textures/textures/effects/fxbird01.dds,75BFE6D43BC56C8E
-80 Half-Sized Textures/textures/effects/fxbird01_n.dds,761D1EDDE3C0F410
-81 Half-Sized Furniture Skyrim HD Appearance/textures/clutter/furniturewood01.dds,4C653E3C708EFA8D
-81 Half-Sized Furniture Skyrim HD Appearance/textures/clutter/furniturewood01_n.dds,5B44194C2E6386FA
-81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/clutter/furniturewood01.dds,DBB0160368E467D4
-81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/clutter/furniturewood01_n.dds,19824D6044C7C673
-00 Core/meshes/architecture/farmhouse/farmbannerpost01.nif,AA56A68884EEFF3D
-00 Core/meshes/architecture/farmhouse/farmhouse01.nif,7B21A396B3E8E5B1
-00 Core/meshes/architecture/farmhouse/farmhouse01walkway.nif,6D44CBEF75BBA9EF
-00 Core/meshes/architecture/farmhouse/farmhouse02.nif,7BD8516E44D2ED81
-00 Core/meshes/architecture/farmhouse/farmhouse02walkway.nif,351371B0B61CB847
-00 Core/meshes/architecture/farmhouse/farmhouse03.nif,BF6BCD1C50D3BDBD
-00 Core/meshes/architecture/farmhouse/farmhouse03walkway.nif,6C31F3CC2752337F
-00 Core/meshes/architecture/farmhouse/farmhouse04.nif,4B0EFAF3FD85FF49
-00 Core/meshes/architecture/farmhouse/farmhouse04walkway.nif,1DEE9DE7FB505C17
-00 Core/meshes/architecture/farmhouse/farmhouse05.nif,F8BD11651A084F4E
-00 Core/meshes/architecture/farmhouse/farmhouse05destroyed01.nif,92406ECDE5A485D4
-00 Core/meshes/architecture/farmhouse/farmhouse05destroyed02.nif,AAB82ABBE213EA34
-00 Core/meshes/architecture/farmhouse/farmhouse06.nif,EF052F5A04BFD31D
-00 Core/meshes/architecture/farmhouse/farmhouse06destroyed01.nif,32A48CBFE9CBF3A4
-00 Core/meshes/architecture/farmhouse/farmhouse06destroyed02.nif,6A991B17E23DAFD8
-00 Core/meshes/architecture/farmhouse/farmlonghouse01.nif,BA18ACA872189447
-00 Core/meshes/architecture/farmhouse/farmwell01.nif,A0886C1E7F290F6A
-00 Core/meshes/architecture/farmhouse/inn01.nif,F759AD05898435B9
-00 Core/meshes/architecture/farmhouse/inndestroyed01.nif,DCD6D877991331B8
-00 Core/meshes/architecture/farmhouse/inndestroyed02.nif,4D7407E9450AD203
-00 Core/meshes/architecture/farmhouse/lumbermill01.nif,E4BCB62767BCF115
-00 Core/meshes/architecture/farmhouse/lumbermill01waterwheel01.nif,C7A7A59E6879C612
-00 Core/meshes/architecture/farmhouse/lumbermill01waterwheel02.nif,3CD096743CBD1AAE
-00 Core/meshes/architecture/farmhouse/smith01.nif,BCA491A04AC0EA70
-00 Core/meshes/architecture/highhrothgar/mqetchedshrine.nif,AE8F91990F99F08
-00 Core/meshes/architecture/markarth/mrkmillroof01.nif,F8AC5745564EA8F6
-00 Core/meshes/architecture/markarth/mrksilverfishinnpart01.nif,538D3459473E8C9B
-00 Core/meshes/architecture/riften/riftenkeepdoor01.nif,1C657EE1AC629AEB
-00 Core/meshes/architecture/shackkit/shackwalll01.nif,7FF20B273F05F55
-00 Core/meshes/architecture/shackkit/shackwalll02.nif,E2A830E30F08D192
-00 Core/meshes/architecture/shackkit/shackwallr01.nif,F069AF1DAAD3F5B3
-00 Core/meshes/architecture/shackkit/shackwallr02.nif,D00022CFBE348C5
-00 Core/meshes/architecture/shackkit/shackwalltop01.nif,5A162A9F5E525308
-00 Core/meshes/architecture/shackkit/shackwalltopwindow01.nif,3E8CDA35C6524633
-00 Core/meshes/architecture/solitude/sblacksmith.nif,ABE0FAD8AA1D8BFB
-00 Core/meshes/architecture/solitude/sbridge01.nif,6375AEA41FC38514
-00 Core/meshes/architecture/solitude/seastempireco.nif,2A2492E8F659B641
-00 Core/meshes/architecture/solitude/spatiowallentrance.nif,87DBCAF56585866C
-00 Core/meshes/architecture/solitude/sthalmorembassy.nif,37CF2367E6D21F33
-00 Core/meshes/architecture/tents/largeimperialtent01.nif,B89BA1908CDBFA79
-00 Core/meshes/architecture/windhelm/whwallwulfharth.nif,411693C0CF9C4F0C
-00 Core/meshes/betterdynamicsnow/shader/snowshader.nif,20508F83CC27E1AD
-00 Core/meshes/clutter/blackreach/blackreachcrystall01.nif,DD9D87FD87973D84
-00 Core/meshes/clutter/blackreach/blackreachcrystall02.nif,C1D5894B9D0F20A0
-00 Core/meshes/clutter/blackreach/blackreachcrystall04.nif,771050B0D2801848
-00 Core/meshes/clutter/blackreach/blackreachcrystalm02.nif,BAC7119B8BCA568C
-00 Core/meshes/clutter/blackreach/blackreachcrystalm03.nif,9C100271938E08BF
-00 Core/meshes/clutter/blackreach/blackreachcrystalpiles02.nif,18DB8DC2010A3D75
-00 Core/meshes/clutter/blackreach/blackreachcrystalpiles04.nif,5BE85680D40E0F55
-00 Core/meshes/clutter/blackreach/blackreachcrystals02.nif,D089472C7672F9E2
-00 Core/meshes/clutter/blackreach/blackreachcrystals03.nif,205B7E75E4661073
-00 Core/meshes/clutter/blackreach/blackreachtinymushroom01.nif,2C0654953AB4B337
-00 Core/meshes/clutter/blackreach/blackreachtinymushroom02.nif,211C0C68438615D
-00 Core/meshes/clutter/caves/cave_lamp01.nif,AF80B172660B812A
-00 Core/meshes/clutter/caves/cave_lamp02.nif,91D8BE1182DF9316
-00 Core/meshes/clutter/common/archerytarget01.nif,4540292B1BF7619E
-00 Core/meshes/clutter/common/archerytargettripod01.nif,A981C5417529430C
-00 Core/meshes/clutter/common/cratesmall01.nif,90B6C67B9B9E2059
-00 Core/meshes/clutter/common/cratesmall01eeco.nif,63ED76D680822581
-00 Core/meshes/clutter/common/cratesmall02.nif,348B39C6EF590E74
-00 Core/meshes/clutter/common/cratesmalllong01.nif,8CF0F1E71A011662
-00 Core/meshes/clutter/common/cratesmalllong01eeco.nif,99EBAA1E6B7714C3
-00 Core/meshes/clutter/common/cratesmalllong02.nif,D73918841D900E63
-00 Core/meshes/clutter/common/lockpick.nif,113AD2E17E1EC6B
-00 Core/meshes/clutter/common/quill01.nif,FECF24BBFEE38C12
-00 Core/meshes/clutter/deadanimals/rabbitmeat01.nif,28EDF4519EEB20D5
-00 Core/meshes/clutter/deadanimals/rabbitmeatcooked01.nif,45388F050283A125
-00 Core/meshes/clutter/dwemer/dwarvenscraplarge1.nif,E702E43C6854896F
-00 Core/meshes/clutter/giant/giantobelisk01.nif,32DE27A1687CF67F
-00 Core/meshes/clutter/giant/giantobeliskblue01.nif,9BC7AF9041964291
-00 Core/meshes/clutter/giant/giantskewer01.nif,56C581F83850B260
-00 Core/meshes/clutter/giant/giantsmokestack01.nif,1C1B676ED37494A0
-00 Core/meshes/clutter/giant/giantspit01.nif,DF42B745B3D87DA7
-00 Core/meshes/clutter/ingredients/dwarvenoil.nif,1CF81C7BF31BFCB1
-00 Core/meshes/clutter/ingredients/hagclaw.nif,C46CA921BC3ACEDD
-00 Core/meshes/clutter/ingredients/hawkfeather01.nif,C4132BB8940C9216
-00 Core/meshes/clutter/ingredients/sabrecattooth.nif,8A59D53A76ED8DDE
-00 Core/meshes/clutter/quest/giantmortar.nif,684A5A867F267B3C
-00 Core/meshes/clutter/ruins/ruinsfurniturerubble01.nif,D2BE4E399E71CCEB
-00 Core/meshes/clutter/ruins/ruinsfurniturerubble02.nif,2181D6AE7F806F7B
-00 Core/meshes/clutter/ruins/ruinsfurniturerubble12.nif,DDF5C87592A8CB4
-00 Core/meshes/clutter/ruins/ruinsfurniturerubble13.nif,5A785CA2AE617A3D
-00 Core/meshes/clutter/ruins/ruinspot01.nif,9BDD5D6BF289152C
-00 Core/meshes/clutter/ruins/ruinspot02.nif,2DBDAFD6AA64EAAA
-00 Core/meshes/clutter/ruins/ruinspot03.nif,9E55B9618F0B356B
-00 Core/meshes/clutter/ruins/ruinspot03static.nif,3B289BE0648F36FC
-00 Core/meshes/clutter/ruins/ruinspot04.nif,E81F2530B3B22436
-00 Core/meshes/clutter/ruins/ruinspot05.nif,E5BD884FA271E7E3
-00 Core/meshes/clutter/ruins/ruinspot06.nif,FE641210E04E401
-00 Core/meshes/clutter/ruins/ruinssarcophagusverthole.nif,8FB6009BD3766B0B
-00 Core/meshes/clutter/ruins/ruinssarcophagus_bottom01.nif,3793DB7B803014EC
-00 Core/meshes/clutter/ruins/ruins_largechest.nif,CEBA219FC89AE146
-00 Core/meshes/clutter/ruins/ruins_smallchest.nif,EA527454BB3D847C
-00 Core/meshes/clutter/statues/statuenamira.nif,170FD4E37E072BF
-00 Core/meshes/clutter/woodfires/campfire01burning.nif,3EE7B0022A5618F5
-00 Core/meshes/clutter/woodfires/campfire01landburning.nif,3126A557CA24E2E1
-00 Core/meshes/clutter/woodfires/campfire01landoff.nif,6E8BCA68714D4AEE
-00 Core/meshes/clutter/woodfires/campfire01off.nif,2B521CDE741080D8
-00 Core/meshes/furniture/cart/cartfurnstatic01.nif,B2D9A4C59477CE1
-00 Core/meshes/furniture/clutter/leveranimating.nif,684DCB550E7325A5
-00 Core/meshes/furniture/clutter/milllogpile.nif,1ED80E030B458DC8
-00 Core/meshes/furniture/noble/noblechair01.nif,77D4A5F8B2373A1E
-00 Core/meshes/furniture/noble/noblechair02.nif,B835747FE8CF7F54
-00 Core/meshes/furniture/noble/scoffinpoor.nif,8C16C5E779FDD7B9
-00 Core/meshes/furniture/nordic/ruins_chair01.nif,1381D10B261A7516
-00 Core/meshes/furniture/nordic/ruins_chairshadow01.nif,AF1338F01847B22C
-00 Core/meshes/furniture/prisonercarriage/prisonercarriage01.nif,3F57273A98DB1D42
-00 Core/meshes/furniture/prisonercarriage/prisonercarriage01static.nif,2BD6D5CAD6E76C33
-00 Core/meshes/furniture/prisonercarriage/prisonercarriagefurniture01.nif,30A1D8EC0B61AD33
-00 Core/meshes/landscape/dirtcliffs/dirtcliffs01moss.nif,6FEB1FD8F6417A5
-00 Core/meshes/landscape/dirtcliffs/dirtcliffs02moss.nif,11C5A18DD6A2C685
-00 Core/meshes/landscape/dirtcliffs/dirtcliffs03moss.nif,978FCCAC123C5907
-00 Core/meshes/landscape/dirtcliffs/dirtcliffs04moss.nif,9E92D3EA36FB71AB
-00 Core/meshes/landscape/dirtcliffs/dirtcliffs05moss.nif,1DD65959CD8EE146
-00 Core/meshes/landscape/mountains/mountaincliff02.nif,2B69FCBFACB704DB
-00 Core/meshes/landscape/mountains/mountaincliffsm01.nif,D45DB4BF0812BEE5
-00 Core/meshes/landscape/rocks/rockanimalden01.nif,D611DC310C8054F2
-00 Core/meshes/landscape/rocks/rockl01.nif,B49CD689D23C760E
-00 Core/meshes/landscape/rocks/rockl02.nif,9EBBA7EE5F1D33B
-00 Core/meshes/landscape/rocks/rockl04.nif,BB6BE12A8286E63A
-00 Core/meshes/landscape/rocks/rockm03.nif,D0DC5EE84E5FF6E6
-00 Core/meshes/landscape/rocks/rockpilel01.nif,6F57A9AA99EB3B35
-00 Core/meshes/landscape/rocks/rockpilem02.nif,21C561ACBB0AB3EB
-00 Core/meshes/landscape/rocks/rockpilem02tundra.nif,A81E131659A264FF
-00 Core/meshes/landscape/rocks/rockpiles02.nif,6B9076C41CA4580A
-00 Core/meshes/landscape/rocks/rockpiles04.nif,CCA0AD26F756C462
-00 Core/meshes/landscape/trees/coastdriftwood01.nif,AAB9EADDB91118A8
-00 Core/meshes/landscape/trees/coastdriftwood02.nif,466591844B5FC11B
-00 Core/meshes/landscape/trees/coastdriftwood03.nif,BF653A7BEDC0C8AE
-00 Core/meshes/traps/doordeadbolt/doordeadbolt01.nif,452681404CADEA04
-00 Core/meshes/traps/doordeadboltdbl/doordeadboltdbl01.nif,617830255AD0836C
-00 Core/textures/architecture/farmhouse/woodpost02.dds,AFEF4D6A0B8C244E
-00 Core/textures/architecture/farmhouse/woodpost02_n.dds,49AC117D42EC48B1
-00 Core/textures/architecture/whiterun/wrslate02.dds,1B7EF5CC8368C80D
-00 Core/textures/architecture/whiterun/wrslate02_n.dds,D7E7ECCEDA0763D6
-00 Core/textures/architecture/whiterun/wrwoodbeam01.dds,A475E49576504E01
-00 Core/textures/architecture/whiterun/wrwoodbeam01_n.dds,D09BB42D776D8654
-00 Core/textures/clutter/caves/caves_lamp01.dds,D49DF9FC7EB49AF3
-00 Core/textures/clutter/caves/caves_lamp01_n.dds,AC5108644F6D5DFB
-00 Core/textures/clutter/deadanimals/rabbitmeatcooked.dds,F126EF3408C8D9C5
-00 Core/textures/clutter/ingredients/hagfeathers.dds,816AD08DEBB0EBEE
-00 Core/textures/clutter/ruins/ruinschest01snow.dds,FDDB0382EE50009D
-00 Core/textures/dungeons/azurasstar/azuracrystal01.dds,2F2000C320B2AA92
-00 Core/textures/dungeons/azurasstar/azuracrystal01_n.dds,F2C98E8703D8FBBD
-00 Core/textures/dungeons/caves/CaveRocks01_n.dds,A65C028F09EB7486
-00 Core/textures/dungeons/mines/mineroots01.dds,38D5124C46E90572
-00 Core/textures/smim/chains/metalwork01_brown.dds,EC6D1D0DEB249E38
-00 Core/textures/smim/chains/metalwork01_brown_n.dds,D7732E6E282E1D36
-00 Core/textures/smim/chains/metalwork01_gray.dds,CCDFBED05C08CF08
-00 Core/textures/smim/chains/metalwork01_gray_n.dds,553FCF5E0628A21A
-00 Core/textures/smim/clutter/barrel02.dds,AA89AFADF99FBA33
-00 Core/textures/smim/clutter/barrel02_n.dds,87E2B710D2B532F
-00 Core/textures/smim/clutter/barrel_smim_metal.dds,89E7C9F747C18B96
-00 Core/textures/smim/clutter/barrel_smim_metal_n.dds,96E6A701490A9E32
-00 Core/textures/smim/clutter/barrel_smim_wood.dds,45BA154BA4D89AC
-00 Core/textures/smim/clutter/barrel_smim_wood_n.dds,EE038180EA601238
-00 Core/textures/smim/clutter/smim_ingotdwemer.dds,DA161F73549CB8BF
-00 Core/textures/smim/clutter/smim_ingotdwemer_n.dds,3B4BEE947C4AF6F3
-00 Core/textures/smim/traps/smim_trap_deadbolt.dds,8BDEEB2B12A29710
-00 Core/textures/smim/traps/smim_trap_deadbolt_n.dds,6A41FAD94C006443
-01 Furniture/meshes/_byoh/furniture/byohupperendtable02.nif,7916B38B6DF30AD3
-01 Furniture/meshes/clutter/common/commonchair02.nif,E252797C3FEF89D0
-01 Furniture/meshes/clutter/common/commonchair02static.nif,8B674C828B203AE6
-01 Furniture/meshes/clutter/common/commoncrate01.nif,8399E59417B9C31B
-01 Furniture/meshes/clutter/common/commoncrate02.nif,BE046339A377DDCC
-01 Furniture/meshes/clutter/common/commonshelf01.nif,417E76E4C52FAB28
-01 Furniture/meshes/clutter/common/commonshelf03.nif,33D2523688139A42
-01 Furniture/meshes/clutter/common/commonshelf04.nif,B8D8AB715EEC4775
-01 Furniture/meshes/clutter/common/commonshelf04open.nif,489746F39A7D0578
-01 Furniture/meshes/clutter/common/commonshelf05.nif,33FE02CFA3558BF5
-01 Furniture/meshes/clutter/common/commontable01.nif,F2D656C1AA648A4F
-01 Furniture/meshes/clutter/common/commontable02.nif,F38B36B2DACEF945
-01 Furniture/meshes/clutter/common/commontablelow01.nif,25AE63205601CB16
-01 Furniture/meshes/clutter/common/commontablelow02.nif,A8D7BC9293AD4BD6
-01 Furniture/meshes/clutter/common/commontableround01.nif,798083A21F76C455
-01 Furniture/meshes/clutter/common/commontablesquare01.nif,AEF20499AF731EE8
-01 Furniture/meshes/clutter/common/commontablethin01.nif,F7102E6866762FB4
-01 Furniture/meshes/clutter/common/cupboard01.nif,992DD2747714A1F7
-01 Furniture/meshes/clutter/common/dresser01.nif,A342D5F6E6501CA2
-01 Furniture/meshes/clutter/common/endtable01.nif,3FEF591CDA3513B6
-01 Furniture/meshes/clutter/common/wardrobe01.nif,7D666FCD553D7128
-01 Furniture/meshes/clutter/upperclass/upperbeddouble01.nif,BE768B64C4085028
-01 Furniture/meshes/clutter/upperclass/upperbedsingle01.nif,C3C8751E4554422A
-01 Furniture/meshes/clutter/upperclass/upperbench01.nif,5E51FCA85B2986E7
-01 Furniture/meshes/clutter/upperclass/upperbench02.nif,43598F6D7AFD8F5B
-01 Furniture/meshes/clutter/upperclass/upperbench03.nif,EDA3475790C89127
-01 Furniture/meshes/clutter/upperclass/upperchair01.nif,33D19598C05088D9
-01 Furniture/meshes/clutter/upperclass/uppercupboard01.nif,971B17BDAB2B2A29
-01 Furniture/meshes/clutter/upperclass/upperdresser01.nif,96201A651A3AD79
-01 Furniture/meshes/clutter/upperclass/upperendtable01.nif,E14A5B09E5FA1179
-01 Furniture/meshes/clutter/upperclass/upperendtable02.nif,F2A5E2A8A5453273
-01 Furniture/meshes/clutter/upperclass/uppernightstand01.nif,99FD9B6600661FAA
-01 Furniture/meshes/clutter/upperclass/uppershelf01.nif,BB0BECE4B700F8D3
-01 Furniture/meshes/clutter/upperclass/uppershelf02.nif,67D01750F2EAE509
-01 Furniture/meshes/clutter/upperclass/uppertable01.nif,EF4972F65F1AFC0C
-01 Furniture/meshes/clutter/upperclass/uppertable01custom01.nif,A33FF5BA3A4F9D81
-01 Furniture/meshes/clutter/upperclass/uppertable01custom01cloth01.nif,5984C13A86196D13
-01 Furniture/meshes/clutter/upperclass/uppertablebench01.nif,C1BAFE6510CEBC57
-01 Furniture/meshes/clutter/upperclass/uppertablebench02.nif,A0FD9BA3C93C306F
-01 Furniture/meshes/clutter/upperclass/uppertableround01.nif,1DD70EDA50F679BE
-01 Furniture/meshes/clutter/upperclass/uppertablesquare01.nif,BC2D8ABD0658D4C6
-01 Furniture/meshes/clutter/upperclass/upperwardrobe01.nif,26440697DF4A2C4B
-01 Furniture/meshes/furniture/common/commonbench01.nif,4BDB12BDE5421A45
-01 Furniture/meshes/furniture/common/commonchair01.nif,625A7FD172C199E7
-01 Furniture/meshes/furniture/farm/farmbench01.nif,CCA62FB399C4C48B
-01 Furniture/meshes/furniture/farm/farmtable01.nif,EF3A3F1B6757480A
-01 Furniture/meshes/furniture/farm/farmtablebench01.nif,238056FF5F83C7BA
-01 Furniture/meshes/furniture/farm/farmtablebench02.nif,A1415DA1D80A30BF
-01 Furniture/textures/clutter/common/dresser01.dds,E1AC4C65A127F3F4
-01 Furniture/textures/clutter/common/dresser01_n.dds,5BEA1ADF32BCA51B
-01 Furniture/textures/smim/clutter/furniturewood01.dds,5FFAE78BD5600579
-01 Furniture/textures/smim/clutter/furniturewood01_n.dds,31DFD2D87198F2CF
-01 Furniture/textures/smim/furniture/smim_wooden_chair.dds,C5DE24915AE25EDA
-01 Furniture/textures/smim/furniture/smim_wooden_chair_n.dds,F655882EDE099D16
-02 SMIM Rustic Barrel Textures Animations/textures/smim/clutter/barrel_smim_wood.dds,E9F17B41386B7DA7
-02 SMIM Rustic Barrel Textures Animations/textures/smim/clutter/barrel_smim_wood_n.dds,94EF176EA22DB6BB
-02 SMIM Rustic Barrel Textures No Animations/textures/smim/clutter/barrel_smim_wood.dds,E9F17B41386B7DA7
-02 SMIM Rustic Barrel Textures No Animations/textures/smim/clutter/barrel_smim_wood_n.dds,94EF176EA22DB6BB
-03 Food/meshes/clutter/food/apple01.nif,8800A499BBDDDFE7
-03 Food/meshes/clutter/food/apple02.nif,85DBBA7D1EFF6B0F
-03 Food/meshes/clutter/food/bread01a.nif,ADEE99EAFCC0B5A1
-03 Food/meshes/clutter/food/bread01b.nif,AAB8EEBD63874C00
-03 Food/meshes/clutter/food/grilledpotatoes01.nif,5E379395F022BC27
-03 Food/meshes/clutter/ingredients/tomato.nif,8BA8BB9926BF49EB
-03 Food/textures/smim/plants/potato01_properUVmap.dds,E393E2D39E44E60B
-03 Food/textures/smim/plants/potato01_properUVmap_n.dds,9DBB1F5E4A72B840
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmbannerpost01.nif,C631ACCAF8924D44
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse01walkway.nif,45D07C38940A6DB9
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse02.nif,853C7CFAA33EE352
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse02walkway.nif,CE648483ADDABE55
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse03.nif,DE114EEA33593CA3
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse03walkway.nif,4FAC71C91408D426
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse04.nif,90643D567205AA1D
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse04walkway.nif,F0B55D66DEE91A88
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse06.nif,B694F7C7E90390A8
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmwell01.nif,3B0CD6188FB67A69
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/inn01.nif,EAA89663303ADC7E
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/lumbermill01.nif,DB1D30E035E39017
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmbannerpost01.nif,C631ACCAF8924D44
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse01walkway.nif,2D602701AFEDD20B
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse02.nif,BA49A9D19CEF88D
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse02walkway.nif,9AD3D66D74C648AA
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse03.nif,4A82033407D4AB9D
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse03walkway.nif,AABBEB3119F518EC
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse04.nif,5172474EFB3E67DE
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse04walkway.nif,B57E39DF0FF9DA5D
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse06.nif,B694F7C7E90390A8
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmwell01.nif,3B0CD6188FB67A69
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/inn01.nif,EAA89663303ADC7E
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/lumbermill01.nif,A8897C6B94EE6D75
-05 Chains 3D - Misc/meshes/architecture/markarth/mrkapoth01.nif,BD3B010D1218127D
-05 Chains 3D - Misc/meshes/architecture/markarth/mrkbrazierhanging01.nif,FFBF45EDB49B133F
-05 Chains 3D - Misc/meshes/architecture/markarth/mrkbrazierhanging02.nif,6133635B1ABCBC2C
-05 Chains 3D - Misc/meshes/architecture/markarth/mrksilverfishinnpart03.nif,CF195DE06B6FD630
-05 Chains 3D - Misc/meshes/architecture/markarth/mrksilverfishinnpart05.nif,BC9845739BF52AAA
-05 Chains 3D - Misc/meshes/architecture/markarth/mrktempledoorl01.nif,DE1AAEABAB411BC1
-05 Chains 3D - Misc/meshes/architecture/markarth/mrktempledoorr01.nif,217853E77CE7AE80
-05 Chains 3D - Misc/meshes/architecture/riften/riftendoor01.nif,2DA97F50EB41AB96
-05 Chains 3D - Misc/meshes/architecture/riften/riftendoor02.nif,F27C8CEA1EC52DA5
-05 Chains 3D - Misc/meshes/clutter/common/metalcage01.nif,67180E32079A87A2
-05 Chains 3D - Misc/meshes/clutter/common/torturerack01.nif,8DCB88DCFF66FCA1
-06 Chains 3D - Signs/meshes/architecture/markarth/mrksigngeneralgoods01.nif,85AC77936A924F06
-06 Chains 3D - Signs/meshes/architecture/markarth/mrksignmrksilverbloodinnsign01.nif,BAB3AF258D371971
-06 Chains 3D - Signs/meshes/clutter/signage/signtg03blackbriarmeadery.nif,38CB0C7B91B3F922
-07 Chains 3D - Whiterun/meshes/architecture/whiterun/wrdrawbridge01.nif,7AB8050AC9D68B63
-07 Chains 3D - Whiterun/meshes/traps/whiterundragontrap/whiterundragontrap01.nif,E617CED45FCA427E
-09 Dwemer Clutter/meshes/clutter/dwemer/armscrap.nif,8595D43E99B74AF3
-09 Dwemer Clutter/meshes/clutter/dwemer/centuriondynamocore01.nif,63C5CF37EFF5D911
-09 Dwemer Clutter/meshes/clutter/dwemer/dwarvengear.nif,A18DD997482CA82E
-09 Dwemer Clutter/meshes/clutter/dwemer/dwarvengyro.nif,1CE3A942D1F0608A
-09 Dwemer Clutter/meshes/clutter/dwemer/dwarvenplate.nif,3BFB85E4BDDEF65F
-09 Dwemer Clutter/meshes/clutter/dwemer/dwarvenscrap1.nif,F6BDCB8622E5EA8D
-09 Dwemer Clutter/meshes/clutter/dwemer/dwarvenscrap2.nif,FBEB74C960896E27
-09 Dwemer Clutter/meshes/clutter/dwemer/dwarvenscrap3.nif,6A087B530EC4DD06
-09 Dwemer Clutter/meshes/clutter/dwemer/dwarvenscrap4.nif,F4E97AA4CA4C6BD7
-09 Dwemer Clutter/meshes/clutter/dwemer/dwarvenscraplarge1.nif,2248EEEC739C50F0
-09 Dwemer Clutter/meshes/clutter/dwemer/dwarvenscraplarge2.nif,DEA5C420D0B5FC55
-09 Dwemer Clutter/meshes/clutter/dwemer/dwebowl01.nif,DA1F680E4243E7D
-09 Dwemer Clutter/meshes/clutter/dwemer/dwebowl02.nif,F330079BF0ECB0A2
-09 Dwemer Clutter/meshes/clutter/dwemer/dwecog01.nif,CBAE2720B74DFEC3
-09 Dwemer Clutter/meshes/clutter/dwemer/dwecup01.nif,98B789A3280B14D2
-09 Dwemer Clutter/meshes/clutter/dwemer/dwecup02.nif,6AD6FB7F6158F59C
-09 Dwemer Clutter/meshes/clutter/dwemer/dwecup03.nif,943970700F68F1F2
-09 Dwemer Clutter/meshes/clutter/dwemer/dwefork.nif,2A169F52A1BEFDF6
-09 Dwemer Clutter/meshes/clutter/dwemer/dweknife.nif,7E63AAF2D8E2249D
-09 Dwemer Clutter/meshes/clutter/dwemer/dweplate01.nif,41DACA469B1141D1
-09 Dwemer Clutter/meshes/clutter/dwemer/dwepot01.nif,E473A437BBB12997
-09 Dwemer Clutter/meshes/clutter/dwemer/dwespoon.nif,1FA15F9E09CC5C45
-10 Nordic Tables and Benches/meshes/clutter/ruins/ruinsfurniturerubble03.nif,BD1B5BC375D894AC
-10 Nordic Tables and Benches/meshes/clutter/ruins/ruinsfurniturerubble04.nif,15D3F9141DF16FE1
-10 Nordic Tables and Benches/meshes/clutter/ruins/ruinsfurniturerubble09.nif,A82D35B177B33B72
-10 Nordic Tables and Benches/meshes/clutter/ruins/ruinsfurniturerubble10.nif,34064AAFFAE6D172
-10 Nordic Tables and Benches/meshes/clutter/ruins/ruinsfurniturerubble11.nif,3127E3256B95605D
-10 Nordic Tables and Benches/meshes/clutter/ruins/ruinsfurniturerubble15.nif,D5D3EAAF5B83B522
-10 Nordic Tables and Benches/meshes/clutter/ruins/ruinslongtable01.nif,E9F373A78A3CD61C
-10 Nordic Tables and Benches/meshes/clutter/ruins/ruinstable01.nif,FE7C2FE82CC14226
-10 Nordic Tables and Benches/meshes/clutter/ruins/ruins_altar01.nif,7E2C8D8D5645A7A7
-10 Nordic Tables and Benches/meshes/furniture/nordic/ruinsbenchtable1sided.nif,9474DE23D04AA485
-10 Nordic Tables and Benches/meshes/furniture/nordic/ruinsbenchtable2sided.nif,D05140596001432D
-10 Nordic Tables and Benches/meshes/furniture/nordic/ruinsbookpedestal.nif,F328533B5CF15807
-10 Nordic Tables and Benches/meshes/furniture/nordic/ruinsbookpedestalshadow.nif,7082A8F3F2FFE4B
-10 Nordic Tables and Benches/meshes/furniture/nordic/ruins_bench01.nif,101686F1270CE507
-10 Nordic Tables and Benches/meshes/furniture/nordic/ruins_benchshadow01.nif,EBF3DE61DAF404D6
-11 Bridges/meshes/landscape/bridges/bridge01.nif,F8289F6F0FEDA8A0
-11 Bridges/meshes/landscape/bridges/bridgelong01.nif,94B23404F9236282
-11 Bridges/meshes/landscape/bridges/bridgenarrow01.nif,E22F67EB0564BA72
-11 Bridges/meshes/landscape/bridges/bridgeshort01.nif,496AB236DF714D66
-11 Bridges Old Stonework/meshes/landscape/bridges/bridge01.nif,E234236FF4A37A80
-11 Bridges Old Stonework/meshes/landscape/bridges/bridgelong01.nif,62957E827D0866C0
-11 Bridges Old Stonework/meshes/landscape/bridges/bridgenarrow01.nif,169A5D8D65B2E29D
-11 Bridges Old Stonework/meshes/landscape/bridges/bridgeshort01.nif,A6EFAAE6255E6E89
-11 Bridges Real Roads/meshes/architecture/solitude/sbridge01.nif,EE2D544780533F5C
-11 Bridges Real Roads/meshes/landscape/bridges/bridge01.nif,632C72927734956B
-11 Bridges Real Roads/meshes/landscape/bridges/bridgelong01.nif,8E1BD17F38FCAE05
-11 Bridges Real Roads/meshes/landscape/bridges/bridgenarrow01.nif,21E72C950BF76EED
-11 Bridges Real Roads/meshes/landscape/bridges/bridgeshort01.nif,7C4E330B5CDCC5AE
-12 Whiterun Doors/meshes/architecture/whiterun/wrcastledoor01.nif,F509F2F6C2484DF6
-12 Whiterun Doors/meshes/architecture/whiterun/wrdoormaingate01.nif,F72AC8BCE05EC867
-12 Whiterun Doors/meshes/architecture/whiterun/wrdragondoor01.nif,79B17611D4F03414
-13 Lanterns/meshes/clutter/common/candlelantern01.nif,A0BABD84540BECEA
-13 Lanterns/meshes/clutter/common/candlelanternwithcandle01.nif,B2DFFBEF45B6284C
-13 Lanterns/meshes/dlc02/loadscreenart/loadscreenadventure02.nif,9DE052F2B62E3971
-13 Lanterns/textures/smim/candles/candles01.dds,36D9D5EAD48714CC
-13 Lanterns/textures/smim/candles/candles01_g.dds,CFAD1913638FEEB6
-13 Lanterns/textures/smim/candles/candles01_n.dds,EA8228DA6595E530
-14 Stockade 3D Ropes/meshes/clutter/stockade/stockadescaffoldtoppost01.nif,727F3B09B705D9D7
-14 Stockade 3D Ropes/meshes/clutter/stockade/stockadescaffoldtoppost02.nif,2FF933D680818648
-14 Stockade 3D Ropes/meshes/clutter/stockade/stockadescaffoldtoppost03.nif,609BDBBA1C85266A
-14 Stockade 3D Ropes/meshes/clutter/stockade/stockadescaffoldtoprope01.nif,95FB865885EEDE5D
-14 Stockade 3D Ropes/meshes/clutter/stockade/stockadescaffoldtoprope02.nif,C60A9A19FD5D9EE4
-14 Stockade 3D Ropes/meshes/clutter/stockade/stockadescaffoldtoprope03.nif,6D75608FA1614686
-14 Stockade 3D Ropes/textures/clutter/stockade/stockadewood01.dds,5E19FE0DB8D1570A
-14 Stockade 3D Ropes/textures/clutter/stockade/stockadewood01snow.dds,E49B015B7E797019
-14 Stockade 3D Ropes/textures/clutter/stockade/stockadewood01_n.dds,DEB4D7E6021A4EB9
-15 Clothing Fixes/meshes/armor/dragonscale/dragonscalecuirassgo.nif,18CC3FEFD3C32AA8
-15 Clothing Fixes/meshes/clothes/farmclothes04/robem_0.nif,CC9E9A2D42D96367
-15 Clothing Fixes/meshes/clothes/farmclothes04/robem_1.nif,4DBDFF67F540FF9
-15 Clothing Fixes/meshes/clothes/wench/wenchoutfitm_0.nif,FF2FA3C8AC443EB3
-15 Clothing Fixes/meshes/clothes/wench/wenchoutfitm_1.nif,AC37AC1E5113AEE2
-15 Clothing Fixes/textures/clothes/wench/wenchoutfitm.dds,4B3C9B76ABB5ECFC
-16 Tankard Bright Brushed Metal/meshes/clutter/dining set/basictankard01.nif,49FEEC7D931F4772
-16 Tankard Bright Brushed Metal/meshes/dlc01/clutter/dlc01tankardblood.nif,17440A66F94FCACB
-16 Tankard Dark Brushed Metal/meshes/clutter/dining set/basictankard01.nif,49FEEC7D931F4772
-16 Tankard Dark Brushed Metal/meshes/dlc01/clutter/dlc01tankardblood.nif,17440A66F94FCACB
-16 Tankard Pewter Metal/meshes/clutter/dining set/basictankard01.nif,1AD741C33F746556
-16 Tankard Pewter Metal/meshes/dlc01/clutter/dlc01tankardblood.nif,FC62AF9706DF0DE8
-17 Nordic Catacombs Skeletal Remains/textures/actors/skeleton/skeleton.dds,8C316D8CA8F2EA3E
-17 Nordic Catacombs Skeletal Remains/textures/actors/skeleton/skeleton_n.dds,2D2A0E827CC030FA
-17 Nordic Catacombs Skeletal Remains/textures/smim/candles/candles01.dds,36D9D5EAD48714CC
-17 Nordic Catacombs Skeletal Remains/textures/smim/candles/candles01_g.dds,CFAD1913638FEEB6
-17 Nordic Catacombs Skeletal Remains/textures/smim/candles/candles01_n.dds,EA8228DA6595E530
-17 Nordic Catacombs Skeletal Remains/textures/smim/candles/candles02.dds,66AABA8688C65CCC
-17 Nordic Catacombs Skeletal Remains/textures/smim/candles/candles02_g.dds,F33F95B88753EEFD
-17 Nordic Catacombs Skeletal Remains/textures/smim/candles/candles02_n.dds,DC06819AD91AC894
-18 Farmhouse Woven Fence/meshes/architecture/farmhouse/fencewoven01.nif,1F28E804BC15B76C
-18 Farmhouse Woven Fence/meshes/architecture/farmhouse/fencewoven02.nif,56C4132959A6D0AD
-18 Farmhouse Woven Fence Dense/meshes/architecture/farmhouse/fencewoven01.nif,518554264DC69C85
-18 Farmhouse Woven Fence Dense/meshes/architecture/farmhouse/fencewoven02.nif,BEB1B675E523B549
-18 Farmhouse Woven Fence Dense Gray/meshes/architecture/farmhouse/fencewoven01.nif,969B95D1A294484B
-18 Farmhouse Woven Fence Dense Gray/meshes/architecture/farmhouse/fencewoven02.nif,714BE2755F1A4AF
-18 Farmhouse Woven Fence Less Flicker/meshes/architecture/farmhouse/fencewoven01.nif,E8DC441F6718BE6B
-18 Farmhouse Woven Fence Less Flicker/meshes/architecture/farmhouse/fencewoven02.nif,85A54778CB01A193
-20 Furniture Skyrim HD Appearance/meshes/clutter/common/commontablesquare01.nif,9517C1E62F7D1A4B
-20 Furniture Skyrim HD Appearance/meshes/clutter/common/dresser01.nif,AA5B41A1F8528CFD
-20 Furniture Skyrim HD Appearance/meshes/clutter/common/endtable01.nif,D6A8DA261124424F
-20 Furniture Skyrim HD Appearance/meshes/clutter/common/wardrobe01.nif,DDC432C56546358B
-20 Furniture Skyrim HD Appearance/textures/clutter/common/dresser01.dds,879EFD7F76CEB462
-20 Furniture Skyrim HD Appearance/textures/clutter/common/dresser01_n.dds,5FD4C847531E9B66
-20 Furniture Skyrim HD Weathered Appearance/meshes/clutter/common/commontablesquare01.nif,9517C1E62F7D1A4B
-20 Furniture Skyrim HD Weathered Appearance/meshes/clutter/common/dresser01.nif,AA5B41A1F8528CFD
-20 Furniture Skyrim HD Weathered Appearance/meshes/clutter/common/endtable01.nif,D6A8DA261124424F
-20 Furniture Skyrim HD Weathered Appearance/meshes/clutter/common/wardrobe01.nif,DDC432C56546358B
-20 Furniture Skyrim HD Weathered Appearance/textures/clutter/common/dresser01.dds,5D4F2CC651AE4232
-20 Furniture Skyrim HD Weathered Appearance/textures/clutter/common/dresser01_n.dds,3AFE67ADDE187B92
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockcolstr01.nif,E89B9DBCDE4C501A
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockcolstr02.nif,F7C94B69D00E523E
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockcolstrsign01.nif,8F4B92DAFB35D8F9
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockcolstrsignrope01.nif,DDC5CA7E0C494D9
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockcorsol01.nif,7F681DAFB15211CA
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockcorsol01uskp.nif,106BE31AABBA4F81
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockropestr01.nif,D13271A5CEFE4BDA
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockropestr02.nif,E244FED583D75E35
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstepsdown01.nif,376EE91D0837C75
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstepsdown02.nif,ECD28D880581423C
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstepsdown02uskp.nif,3FC26AE3706239E9
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstepsdownend01.nif,141B90E558F11814
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstr4way01.nif,B4EB2CA18929142
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrent01.nif,74ACBA98DAB7ADE6
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrent02.nif,6020D963909731E6
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrent02uskp.nif,D1729D98F8574678
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrent03.nif,39EAE8D0789B932D
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrent03uskp.nif,5058D3393DD28D46
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrent04.nif,A34DF9D8589484CA
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrsol01.nif,E76F5392A5331F34
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrsol01uskp.nif,6328A99BE8E2466F
-22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrsol02.nif,9C21EB59AFC98CF2
-22 Solitude Docks Ropes SE/meshes/architecture/solitude/seastempireco.nif,723D453D05A6E11B
-26 Human Skull Fixes/meshes/actors/skeleton/testskeleton.nif,3DD823EA7E9D080D
-26 Human Skull Fixes/meshes/clutter/bones/bloodyskull.nif,5A84E4E3FDB4911F
-26 Human Skull Fixes/meshes/clutter/bones/humanskull.nif,11FD62ECFFDDA2E3
-26 Human Skull Fixes/meshes/clutter/bones/humanskullfull.nif,311480C1DD8DD8EA
-26 Human Skull Fixes/meshes/clutter/bones/humanskullfullstatic.nif,2A69FCF889AB0D8F
-26 Human Skull Fixes/meshes/clutter/bones/humanskullstatic.nif,D5B8D39FBAC687C5
-26 Human Skull Fixes/meshes/clutter/potema/potemasskull.nif,4696D7231ADFD510
-26 Human Skull Fixes/textures/actors/skeleton/skeleton.dds,8C316D8CA8F2EA3E
-26 Human Skull Fixes/textures/actors/skeleton/skeleton_n.dds,5CEC730DADB3C56A
-26 Human Skull Fixes/textures/clutter/bones/bloodybones.dds,294C0898604DB303
-26 Human Skull Fixes/textures/clutter/bones/bloodybones_n.dds,C13DBEFAA5AB9489
-26 Human Skull Fixes/textures/smim/loadscreenart/smim_trollloadscreen_meat.dds,6D5E0D9363312CD7
-26 Human Skull Fixes/textures/smim/loadscreenart/smim_trollloadscreen_meat_n.dds,9FA8A9DE8D085A8
-27 Hawk/meshes/critters/fchawk/fchawkgo.nif,21C263F34394F902
-30 Rocks - Generic/meshes/landscape/rocks/rockl01.nif,FF27921FCC6F6FB
-30 Rocks - Generic/meshes/landscape/rocks/rockl02.nif,15BCE834DAC9FCC5
-30 Rocks - Generic/meshes/landscape/rocks/rockl03.nif,3A8C243D7D94D2BD
-30 Rocks - Generic/meshes/landscape/rocks/rockl04.nif,59E8A4C3401B8645
-30 Rocks - Generic/meshes/landscape/rocks/rockl05.nif,5A6FF54459381E0E
-30 Rocks - Generic/meshes/landscape/rocks/rockm01.nif,A94B688B3505D33A
-30 Rocks - Generic/meshes/landscape/rocks/rockm02.nif,59D0987A6ED8E2D3
-30 Rocks - Generic/meshes/landscape/rocks/rockm03.nif,1BF99E4680339DBF
-30 Rocks - Generic/meshes/landscape/rocks/rockm04.nif,82CECE4C1EE30012
-30 Rocks - Generic/meshes/landscape/rocks/rockpilel01.nif,D353BC0315AE68A2
-30 Rocks - Generic/meshes/landscape/rocks/rockpilem02.nif,C3FBA0C885338754
-30 Rocks - Generic/meshes/landscape/rocks/rockpilem02tundra.nif,55623E9A2D3BE25B
-30 Rocks - Generic/meshes/landscape/rocks/rockpiles01.nif,55CA1D546F7039E0
-30 Rocks - Generic/meshes/landscape/rocks/rockpiles02.nif,D559C82402389D5F
-30 Rocks - Generic/meshes/landscape/rocks/rockpiles03.nif,57F3EBB44AD3DD94
-30 Rocks - Generic/meshes/landscape/rocks/rockpiles04.nif,21857AA84284925E
-30 Rocks - Generic/meshes/landscape/rocks/rocks01.nif,85C7D00998AAFD81
-30 Rocks - Generic/meshes/landscape/rocks/rocks02.nif,7A98012EB479964
-30 Rocks - Generic/meshes/landscape/rocks/rocks03.nif,2403477D499A5B78
-31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystall01.nif,43D9722AD837A502
-31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystall02.nif,53ABA04CB790874C
-31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystall03.nif,9796D57712E722BD
-31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystall04.nif,C1FC7BEF25C2B15E
-31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystall05.nif,6864BFE35FEBD32E
-31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystalm01.nif,E0E01EE5739CB8D7
-31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystalm02.nif,283012347E60A213
-31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystalm03.nif,6C793D4198FA2F33
-31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystalm04.nif,3F155A82BD0DC7FD
-31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystalpiles02.nif,30A58E6066E1BE31
-31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystalpiles03.nif,CBE4330829C1F830
-31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystalpiles04.nif,3D6250131D1F2D7B
-31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystals02.nif,77B13AF2A21B9417
-31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystals03.nif,5658C522D2AE7DD9
-32 Rocks - Mountains/meshes/landscape/mountains/mountaincliff02.nif,6C536FB95BDDC4EB
-32 Rocks - Mountains/meshes/landscape/mountains/mountaincliff03.nif,A1DF76224A8D7D3C
-32 Rocks - Mountains/meshes/landscape/mountains/mountaincliff04.nif,EC405C8A812CA830
-32 Rocks - Mountains/meshes/landscape/mountains/mountaincliffcrevasse.nif,F37A2822CB5DDBFD
-32 Rocks - Mountains/meshes/landscape/mountains/mountaincliffsm01.nif,8104D5F46DDAC9D8
-32 Rocks - Mountains/meshes/landscape/mountains/mountainridge01.nif,D6E9E56109E629EF
-32 Rocks - Mountains/meshes/landscape/mountains/mountaintrim01.nif,1BA638430B27E3F1
-32 Rocks - Mountains/meshes/landscape/mountains/mountaintrim01wet.nif,23F711036212FB
-32 Rocks - Mountains/meshes/landscape/mountains/mountaintrimslab.nif,9FD44C22C9E464E2
-33 Orc Longhouse/meshes/architecture/orclonghouse/orcawning01.nif,3DD749F2EE8875C6
-33 Orc Longhouse/meshes/architecture/orclonghouse/orcawningfull01.nif,645BB234D198D76C
-33 Orc Longhouse/meshes/architecture/orclonghouse/orcawninghalf01.nif,FE4E6E5EC38675E0
-33 Orc Longhouse/meshes/architecture/orclonghouse/orcawningpartitionexsm01.nif,54044BE3E473272
-33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghouse01.nif,9FEEC3A8C2C6ABE6
-33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghouseinterior01.nif,4C3C3EEB78B54200
-33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghouseinterioreastwing01.nif,B1C28DAD50839B9E
-33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghouseinteriorwestwing01.nif,BC61B94932B7C83
-33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghousepartitionbeam01.nif,B667F041F2D80A3E
-33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghousepartitionend01.nif,C33D6A6D4A77C0BD
-33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghousepartitionexsm01.nif,EC4D16CFF9595D3F
-33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghousepartitionwall01.nif,8B30E7B0A19076BD
-35 Shack Kit/meshes/architecture/shackkit/shackbrokepole01.nif,DA4BFD365E42F6A0
-35 Shack Kit/meshes/architecture/shackkit/shackbrokepole02.nif,13DB7218F1550CE1
-35 Shack Kit/meshes/architecture/shackkit/shackbrokepole03.nif,BB83A25D4CCB12CE
-35 Shack Kit/meshes/architecture/shackkit/shackbrokewood01.nif,942521ADA7098A6
-35 Shack Kit/meshes/architecture/shackkit/shackbrokewood02.nif,79047416189B7D7C
-35 Shack Kit/meshes/architecture/shackkit/shackbrokewood03.nif,DE23E60B9A4C73CB
-35 Shack Kit/meshes/architecture/shackkit/shackbrokewood04.nif,792DE039C5418C7
-35 Shack Kit/meshes/architecture/shackkit/shackbrokewood05.nif,A2773172DDF30BB6
-35 Shack Kit/meshes/architecture/shackkit/shackbrokewood06.nif,B12051520C92EB3B
-35 Shack Kit/meshes/architecture/shackkit/shackbrokewood07.nif,351143E9A6FF56DB
-35 Shack Kit/meshes/architecture/shackkit/shackbrokewood08.nif,4AF020348710F899
-35 Shack Kit/meshes/architecture/shackkit/shackbrokewood09.nif,2E8D758DE8A1930B
-35 Shack Kit/meshes/architecture/shackkit/shackbrokewood10.nif,B1072A12B1ED8322
-35 Shack Kit/meshes/architecture/shackkit/shackbrokewood11.nif,A686F2F714AC7423
-35 Shack Kit/meshes/architecture/shackkit/shackframebend01.nif,38D40238AD2DC0C3
-35 Shack Kit/meshes/architecture/shackkit/shackframelend01.nif,7E3F583049C0849B
-35 Shack Kit/meshes/architecture/shackkit/shackframelend02.nif,69F77BC1FE437693
-35 Shack Kit/meshes/architecture/shackkit/shackframelmid01.nif,7AE369459E066937
-35 Shack Kit/meshes/architecture/shackkit/shackframemend01.nif,CEAFC7BE566D67BE
-35 Shack Kit/meshes/architecture/shackkit/shackframemend02.nif,23804DDED86390DD
-35 Shack Kit/meshes/architecture/shackkit/shackframemmid01.nif,47993100CC8535D2
-35 Shack Kit/meshes/architecture/shackkit/shackframerend01.nif,356494F42C45D718
-35 Shack Kit/meshes/architecture/shackkit/shackframerend02.nif,BCFB943ED9CB787D
-35 Shack Kit/meshes/architecture/shackkit/shackframermid01.nif,44A9B121AB48BB73
-35 Shack Kit/meshes/architecture/shackkit/shackframeturncorner01.nif,46C7C49D2F965CC9
-35 Shack Kit/meshes/architecture/shackkit/shackframeturncorner01FIX.nif,7A5E94FBFB0D6684
-35 Shack Kit/meshes/architecture/shackkit/shackframeturncorner02.nif,42EE26DF96A3763C
-35 Shack Kit/meshes/architecture/shackkit/shackframeturnmid01.nif,61F3D8435DCEC2C
-35 Shack Kit/meshes/architecture/shackkit/shackroofcorner01.nif,21565952FFD5268F
-35 Shack Kit/meshes/architecture/shackkit/shackroofcorner02.nif,1F6A2A815C607463
-35 Shack Kit/meshes/architecture/shackkit/shackroofmid01.nif,6A67960765B5B9DA
-35 Shack Kit/meshes/architecture/shackkit/shackroofmid02.nif,20769F5C99267DE7
-35 Shack Kit/meshes/architecture/shackkit/shackroofmid03.nif,6756990AB30CB089
-35 Shack Kit/meshes/architecture/shackkit/shackroofmid04.nif,422886681F142FA7
-35 Shack Kit/meshes/architecture/shackkit/shackroofmid05.nif,ABC10892B7804A50
-35 Shack Kit/meshes/architecture/shackkit/shackroofside01.nif,CF6B0B97F406ABF8
-35 Shack Kit/meshes/architecture/shackkit/shackroofside01SMIMBoards.nif,6C49C5C01293C047
-35 Shack Kit/meshes/architecture/shackkit/shackroofside02.nif,2DD0FDD8A7A7C8E7
-35 Shack Kit/meshes/architecture/shackkit/shackroofside03.nif,3B787F32BC81719F
-35 Shack Kit/meshes/architecture/shackkit/shackroofside04.nif,22D98A9E188186AE
-35 Shack Kit/meshes/architecture/shackkit/shackwall01.nif,3423E8E4A11B9E74
-35 Shack Kit/meshes/architecture/shackkit/shackwall03.nif,328087509BEEC7EA
-35 Shack Kit/meshes/architecture/shackkit/shackwall04.nif,E8FF707664771443
-35 Shack Kit/meshes/architecture/shackkit/shackwalldoor01.nif,6CA37E7893603295
-35 Shack Kit/meshes/architecture/shackkit/shackwalll01.nif,2D1DADA44E7260D6
-35 Shack Kit/meshes/architecture/shackkit/shackwalll02.nif,5BAA303D8B463104
-35 Shack Kit/meshes/architecture/shackkit/shackwallr01.nif,F069AF1DAAD3F5B3
-35 Shack Kit/meshes/architecture/shackkit/shackwallr02.nif,D00022CFBE348C5
-35 Shack Kit/meshes/architecture/shackkit/shackwalltop01.nif,5A162A9F5E525308
-35 Shack Kit/meshes/architecture/shackkit/shackwalltopwindow01.nif,5D4DC0B50DD32D5F
-35 Shack Kit/meshes/architecture/shackkit/shackwallwindow01.nif,7AE77F45C4F59655
-35 Shack Kit/meshes/architecture/shackkit/shackwallwindow02.nif,8658CD3AAFA4402
-35 Shack Kit/meshes/betterdynamicsnow/shader/snowshader.nif,20508F83CC27E1AD
-37 Riften 3D Ropes/meshes/architecture/riften/rtcanallock01.nif,9CA878D845EAF915
-37 Riften 3D Ropes/meshes/architecture/riften/rtcanalsdeck01.nif,FA2541A9D42FB6D1
-37 Riften 3D Ropes/meshes/architecture/riften/rtcanalsdeck02.nif,D4787F25125CA624
-37 Riften 3D Ropes/meshes/architecture/riften/rtlamppost01.nif,215D47FA88F640FE
-37 Riften 3D Ropes/meshes/architecture/riften/rtplayerhousedeck01.nif,BA2106349EF782A8
-39 Dungeons 3D Ropes and Glorious Scaffolding/textures/dungeons/imperial/impwood01.dds,A2DBBD44628EA198
-39 Dungeons 3D Ropes and Glorious Scaffolding/textures/dungeons/imperial/impwood01_n.dds,EE7A6843B8D8BA02
-39 Dungeons 3D Ropes and Glorious Scaffolding/textures/dungeons/mines/minewood01.dds,A2DBBD44628EA198
-39 Dungeons 3D Ropes and Glorious Scaffolding/textures/dungeons/mines/minewood01_n.dds,EE7A6843B8D8BA02
-40 Furniture Chests/meshes/clutter/containers/chestopen01.nif,E3620D88EB5B2A31
-40 Furniture Chests/meshes/clutter/upperclass/upperchest01.nif,C6B622B738C306DC
-41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugr01.nif,A4C8361A4B7F4261
-41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugr02.nif,9CD0FA6B406B6628
-41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugr03.nif,1D228ABDC55B741A
-41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugr04.nif,6182456D732D8B7D
-41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugr05.nif,F0F35021E0DE28E1
-41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugr06.nif,94BC63352B34835D
-41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugrwrapped01.nif,D148D056600F69C8
-41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugrwrapped02.nif,11A94358F063B611
-42 Furniture Noble/meshes/furniture/noble/noblechair01.nif,E42D429399739756
-42 Furniture Noble/meshes/furniture/noble/noblechair02.nif,A5E7F4DB072378ED
-44 Poor Coffin Custom Texture/meshes/furniture/noble/scoffinpoor.nif,4286C7A19B372745
-45 Hanging Rings/meshes/clutter/deadanimals/hanginganimals01.nif,7C9EBEDDAFCE3E11
-45 Hanging Rings/meshes/clutter/deadanimals/hanginganimals02.nif,1A6546232F287C87
-45 Hanging Rings/meshes/clutter/deadanimals/hanginganimals03.nif,A821DE4087B0EC2A
-45 Hanging Rings/meshes/clutter/deadanimals/hanginganimalsring01.nif,B592BE212485FE6B
-45 Hanging Rings/meshes/clutter/deadanimals/hanginganimalsring02.nif,6B97C9B5132D23BA
-46 Carriage Seats and Fixes/meshes/clutter/common/wagonwheel01.nif,61F69F7AAF49C756
-46 Carriage Seats and Fixes/meshes/clutter/helgen/burntrubblecart01.nif,6FB89BA855D3EB08
-46 Carriage Seats and Fixes/meshes/furniture/cart/cartfurndriver01.nif,C580E2939F1B6F4B
-46 Carriage Seats and Fixes/meshes/furniture/cart/cartfurnpassanger01.nif,1B3E3EE15019A0CE
-46 Carriage Seats and Fixes/meshes/furniture/cart/cartfurnstatic01.nif,90C2BECFFC684D8F
-46 Carriage Seats and Fixes/meshes/furniture/prisonercarriage/prisonercarriage01.nif,8819BF04FD86F16E
-46 Carriage Seats and Fixes/meshes/furniture/prisonercarriage/prisonercarriage01static.nif,D3AEF423899A84FD
-46 Carriage Seats and Fixes/meshes/furniture/prisonercarriage/prisonercarriagefurniture01.nif,BFCA3B24A8F85E50
-47 Juniper Tree/textures/smim/plants/smim_juniper_tree.dds,C9A8A05903FCC17F
-47 Juniper Tree/textures/smim/plants/smim_juniper_tree_n.dds,78C37FF1144FD718
-49 Tundra Tree/meshes/landscape/trees/tundradriftwood01.nif,97D1AF8457AEB8EC
-50 Dawnguard Soulcairn Bone Piles/meshes/dlc01/soulcairn/sc_bonepile01.nif,C524169F240A7832
-50 Dawnguard Soulcairn Bone Piles/meshes/dlc01/soulcairn/sc_bonepile02.nif,69E5951788F8404E
-50 Dawnguard Soulcairn Bone Piles/meshes/dlc01/soulcairn/sc_bonepile03.nif,C38185C3181C9C70
-50 Dawnguard Soulcairn Bone Piles/meshes/dlc01/soulcairn/sc_bonepile04.nif,D3A0D534617D12F
-50 Dawnguard Soulcairn Bone Piles/meshes/dlc01/soulcairn/sc_bonepile05.nif,CB9EB479E4EBC9B0
-50 Dawnguard Soulcairn Bone Piles/meshes/dlc01/soulcairn/sc_bonepile06.nif,5F73EE3FBA03C5F7
-50 Dawnguard Soulcairn Bone Piles/textures/dlc01/landscape/soulcairnbones01.dds,8D0E9BF6E51040F9
-50 Dawnguard Soulcairn Bone Piles/textures/dlc01/landscape/soulcairnbones01_n.dds,A89C0A65614B8653
-50 Dawnguard Soulcairn Bone Piles/textures/dlc01/soulcairn/scbonetile.dds,99ABFA4DC1309413
-50 Dawnguard Soulcairn Bone Piles/textures/dlc01/soulcairn/scbonetile_n.dds,45BCC69178C4A010
-51 Dawnguard Soulcairn Bone Piles (More Bones)/meshes/dlc01/soulcairn/sc_bonepile01.nif,74DC5FD390AB8EF2
-51 Dawnguard Soulcairn Bone Piles (More Bones)/meshes/dlc01/soulcairn/sc_bonepile02.nif,E323DA082F45A8C1
-51 Dawnguard Soulcairn Bone Piles (More Bones)/meshes/dlc01/soulcairn/sc_bonepile03.nif,CD0A5E98C5073ADC
-51 Dawnguard Soulcairn Bone Piles (More Bones)/meshes/dlc01/soulcairn/sc_bonepile04.nif,5AE45704D356FBFA
-51 Dawnguard Soulcairn Bone Piles (More Bones)/meshes/dlc01/soulcairn/sc_bonepile05.nif,71FA0C7D109D7D34
-51 Dawnguard Soulcairn Bone Piles (More Bones)/meshes/dlc01/soulcairn/sc_bonepile06.nif,2B98CA70E027F55C
-52 Dawnguard Soulcairn Bone Piles (White Bones)/textures/dlc01/landscape/soulcairnbones01.dds,61986AEABE168D02
-52 Dawnguard Soulcairn Bone Piles (White Bones)/textures/dlc01/soulcairn/scbonetile.dds,290DE04B4EB4D8B9
-55 Windmills Base Vanilla Version/meshes/architecture/solitude/swindmill.nif,39682ED62CF305E3
-55 Windmills Base Vanilla Version Sails/meshes/architecture/solitude/swindmill.nif,C65180D771888B66
-56 Windmills SkyMills Compatibility/meshes/architecture/solitude/swindmillrotor.nif,AA908F85B8380CA8
-56 Windmills SkyMills Compatibility Sails/meshes/architecture/solitude/swindmillrotor.nif,2F6728AEC8901E78
-57 Ruins Sarcophagus/meshes/clutter/ruins/ruinsfurniturerubble01.nif,AE3ABB0B998C8E23
-57 Ruins Sarcophagus/meshes/clutter/ruins/ruinsfurniturerubble02.nif,E5A4973F93BDB687
-57 Ruins Sarcophagus/meshes/clutter/ruins/ruinssarcophagusvert01.nif,FEE203E10803A06
-57 Ruins Sarcophagus/meshes/clutter/ruins/ruinssarcophagusvert02.nif,110F6B002E70E3BB
-57 Ruins Sarcophagus/meshes/clutter/ruins/ruinssarcophagusvert03.nif,3CD1D6124D8A1514
-57 Ruins Sarcophagus/meshes/clutter/ruins/ruinssarcophagusverthole.nif,D41648FC7FF8B830
-57 Ruins Sarcophagus/meshes/clutter/ruins/ruinssarcophagus_bottom01.nif,DF831B0EEEA3B83A
-57 Ruins Sarcophagus/meshes/clutter/ruins/ruinssarcophagus_top01.nif,30CFE5DC741752F5
-58 Jewelry Rings/meshes/armor/amuletsandrings/goldringdiamondgo.nif,CFF346E90E6F6B4E
-58 Jewelry Rings/meshes/armor/amuletsandrings/goldringdiamond_1.nif,2CA60FAA4BC36288
-58 Jewelry Rings/meshes/armor/amuletsandrings/goldringemeraldgo.nif,E691D66A62BD5A13
-58 Jewelry Rings/meshes/armor/amuletsandrings/goldringemerald_1.nif,8C721CA7A1F71433
-58 Jewelry Rings/meshes/armor/amuletsandrings/goldringgo.nif,8F176E050421E089
-58 Jewelry Rings/meshes/armor/amuletsandrings/goldringsapphirego.nif,4826BBC74EF00800
-58 Jewelry Rings/meshes/armor/amuletsandrings/goldringsapphire_1.nif,28BA7B6A563D66D7
-58 Jewelry Rings/meshes/armor/amuletsandrings/goldring_1.nif,6F0463642E8B020E
-58 Jewelry Rings/meshes/armor/amuletsandrings/silverringamethystgo.nif,C7B2C0FFB7A39225
-58 Jewelry Rings/meshes/armor/amuletsandrings/silverringamethyst_1.nif,9917B5ED30275575
-58 Jewelry Rings/meshes/armor/amuletsandrings/silverringgarnetgo.nif,6520008466E9592B
-58 Jewelry Rings/meshes/armor/amuletsandrings/silverringgarnet_1.nif,67188253873B7420
-58 Jewelry Rings/meshes/armor/amuletsandrings/silverringgo.nif,80DE76243493DB4E
-58 Jewelry Rings/meshes/armor/amuletsandrings/silverringrubygo.nif,C4067321557BF2AF
-58 Jewelry Rings/meshes/armor/amuletsandrings/silverringruby_1.nif,7C98FFAB0B26414F
-58 Jewelry Rings/meshes/armor/amuletsandrings/silverring_1.nif,C1EFD83C141FA953
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingAmethystGo.nif,DCDF95E46F85496F
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingAmethyst_1.nif,CEF6D35DF264AF16
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingDiamondGo.nif,9A397544A8AF891A
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingDiamond_1.nif,B70A811F0B7A18F7
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingEmeraldGo.nif,18B0D1F74A910688
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingEmerald_1.nif,D3045200C6E410F
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingGarnetGo.nif,A57DEBC4C2EB7140
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingGarnet_1.nif,E9945A5358C9D13C
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingGo.nif,27F407410AEAF67F
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingOnyxGo.nif,1AE23BBC28CAFC35
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingOnyx_1.nif,562B8601E89A27E7
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingRubyGo.nif,685337B1634D9E30
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingRuby_1.nif,7A43504F8618987F
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingSapphireGo.nif,1977F7F39ACD8EDE
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingSapphire_1.nif,472D0F8E81A0A029
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingTopazGo.nif,B75B9460E816C64D
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingTopaz_1.nif,483341B3F033553E
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRing_1.nif,D549E886509E6828
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingAmethystGo.nif,3D44714EFF2BC9D8
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingAmethyst_1.nif,D35D2C99C7837C6F
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingGarnetGo.nif,162B13CCE9D26ED
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingGarnet_1.nif,E3224E4D3CDC76AF
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingOnyxGo.nif,A93E7D08E72360E4
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingOnyx_1.nif,5F4A1AD7243F90C8
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingRubyGo.nif,E5FDAEDBB41B165C
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingRuby_1.nif,300E943AC075336D
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingTopazGo.nif,FAEBF4E7C93A8B50
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingTopaz_1.nif,186915E321CAAF37
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingAmethystGo.nif,F9DDEF4952DB3E50
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingAmethyst_1.nif,81D978AE2DB56EBE
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingDiamondGo.nif,19F220371E1782DB
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingDiamond_1.nif,7491984DC0694FE4
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingEmeraldGo.nif,730C85495C6F2ADF
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingEmerald_1.nif,1A3ADD64E4B071AA
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingGarnetGo.nif,B94FDA1C7AC1486B
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingGarnet_1.nif,276A256A97BA6F51
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingGo.nif,E881187C8724C9F9
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingOnyxGo.nif,2A5A08DD8EFAFF7D
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingOnyx_1.nif,31DD077FAC10BAAC
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingRubyGo.nif,14ACC6C201F604E5
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingRuby_1.nif,405D8114D5B3878C
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingSapphireGo.nif,22FB7D283CD22A76
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingSapphire_1.nif,B37989311AA9C744
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingTopazGo.nif,FC245F90E61D4211
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingTopaz_1.nif,B37989311AA9C744
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRing_1.nif,AD9E097F1A4B447A
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingDiamondGo.nif,84039BEF08F0B40A
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingDiamond_1.nif,C0A2726BF7562F37
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingEmeraldGo.nif,A07B886840560BA4
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingEmerald_1.nif,BE938BE6449AF8BC
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingOnyxGo.nif,3F004530CC0AB893
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingOnyx_1.nif,8A16CC846F67C54F
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingSapphireGo.nif,B1DBBEB4AACDC6E0
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingSapphire_1.nif,2A6303788A48441A
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingTopazGo.nif,B8FD9F89CB73C9CD
-59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingTopaz_1.nif,EA14D8DA80F98E53
-60 Hearthfires Stuff/meshes/_byoh/loadsscreens/loadscreenadoptionboy01.nif,577D56FE2724E929
-60 Hearthfires Stuff/meshes/_byoh/loadsscreens/loadscreenadoptiongirl01.nif,3CBD17936477E29D
-61 Bowl Ingredients/meshes/clutter/ingredients/bonemeal01.nif,887C47F486E63F00
-61 Bowl Ingredients/meshes/clutter/ingredients/ectoplasm.nif,51E98FEEBD63434C
-61 Bowl Ingredients/meshes/clutter/ingredients/glowdust01.nif,8732105A681592DD
-61 Bowl Ingredients/meshes/clutter/ingredients/mammothcheesebowl.nif,DB53B8E842BA8BA
-61 Bowl Ingredients/meshes/clutter/ingredients/moonsugar01.nif,2E9C7B62FC0AA249
-61 Bowl Ingredients/meshes/clutter/ingredients/powderedmammothtusk.nif,E2C4B86875796836
-61 Bowl Ingredients/meshes/clutter/ingredients/saltpile.nif,526753D782047D9A
-61 Bowl Ingredients/meshes/clutter/ingredients/sap.nif,54FA60662516BC5
-61 Bowl Ingredients/meshes/clutter/ingredients/stew.nif,30ACC4DDD790889E
-61 Bowl Ingredients/meshes/clutter/ingredients/trollfat01.nif,4662E79A5486E9D
-61 Bowl Ingredients/meshes/clutter/ingredients/vampiredust.nif,216ECF053F4CED6B
-70 Rabbit/meshes/clutter/deadanimals/hangingrabbit01.nif,65E65545568B9ACB
-70 Rabbit/meshes/clutter/deadanimals/hangingrabbit02.nif,CFE41024E3A698F7
-71 Candelabras Sconces Walltorches/meshes/clutter/common/torchpermanent01.nif,6A4607B06106AF67
-71 Candelabras Sconces Walltorches/meshes/clutter/common/torchpermanentoff.nif,F82A6235D6136777
-71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impbrazier01.nif,A6C947BBD7339836
-71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impcandelabracandle01.nif,A87421662E4C29DF
-71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impcandelabracandle02.nif,848AD65BF0B3FF06
-71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impcandelabracandleoff01.nif,E5FE4A9FF8501B17
-71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impcandelabranocandle.nif,C46ABC27D930339B
-71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impcandle01.nif,C91C2AE731076069
-71 Candelabras Sconces Walltorches/meshes/clutter/imperial/imperialwallshackle01.nif,D7273DBC2BB31D77
-71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impwallsconce02candleoff01.nif,E8DC2A2B7768D660
-71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impwallsconce02candleon01.nif,51182370AB4300C4
-71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impwallsconce02nocandle01.nif,47762237BF064BE4
-71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impwallsconcecandle01.nif,87B64F8F02064D3B
-71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impwallsconcecandle02.nif,69EEB5FC9361202B
-71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impwallsconcecandleoff01.nif,D9AB7A3EA0742BB1
-71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impwallsconcenocandle01.nif,1BD0F9035FBC81F2
-71 Candelabras Sconces Walltorches/meshes/traps/pressureplatemetal/trappressureplatemetal01.nif,303B53FF6A7C63B9
-71 Candelabras Sconces Walltorches/textures/smim/candles/candles01.dds,36D9D5EAD48714CC
-71 Candelabras Sconces Walltorches/textures/smim/candles/candles01_g.dds,CFAD1913638FEEB6
-71 Candelabras Sconces Walltorches/textures/smim/candles/candles01_n.dds,EA8228DA6595E530
-72 Chandeliers/meshes/clutter/imperial/impchandelliercandle01.nif,5EC8BC5895D4FC37
-72 Chandeliers/meshes/clutter/imperial/impchandelliercandle02.nif,ABF9B19341E9E2B5
-72 Chandeliers/meshes/clutter/imperial/impchandelliercandle03.nif,48D7CB5BFD174B38
-72 Chandeliers/meshes/clutter/imperial/impchandelliercandleoff.nif,824D0B8B39F4B75E
-72 Chandeliers/meshes/clutter/imperial/impchandellierextension.nif,5C1BA1733D106B7E
-72 Chandeliers/meshes/clutter/imperial/impchandelliernocandle01.nif,C65E9B9FE7B09D36
-72 Chandeliers/textures/smim/candles/candles01.dds,36D9D5EAD48714CC
-72 Chandeliers/textures/smim/candles/candles01_g.dds,CFAD1913638FEEB6
-72 Chandeliers/textures/smim/candles/candles01_n.dds,EA8228DA6595E530
-73 Chandeliers No 3D Chains Addon/meshes/clutter/imperial/impchandelliercandle01.nif,F951792791B78314
-73 Chandeliers No 3D Chains Addon/meshes/clutter/imperial/impchandelliercandle02.nif,7EEEA262A8327A16
-73 Chandeliers No 3D Chains Addon/meshes/clutter/imperial/impchandelliercandle03.nif,671F01AB46A07BC
-73 Chandeliers No 3D Chains Addon/meshes/clutter/imperial/impchandelliercandleoff.nif,382637D7F54A80FA
-73 Chandeliers No 3D Chains Addon/meshes/clutter/imperial/impchandellierextension.nif,B3576986B3FF0674
-73 Chandeliers No 3D Chains Addon/meshes/clutter/imperial/impchandelliernocandle01.nif,724D6956E6E6ACAF
-80 Half-Sized Textures/textures/actors/skeleton/skeleton.dds,2D4298367EA29491
-80 Half-Sized Textures/textures/actors/skeleton/skeleton_n.dds,2E5C434A5D0F93DC
-80 Half-Sized Textures/textures/clutter/common/dresser01.dds,F0D54E0F86812FAF
-80 Half-Sized Textures/textures/clutter/common/dresser01_n.dds,D7FAA797CC70197E
-80 Half-Sized Textures/textures/clutter/deadanimals/rabbitmeatcooked.dds,9D34603A4651FDE5
-80 Half-Sized Textures/textures/clutter/ruins/ruinschest01snow.dds,91CDBD64CD40972F
-80 Half-Sized Textures/textures/clutter/ruins/smim_ruins_sarcophagus_parts.dds,98FBCAD49910B4AB
-80 Half-Sized Textures/textures/clutter/ruins/smim_ruins_sarcophagus_parts_n.dds,AF49D9BB5AFEAFFC
-80 Half-Sized Textures/textures/clutter/ruins/smim_ruins_sarcophagus_tub.dds,915A7B00571F6A52
-80 Half-Sized Textures/textures/clutter/ruins/smim_ruins_sarcophagus_tub_n.dds,2F04152ABB354528
-80 Half-Sized Textures/textures/clutter/stockade/stockadewood01.dds,FB6563027064FE68
-80 Half-Sized Textures/textures/clutter/stockade/stockadewood01snow.dds,8B587B6C8C2AE3B6
-80 Half-Sized Textures/textures/clutter/stockade/stockadewood01_n.dds,F83580C34898BED5
-80 Half-Sized Textures/textures/dungeons/imperial/impwood01.dds,3032B4970C9C5504
-80 Half-Sized Textures/textures/dungeons/imperial/impwood01_n.dds,CEB7ED796A23DEEA
-80 Half-Sized Textures/textures/dungeons/mines/minewood01.dds,3032B4970C9C5504
-80 Half-Sized Textures/textures/dungeons/mines/minewood01_n.dds,CEB7ED796A23DEEA
-80 Half-Sized Textures/textures/smim/clutter/barrel02.dds,8C64761AB7251690
-80 Half-Sized Textures/textures/smim/clutter/barrel02_n.dds,8F03B07019D4C42B
-80 Half-Sized Textures/textures/smim/clutter/barrel_smim_metal.dds,9B880E5ECCA83DE
-80 Half-Sized Textures/textures/smim/clutter/barrel_smim_metal_n.dds,62A8F59D93467CA
-80 Half-Sized Textures/textures/smim/clutter/barrel_smim_wood.dds,607B701947964DEE
-80 Half-Sized Textures/textures/smim/clutter/barrel_smim_wood_n.dds,6242BB64669261F8
-80 Half-Sized Textures/textures/smim/clutter/furniturewood01.dds,AAD234F4147870E1
-80 Half-Sized Textures/textures/smim/clutter/furniturewood01_n.dds,DBDC0BF8162D9953
-80 Half-Sized Textures/textures/smim/furniture/smim_wooden_chair.dds,2B298C5C6E663078
-80 Half-Sized Textures/textures/smim/furniture/smim_wooden_chair_n.dds,1514776ABA565281
-80 Half-Sized Textures/textures/smim/loadscreenart/smim_trollloadscreen_meat.dds,5FFAD8FB30E509F7
-80 Half-Sized Textures/textures/smim/loadscreenart/smim_trollloadscreen_meat_n.dds,C7651F136675BC01
-80 Half-Sized Textures/textures/smim/plants/potato01_properUVmap.dds,E393E2D39E44E60B
-80 Half-Sized Textures/textures/smim/plants/potato01_properUVmap_n.dds,9DBB1F5E4A72B840
-80 Half-Sized Textures/textures/smim/plants/smim_juniper_tree.dds,9E124AF5716FE27E
-80 Half-Sized Textures/textures/smim/plants/smim_juniper_tree_n.dds,C715B45A3A5F5B45
-80 Half-Sized Textures/textures/smim/traps/smim_trap_deadbolt.dds,4F9FC43DEF65148C
-80 Half-Sized Textures/textures/smim/traps/smim_trap_deadbolt_n.dds,3170B3E58D0FAE25
-81 Half-Sized Furniture Skyrim HD Appearance/textures/clutter/common/dresser01.dds,9FDECFE8AA94D687
-81 Half-Sized Furniture Skyrim HD Appearance/textures/clutter/common/dresser01_n.dds,AA0C4AD3DEE5C171
-81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/clutter/common/dresser01.dds,4904E15C65643314
-81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/clutter/common/dresser01_n.dds,C791950501C8249E
-90 Ultra-Sized Textures/textures/smim/furniture/smim_wooden_chair.dds,AC7B9246B7A1A8F5
-90 Ultra-Sized Textures/textures/smim/furniture/smim_wooden_chair_n.dds,D20834C3B33773F
-90 Ultra-Sized Textures/textures/smim/loadscreenart/smim_trollloadscreen_meat.dds,ACE0F7EF6153A2A4
-90 Ultra-Sized Textures/textures/smim/loadscreenart/smim_trollloadscreen_meat_n.dds,B5A4E0FC725E31E0
-90 Ultra-Sized Textures/textures/smim/plants/smim_juniper_tree.dds,ABAB4C342A75365F
-90 Ultra-Sized Textures/textures/smim/plants/smim_juniper_tree_n.dds,4319AE5359E9C1B7
-00 Core/meshes/architecture/farmhouse/interior/basement - Shortcut.lnk,A8106A400220D6A8
-00 Core/meshes/architecture/farmhouse/interior/farmint2basementent01.nif,5BB3DCA6BF93C3FC
-00 Core/meshes/architecture/farmhouse/interior/farmint2doorway02nodoor.nif,53C19F42C1AF4F39
-00 Core/meshes/architecture/farmhouse/interior/farmint2doorway03.nif,25B0C93012AC43F8
-00 Core/meshes/architecture/farmhouse/interior/farmint2doorway04.nif,EC46593853023DA
-00 Core/meshes/architecture/farmhouse/interior/farmint2end01.nif,EE790B9F626DBC3C
-00 Core/meshes/architecture/farmhouse/interior/farmint2end02.nif,27E12E5D35ADD3FB
-00 Core/meshes/architecture/farmhouse/interior/farmint2end03.nif,B48DAFD01B67D9D9
-00 Core/meshes/architecture/farmhouse/interior/farmint2hearth02.nif,60E3F326BA4A0F2A
-00 Core/meshes/architecture/farmhouse/interior/farmint2wall01.nif,57E925339403776B
-00 Core/meshes/architecture/farmhouse/interior/farmintcorner01.nif,EDD54F510DD17D86
-00 Core/meshes/architecture/farmhouse/interior/farmintdoorway01.nif,F916BC4D9EB1ED6
-00 Core/meshes/architecture/farmhouse/interior/farmintend01.nif,C2084C9B3AFA4E4E
-00 Core/meshes/architecture/farmhouse/interior/farmintend02.nif,C4DAC9085E8A4384
-00 Core/meshes/architecture/farmhouse/interior/farmintend03.nif,4479668BA6122004
-00 Core/meshes/architecture/farmhouse/interior/farmintinnend01.nif,3C672480511FF580
-00 Core/meshes/architecture/farmhouse/interior/farmintinnend02.nif,B3431BD77AFD12FC
-00 Core/meshes/architecture/farmhouse/interior/farmintinnend03.nif,211C8DC2DCFCF502
-00 Core/meshes/architecture/farmhouse/interior/farmintinnend04.nif,EE14095105935E44
-00 Core/meshes/architecture/farmhouse/interior/farmintinnend05.nif,A78B2B23A5FF2DCE
-00 Core/meshes/architecture/farmhouse/interior/farmintinnend06.nif,4276AA21C4CF8E29
-00 Core/meshes/architecture/farmhouse/interior/farmintinnwall01.nif,188932B388300414
-00 Core/meshes/architecture/farmhouse/interior/farmintinnwallentrance01.nif,2CC5EF95770FC43E
-00 Core/meshes/architecture/farmhouse/interior/farmintlhback01.nif,B9278D6C5F93ED24
-00 Core/meshes/architecture/farmhouse/interior/farmintlhend01.nif,8734BC172C627DB4
-00 Core/meshes/architecture/farmhouse/interior/farmintlhend02.nif,6C5B89208425BE6D
-00 Core/meshes/architecture/farmhouse/interior/farmintlhfirepit01.nif,97622DDDC06E166B
-00 Core/meshes/architecture/farmhouse/interior/farmintlhfirepit03.nif,1672891C7D2620A1
-00 Core/meshes/architecture/farmhouse/interior/farmintlhfront01.nif,97B41BA959BBBD57
-00 Core/meshes/architecture/farmhouse/interior/farmintlhloft01.nif,5EDB8F6DDC83CA6A
-00 Core/meshes/architecture/farmhouse/interior/farmintlhloft02.nif,58B4FCFD7592B90
-00 Core/meshes/architecture/farmhouse/interior/farmintlhlofttop01.nif,C24BFD555BCDBCC8
-00 Core/meshes/architecture/farmhouse/interior/farmintlhmid01.nif,A3AA93972104DED8
-00 Core/meshes/architecture/farmhouse/interior/farmintwall01.nif,EA1A190648305E2A
-00 Core/meshes/architecture/farmhouse/interior/farmintwallhearth01.nif,9FE475C059273CE8
-00 Core/meshes/architecture/farmhouse/interior/farmintwallhearth02.nif,87284E7CAB8A3C7D
-00 Core/meshes/architecture/farmhouse/interior/farmintwbasementent01.nif,CC5BCE7C4A746CC7
-00 Core/meshes/architecture/farmhouse/interior/farmintwooddoorway01.nif,DD5148E501BE2DB1
-00 Core/meshes/architecture/farmhouse/interior/farmintwoodend01.nif,7B9E6E123163D26C
-00 Core/meshes/architecture/farmhouse/interior/farmintwoodend02.nif,630B2A1C269FC647
-00 Core/meshes/architecture/farmhouse/interior/farmintwoodwall01.nif,D683AFC917D8FC1
-00 Core/meshes/architecture/farmhouse/rubble/farmhousebrubble01.nif,90DCF046F08AB4F9
-00 Core/meshes/architecture/farmhouse/walkway/walkway01.nif,27B6C77FAA4D6EB8
-00 Core/meshes/architecture/farmhouse/walkway/walkway02.nif,3610CBBB6314AD4C
-00 Core/meshes/architecture/farmhouse/walkway/walkwaybend01.nif,1488F105BA0FD0BD
-00 Core/meshes/architecture/farmhouse/walkway/walkwaybend02.nif,96B7EB6E7050AF8F
-00 Core/meshes/architecture/farmhouse/walkway/walkwaybend03.nif,E5D778B13BF29A0E
-00 Core/meshes/architecture/farmhouse/walkway/walkwayc01.nif,D08CC391B7B9CA73
-00 Core/meshes/architecture/farmhouse/walkway/walkwaycend01.nif,D5AAAFDBBC5AC9ED
-00 Core/meshes/architecture/farmhouse/walkway/walkwaycend02.nif,8AA41AFE7B16E220
-00 Core/meshes/architecture/farmhouse/walkway/walkwaycentwall01.nif,D8AE00B27F53EB73
-00 Core/meshes/architecture/farmhouse/walkway/walkwaycentwall02.nif,A84C08DAE30CAF57
-00 Core/meshes/architecture/farmhouse/walkway/walkwaycwall01.nif,41734632FEC85F33
-00 Core/meshes/architecture/farmhouse/walkway/walkwaycwallend01.nif,787BCDDECCAC3250
-00 Core/meshes/architecture/farmhouse/walkway/walkwaycwallend02.nif,3E3706562B596A2A
-00 Core/meshes/architecture/farmhouse/walkway/walkwaycwallend03.nif,11BE387772DC816
-00 Core/meshes/architecture/farmhouse/walkway/walkwaycwallend04.nif,125311D3CF7A9336
-00 Core/meshes/architecture/farmhouse/walkway/walkwaycwallgate01.nif,BEE934405A9B4D78
-00 Core/meshes/architecture/farmhouse/walkway/walkwaycwallgate02.nif,B4D6CF9BB35F5A67
-00 Core/meshes/architecture/farmhouse/walkway/walkwayend01.nif,362F8078F24CE4C0
-00 Core/meshes/architecture/farmhouse/walkway/walkwayfull01.nif,D005E5072297F432
-00 Core/meshes/architecture/farmhouse/walkway/walkwayfull02.nif,CF09D272CF3099B5
-00 Core/meshes/architecture/farmhouse/walkway/walkwayfull03.nif,D6CA219CD7AD48DC
-00 Core/meshes/architecture/farmhouse/walkway/walkwayramp01.nif,9E2BA187374CD4F
-00 Core/meshes/architecture/farmhouse/walkway/walkwayrend01.nif,19A07A636363F585
-00 Core/meshes/architecture/farmhouse/walkway/walkwaystairs1.nif,FA3773C281852501
-00 Core/meshes/architecture/farmhouse/walkway/walkwaystairs15.nif,E1885CBEC16FE7ED
-00 Core/meshes/architecture/farmhouse/walkway/walkwaystairs3.nif,48CC50B675C7B8C7
-00 Core/meshes/architecture/farmhouse/walkway/walkwaystairs4.nif,5CB2D5EC50BD65C3
-00 Core/meshes/architecture/farmhouse/walkway/walkwaystairs8.nif,FDCEA87754889AF5
-00 Core/meshes/architecture/solitude/farms/slumbermill01.nif,EA17DBEB6B69D9BB
-00 Core/meshes/architecture/solitude/interiors/slgdarchfire02.nif,C0220EE4967400F9
-00 Core/meshes/architecture/whiterun/wrbuildings/wrcastleentrance01.nif,CE30051BDBFB94C2
-00 Core/meshes/architecture/whiterun/wrbuildings/wrcastlemainbuilding01.nif,5E423A559A686FA3
-00 Core/meshes/architecture/whiterun/wrbuildings/wrcastlestonetowertop01.nif,CC1E9C4451D99295
-00 Core/meshes/architecture/whiterun/wrbuildings/wrmarketstand01.nif,D7F8C207CCB0B36C
-00 Core/meshes/architecture/whiterun/wrbuildings/wrmarketstand03.nif,ABF050F043DAB799
-00 Core/meshes/architecture/whiterun/wrbuildings/wrmarketstand03destroyed.nif,2065D2A98022A494
-00 Core/meshes/architecture/whiterun/wrbuildings/wrtempleofk01.nif,883C40326F6258B4
-00 Core/meshes/architecture/whiterun/wrinteriors/wrintfreewallcolumwall01.nif,8701DAAC1B94CB1A
-00 Core/meshes/architecture/whiterun/wrinteriors/wrintroofwall03.nif,85B337CE2DE803B8
-00 Core/meshes/architecture/whiterun/wrscaffold/wrscafguardtower01.nif,C2A5B74BEBD7646C
-00 Core/meshes/architecture/whiterun/wrscaffold/wrscafguardtower02.nif,873EFCD02C6A6695
-00 Core/meshes/architecture/whiterun/wrscaffold/wrscafguardtowerlarge01.nif,9414401FA9059423
-00 Core/meshes/architecture/whiterun/wrscaffold/wrscafguardtowerspikes01.nif,51F8323E4211970A
-00 Core/meshes/architecture/whiterun/wrscaffold/wrscafrailcor01.nif,E63A359B00DCCCF9
-00 Core/meshes/architecture/whiterun/wrscaffold/wrscafrailstr01.nif,B005385F5FF1A133
-00 Core/meshes/architecture/whiterun/wrscaffold/wrscafstr01spikes.nif,3DE022CAB1BAF6A2
-00 Core/meshes/architecture/whiterun/wrterrain/wrmainroadmarket.nif,D9A1BD8AB90E867
-00 Core/meshes/architecture/whiterun/wrterrain/wrstairsplatform01.nif,FB13A87B2839FBE1
-00 Core/meshes/architecture/whiterun/wrterrain/wrterwind01.nif,12C01701034E91E4
-00 Core/meshes/architecture/whiterun/wrterrain/wrtreecircle01.nif,F202FAA4A453A205
-00 Core/meshes/dlc01/clutter/vampirecoffinhoriz/vampirecoffinhoriz01.nif,F4EE62A53AB6A09D
-00 Core/meshes/dlc01/clutter/vampirecoffinhoriz/vampirecoffinhoriz02.nif,A5D797A40CC8CFD2
-00 Core/meshes/dlc01/landscape/rocks/dlc01rockcaveentrance01.nif,EAA5EE8BA65352C1
-00 Core/meshes/dungeons/dwemer/clutter/dwecenturionbust01.nif,95AC05E7282CA86F
-00 Core/meshes/dungeons/dwemer/facades/dwefacadeliftdown01.nif,817F8D58175EC54A
-00 Core/meshes/dungeons/dwemer/facades/dwefacadeliftup01.nif,A3F480EA48C88B2E
-00 Core/meshes/dungeons/imperial/clutterkits/impfloorchunk01.nif,AA970DF40FFDDC5C
-00 Core/meshes/dungeons/imperial/clutterkits/impfloorchunk02.nif,D882A0725CE0D158
-00 Core/meshes/dungeons/imperial/clutterkits/imprubblepiece01.nif,7AC6CA71A2AA6BEE
-00 Core/meshes/dungeons/imperial/clutterkits/imprubblepiece02.nif,ED88FE5E95542B50
-00 Core/meshes/dungeons/imperial/clutterkits/imprubblepiece03.nif,610DBBB0AC7F6E0B
-00 Core/meshes/dungeons/imperial/clutterkits/imprubblepiece04.nif,A029F6CE63E6D36F
-00 Core/meshes/dungeons/imperial/clutterkits/imprubblepiece05.nif,CD4C3A4F0B114A74
-00 Core/meshes/dungeons/imperial/clutterkits/imprubblepile01.nif,1CE7628838F60F84
-00 Core/meshes/dungeons/imperial/clutterkits/imprubblepile02.nif,8F366F36E64522DE
-00 Core/meshes/dungeons/imperial/clutterkits/imprubblepile03.nif,3F5F8B23A9EDB09E
-00 Core/meshes/dungeons/imperial/clutterkits/imprubblepile04.nif,8ABD33503C73BEF7
-00 Core/meshes/dungeons/imperial/clutterkits/imprubblepile05.nif,9DAE60BB410F273
-00 Core/meshes/dungeons/mines/caveroom/minecroomdoor03.nif,E98E4B869C679C03
-00 Core/meshes/dungeons/mines/cavesmallhall/minechall2way02.nif,5EBCCD0DA5B45D17
-00 Core/meshes/dungeons/mines/cavesmallhall/minechall2way02c.nif,1DF52482F4F866E4
-00 Core/meshes/dungeons/mines/cavesmallwall/minecwalldoor01.nif,7D33A7677774C29B
-00 Core/meshes/dungeons/mines/cavewall/mineclewalldoor01.nif,5CAE2F98539B0E85
-00 Core/meshes/dungeons/mines/cavewall/mineclwalldoor01.nif,2E52C64450FF5B9D
-00 Core/meshes/dungeons/mines/cliffs/minecliffs01.nif,7B946B0A20A26D00
-00 Core/meshes/dungeons/mines/cliffs/minecliffs02.nif,324E51D321D2FB44
-00 Core/meshes/dungeons/mines/cliffs/minecliffs03.nif,79A10DC60AE38B98
-00 Core/meshes/dungeons/mines/cliffs/minecliffs03ns.nif,EDE41C8D8E2953E1
-00 Core/meshes/dungeons/mines/cliffs/minecliffscornerin01.nif,E9FADC3F15AB3577
-00 Core/meshes/dungeons/mines/cliffs/minecliffscornerin01ns.nif,521DC61FEA7A6A3F
-00 Core/meshes/dungeons/mines/cliffs/minecliffscornerout01.nif,A81C3FB81139E549
-00 Core/meshes/dungeons/mines/cliffs/minecliffscornerout01ns.nif,10798E1A9A39A3CE
-00 Core/meshes/dungeons/mines/cliffs/minecliffsisland01.nif,CC35B707CCF74614
-00 Core/meshes/dungeons/mines/cliffs/minecliffsisland01ns.nif,83A193DBFF4FF405
-00 Core/meshes/dungeons/mines/clutter/genericwell01.nif,95EB47FABC491BBE
-00 Core/meshes/dungeons/mines/minelargehall/minelhall4way01.nif,DE16D85641EA430E
-00 Core/meshes/dungeons/mines/minelargehall/minelhallentrance01.nif,3C6AE89D12254B15
-00 Core/meshes/dungeons/mines/minelargehall/minelhallentrance02.nif,7C3B0821A2336B2B
-00 Core/meshes/dungeons/mines/ore/ingotdwarven.nif,41A3926F1E7A5095
-00 Core/meshes/dungeons/mines/ore/ingotgold.nif,24C33FF6E115448F
-00 Core/meshes/dungeons/mines/rocks/minecboulderl02.nif,66213A095648EE8E
-00 Core/meshes/dungeons/mines/scaffolding/minescaffoldbridge01.nif,8580F8A7D572D028
-00 Core/meshes/dungeons/mines/scaffolding/minescaffoldbridge02.nif,3D458DFB7C0BFDC0
-00 Core/meshes/dungeons/mines/scaffolding/minescaffoldbridge03.nif,347C98834086B7C6
-00 Core/meshes/dungeons/mines/scaffolding/minescaffoldbridge04.nif,7978FFB73AAC576F
-00 Core/meshes/dungeons/nordic/exterior/nortmpextplanter01.nif,2AE60BBAC1DFB823
-00 Core/meshes/dungeons/nordic/exterior/nortmpextplattower01.nif,FB63B82B74CB522E
-00 Core/meshes/dungeons/nordic/exterior/nortmpextplattower02.nif,18178EA66F52AB1F
-00 Core/meshes/dungeons/nordic/platforms/norplatbgcordblend01.nif,8C22774D5C2365D6
-00 Core/meshes/dungeons/nordic/rubble/norrubblepile01.nif,E0E9FD60179BA5A3
-00 Core/meshes/dungeons/nordic/rubble/norrubblepile02.nif,73A5D71609222785
-00 Core/meshes/dungeons/nordic/rubble/norrubblepile03.nif,45550675D46AA7E
-00 Core/meshes/dungeons/nordic/rubble/norrubblepile04.nif,3004D57B378A10BD
-00 Core/meshes/dungeons/nordic/rubble/norrubblepile06.nif,B350AD8FC695D590
-00 Core/meshes/dungeons/nordic/rubble/norrubblepile07.nif,A251C890D713DBDE
-00 Core/meshes/dungeons/nordic/rubble/norrubblepile08.nif,371A4348B9BAAD17
-00 Core/meshes/landscape/rocks/wetrocks/rockl01wet.nif,CCED600D06C5A1EE
-00 Core/meshes/landscape/rocks/wetrocks/rockl04wet.nif,7DD0C1CA380B757E
-00 Core/meshes/landscape/rocks/wetrocks/rockm03wet.nif,46865651B9938B42
-00 Core/meshes/landscape/rocks/wetrocks/rockpilem02wet.nif,206876EAD1DEC15C
-00 Core/textures/smim/architecture/farmhouse/farmhouse_int_jaillock.dds,3EBB9D196B6921F3
-00 Core/textures/smim/architecture/farmhouse/farmhouse_int_jaillock_n.dds,C060B1C9BC5BED5F
-00 Core/textures/smim/architecture/farmhouse/metalwork01_jailring.dds,D6F23A28A4BFBDE1
-00 Core/textures/smim/architecture/farmhouse/metalwork01_jailring_n.dds,553FCF5E0628A21A
-00 Core/textures/smim/architecture/whiterun/metalwork01_drawbridge.dds,D6F23A28A4BFBDE1
-00 Core/textures/smim/architecture/whiterun/metalwork01_drawbridge_n.dds,553FCF5E0628A21A
-00 Core/textures/smim/architecture/whiterun/wrstockade_properwood.dds,7A681A431BD6082D
-00 Core/textures/smim/architecture/whiterun/wrstockade_properwood_n.dds,856AA25E82E3C988
-00 Core/textures/smim/architecture/whiterun/wrwoodplanks_512_tiling.dds,F322297F45FE959F
-00 Core/textures/smim/architecture/whiterun/wrwoodplanks_512_tiling_n.dds,F8FE9AC43C05250
-00 Core/textures/smim/clutter/charcoal/charcoal01.dds,6F330C055916777B
-00 Core/textures/smim/clutter/charcoal/charcoal01_n.dds,B224234A28240FFF
-00 Core/textures/smim/clutter/common/archery_target_wood.dds,D18B30138085A711
-00 Core/textures/smim/clutter/common/archery_target_wood_n.dds,154A80FBC170BD1D
-00 Core/textures/smim/clutter/common/rope01_beige.dds,52E3642356D315CA
-00 Core/textures/smim/clutter/common/rope01_bright.dds,D913EE7BBE8BEBEC
-00 Core/textures/smim/clutter/common/rope01_midburn.dds,F5E79A5380CA2A8F
-00 Core/textures/smim/clutter/common/rope01_n.dds,86229CDF8C7822AB
-00 Core/textures/smim/clutter/common/smim_quill.dds,6B82BF2B69047ECC
-00 Core/textures/smim/clutter/common/smim_quill_n.dds,6C677520FB031327
-00 Core/textures/smim/clutter/ingredients/smim_dwarven_oil.dds,8702DB8C31EAE1A8
-00 Core/textures/smim/clutter/ingredients/smim_dwarven_oilspill.dds,4872A17FE6A3397F
-00 Core/textures/smim/clutter/ingredients/smim_dwarven_oilspill_n.dds,9ED2124174CC19A2
-00 Core/textures/smim/clutter/ingredients/smim_dwarven_oil_m.dds,DF25A5DD0073BF9
-00 Core/textures/smim/clutter/ingredients/smim_dwarven_oil_n.dds,521095F0ECD30E19
-00 Core/textures/smim/clutter/ingredients/smim_hagclaw.dds,3007096F671FF0C6
-00 Core/textures/smim/clutter/ingredients/smim_hagclaw_n.dds,350DFB5975298D79
-00 Core/textures/smim/clutter/ingredients/smim_sabrecat_tooth.dds,F1E9DD9AACDEF569
-00 Core/textures/smim/clutter/ingredients/smim_sabrecat_tooth_n.dds,AEED390189743245
-00 Core/textures/smim/clutter/quest/smim_giant_mortar.dds,EF35CBA95352D47A
-00 Core/textures/smim/clutter/quest/smim_giant_mortar_n.dds,D4F54FCFA5788C5C
-00 Core/textures/smim/clutter/ruins/ruinschest.dds,342538D715A871AA
-00 Core/textures/smim/clutter/ruins/ruinschestnails.dds,1C46182610707E90
-00 Core/textures/smim/clutter/ruins/ruinschestnails_n.dds,749C430F28F9A795
-00 Core/textures/smim/clutter/ruins/ruinschestsmall.dds,4D179227A74E70D5
-00 Core/textures/smim/clutter/ruins/ruinschestsmall_n.dds,E1560D62A839D3C3
-00 Core/textures/smim/clutter/ruins/ruinschest_n.dds,D3677362C369B1E4
-00 Core/textures/smim/clutter/ruins/smim_ruinspot01.dds,29AADB6FD2CD04BE
-00 Core/textures/smim/clutter/ruins/smim_ruinspot01_n.dds,B012CB4B932CFC4B
-00 Core/textures/smim/clutter/woodfires/smim_campfire_rocks.dds,27F53D9A543738A0
-00 Core/textures/smim/clutter/woodfires/smim_campfire_rocks_n.dds,2A8D9C11F30BC509
-00 Core/textures/smim/dungeons/dwemer/smim_dwemer_focus_rock.dds,FFBD845E45FA0FF9
-00 Core/textures/smim/dungeons/dwemer/smim_dwemer_focus_rock_n.dds,4ABF641CD2353958
-01 Furniture/meshes/architecture/whiterun/wrclutter/wrtemplebench01.nif,83DD0E2233B7A078
-01 Furniture/meshes/architecture/whiterun/wrclutter/wrtemplebench01static.nif,38E1D95CD2578401
-01 Furniture/meshes/clutter/common/commonshelfsecretdoor01/commonshelfsecretdoor01.nif,13BBC240AF073FC5
-01 Furniture/meshes/dungeons/riften/thievesguild/tgsecretdoor01.nif,F3C811730CB2CBDB
-01 Furniture/textures/smim/architecture/whiterun/smim_wr_bench.dds,F422456F91B317DC
-01 Furniture/textures/smim/architecture/whiterun/smim_wr_bench_n.dds,34197122FCFB462B
-01 Furniture/textures/smim/clutter/common/dresser01.dds,443FCF99DAD2F211
-01 Furniture/textures/smim/clutter/common/dresser01_n.dds,693B96D4EDB99CD3
-01 Furniture/textures/smim/clutter/common/Stump_Bottom_for_Furniture.dds,FF48EB31AB4E14BF
-01 Furniture/textures/smim/clutter/common/Stump_Bottom_for_Furniture_n.dds,2CDDC5DE9CDB11CC
-01 Furniture/textures/smim/clutter/common/Table_Leg_Bark.dds,6D9BBC55EF3B3EBD
-01 Furniture/textures/smim/clutter/common/Table_Leg_Bark_n.dds,471AACF7B7FA705D
-01 Furniture/textures/smim/clutter/common/Table_Leg_Bark_Seamless.dds,664272D497B20CD4
-01 Furniture/textures/smim/clutter/common/Table_Leg_Bark_Seamless_n.dds,BF4115D2470E188E
-01 Furniture/textures/smim/clutter/common/Table_Leg_Bark_Thin.dds,8ED2131440EFF2C2
-01 Furniture/textures/smim/clutter/common/Table_Leg_Bark_Thin_n.dds,66CED87FB58FDE92
-01 Furniture/textures/smim/clutter/common/Table_Wood_SinglePiece.dds,D1277B75CF5BBEA9
-01 Furniture/textures/smim/clutter/common/Table_Wood_SinglePiece_n.dds,52B16DD5FC457314
-01 Furniture/textures/smim/clutter/upperclass/smim_upper_bedpost.dds,42AD711376D9CB65
-01 Furniture/textures/smim/clutter/upperclass/smim_upper_bedpost_n.dds,E03D979E30F934C7
-01 Furniture/textures/smim/clutter/upperclass/smim_upper_bench_legs.dds,BDAAF1DCA9B58891
-01 Furniture/textures/smim/clutter/upperclass/smim_upper_bench_legs_n.dds,8D691D67A79CFDD8
-01 Furniture/textures/smim/clutter/upperclass/Stump_Bottom_for_FurnitureUC.dds,2C8CBE5F1AB287CF
-01 Furniture/textures/smim/clutter/upperclass/Stump_Bottom_for_FurnitureUC_n.dds,2CDDC5DE9CDB11CC
-01 Furniture/textures/smim/clutter/upperclass/Table_Leg_Bark_Thin.dds,E3F17ED5A7856C39
-01 Furniture/textures/smim/clutter/upperclass/Table_Leg_Bark_Thin_n.dds,D93E8C6B0D2195A6
-01 Furniture/textures/smim/clutter/upperclass/Table_Wood_SinglePiece.dds,2AB5152B4D10E11
-01 Furniture/textures/smim/clutter/upperclass/Table_Wood_SinglePiece_n.dds,52B16DD5FC457314
-03 Food/textures/smim/clutter/food/apple01_semi-circle-UV.dds,47F82715590F9764
-03 Food/textures/smim/clutter/food/apple01_semi-circle-UV_n.dds,AED2D3CC8C229673
-03 Food/textures/smim/clutter/food/apple02_semi-circle-UV.dds,78796FE12AA982AD
-03 Food/textures/smim/clutter/food/apple02_semi-circle-UV_n.dds,AED2D3CC8C229673
-03 Food/textures/smim/clutter/ingredients/tomato_smim.dds,C86985A0381BFDB5
-03 Food/textures/smim/clutter/ingredients/tomato_smim_n.dds,AA739FDE6A3449FE
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkway01.nif,B75DBA7450E1F6D1
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkway02.nif,F3B22BBB480085C3
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaybend01.nif,38EAFE817BD34110
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaybend02.nif,BEE0B76CD61BB7AD
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaybend03.nif,AA0ADCF267B30155
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwayc01.nif,BAC89D56E388FE66
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycend01.nif,F889D1B91D74CF09
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycend02.nif,3EFF3E7A412AD93C
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycentwall01.nif,CD9776AECF56D8DA
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycentwall02.nif,9A5ED120B26B9120
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycwall01.nif,4335D59F9FC1FC
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycwallend01.nif,87A9C3AE73B66C8B
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycwallend02.nif,E3D82C581E91B58E
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycwallend03.nif,237016C8AE8EF858
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycwallend04.nif,C7C20CBDDBC2EC43
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycwallgate01.nif,E77398296D823323
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycwallgate02.nif,F922441903947263
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwayend01.nif,2FBB9ECD86A03C14
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwayfull02.nif,C5A17194C0F3C2F5
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwayfull03.nif,A3D8A132015AC46D
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwayrend01.nif,ECBA7C1A8A16C0D
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaystairs1.nif,2DF96E5FB1585D19
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaystairs15.nif,7FE28B0D7D859F76
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaystairs3.nif,75ABF2B4C9D6C145
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaystairs4.nif,BB4105EB6B7FAFEC
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaystairs8.nif,A9C51EF2D755A700
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/solitude/farms/slumbermill01.nif,81A9B5EACFF9595C
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkway01.nif,FAA14ECD3FBE82CA
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkway02.nif,30F7D9D13AE09173
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaybend01.nif,B89BA3FE8CE55ED3
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaybend02.nif,15213958A9CD6B08
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaybend03.nif,2291BA40BD292840
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwayc01.nif,8F22899ED1834399
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycend01.nif,898B3D5A0DE51B06
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycend02.nif,81F5FEA3B153BB02
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycentwall01.nif,1E751F6E699EA0E1
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycentwall02.nif,607C7E86A687B6A
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycwall01.nif,273F3BE3EE57D6DC
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycwallend01.nif,AF53554DA722208F
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycwallend02.nif,26B360021B0AACD5
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycwallend03.nif,9B282E5C2A2DD8EB
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycwallend04.nif,9148392834D81A17
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycwallgate01.nif,3A8E077C24063761
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycwallgate02.nif,D55017FD0C719EE
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwayend01.nif,EC316FC5A34860F4
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwayfull02.nif,6E6311411DD96B70
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwayfull03.nif,EABF4CA923098F7A
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwayrend01.nif,E847401ECB5AF2FF
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaystairs1.nif,2279199762F2A8F9
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaystairs15.nif,9F83DEB1250738FD
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaystairs3.nif,83E1EE6C3FF37FD8
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaystairs4.nif,90EEA9AE894B8895
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaystairs8.nif,1F36A51FCBA748F2
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/solitude/farms/slumbermill01.nif,412224CF230879F2
-05 Chains 3D - Misc/meshes/architecture/riften/ratwayhall/riftenrwdoorspecial01.nif,F3063E74F153FAD8
-05 Chains 3D - Misc/meshes/architecture/whiterun/wrclutter/wrherbdryingrack01.nif,3331F9753DC8A23D
-05 Chains 3D - Misc/meshes/dungeons/ship/katariah/shipkatariahanchorchain01.nif,52945D382BDB6B55
-05 Chains 3D - Misc/meshes/dungeons/ship/katariah/shipkatariahanchorwheel01.nif,3CB1F77487DE8B88
-05 Chains 3D - Misc/meshes/dungeons/ship/questitems/shipanchorchain01.nif,E020D82AC0D90A94
-05 Chains 3D - Misc/meshes/dungeons/ship/questitems/shipanchorwheel01.nif,5532CB792FDDF591
-05 Chains 3D - Misc/textures/smim/architecture/riften/smim_RiftenDoor01.dds,80782AAEA3EDA641
-05 Chains 3D - Misc/textures/smim/architecture/riften/smim_RiftenDoor01_n.dds,F74B7AB9AE0751CE
-06 Chains 3D - Signs/meshes/clutter/signage/generic/signalchemyshop01.nif,3509523D5F5B9900
-06 Chains 3D - Signs/meshes/clutter/signage/generic/signgeneralgoods01.nif,2DFCF5111E895D15
-06 Chains 3D - Signs/meshes/clutter/signage/inns/signbraidwoodinn01.nif,8632D282264AB59A
-06 Chains 3D - Signs/meshes/clutter/signage/inns/signdeadmansdrink01.nif,78419DB61A406541
-06 Chains 3D - Signs/meshes/clutter/signage/inns/signfourshieldstavern01.nif,86A5FB7CC5F88E5D
-06 Chains 3D - Signs/meshes/clutter/signage/inns/signfrostfruitinn01.nif,9C1D6A3857A3C7BF
-06 Chains 3D - Signs/meshes/clutter/signage/inns/signfrozenhearth01.nif,10DFD8FD85B17858
-06 Chains 3D - Signs/meshes/clutter/signage/inns/signmoorsideinn01.nif,50225B52382275A1
-06 Chains 3D - Signs/meshes/clutter/signage/inns/signnightgateinn01.nif,AEA02FBF9D95425F
-06 Chains 3D - Signs/meshes/clutter/signage/inns/signoldhroldan01.nif,7A5934C7A0B8430A
-06 Chains 3D - Signs/meshes/clutter/signage/inns/signvilemyrinn01.nif,BD5874D3324A3F7F
-06 Chains 3D - Signs/meshes/clutter/signage/inns/signwindpeakinn01.nif,D13E8DAFD4092D15
-06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtalchemyshop01.nif,85097003E078EDA5
-06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtbeeandbarb01.nif,6ABA768D754706A6
-06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtblackbriarmeadery01.nif,8F4B3782E31421BB
-06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtblacksmith01.nif,ABA53EB6F559E0D
-06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtfishery01.nif,E040704F17BDE49
-06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtpawnshop.nif,D542A47ED18D3C72
-06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtpost01.nif,AEDD3E3157580296
-06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtraggedflagon01.nif,64C280197CA76936
-06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtstables01.nif,4B6A76987129E0B3
-06 Chains 3D - Signs/meshes/clutter/signage/riverwood/signriverwoodriverwoodblacksmith01.nif,E54B30ABB687297E
-06 Chains 3D - Signs/meshes/clutter/signage/riverwood/signriverwoodriverwoodtrader01.nif,6FAAA60E607DC127
-06 Chains 3D - Signs/meshes/clutter/signage/riverwood/signriverwoodsleepinggiantinn01.nif,6991ED9B3AF96B14
-06 Chains 3D - Signs/meshes/clutter/signage/solitude/signsangelinesaromatics.nif,E530FACB6093BE9E
-06 Chains 3D - Signs/meshes/clutter/signage/solitude/signsbitsandpieces.nif,461845BD73E42FE
-06 Chains 3D - Signs/meshes/clutter/signage/solitude/signsfletcher.nif,5A21071F485D1723
-06 Chains 3D - Signs/meshes/clutter/signage/solitude/signsradiantraiments.nif,F19C68614E61AD91
-06 Chains 3D - Signs/meshes/clutter/signage/solitude/signswinkingskeever.nif,B2F220F71A9FF8D
-06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwralchemyshop01.nif,BE4BEDE54FB89EFD
-06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwrbanneredmare01.nif,7E83657EEB2C984B
-06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwrblacksmith01.nif,35EE4F3EC8007A6D
-06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwrdrunkenhuntsman01.nif,635973B51468BEC1
-06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwrgeneralgoods.nif,9DBE613B5C87FF77
-06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwrhonningbrewmeadery01.nif,7D6D7A6EFFB01269
-06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwrpost01.nif,55266C2604F96D2F
-06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwrstables01.nif,B5149CD9A98F5498
-06 Chains 3D - Signs/meshes/clutter/signage/windhelm/signwhalchemyshop01.nif,31033D90A0283A28
-06 Chains 3D - Signs/meshes/clutter/signage/windhelm/signwhblacksmith01.nif,70C34619CE6DF06A
-06 Chains 3D - Signs/meshes/clutter/signage/windhelm/signwhcandlehearthinn.nif,775E52F2C924C2DC
-06 Chains 3D - Signs/meshes/clutter/signage/windhelm/signwhcandlehearthinn02.nif,1E1D6D805C7C5464
-06 Chains 3D - Signs/meshes/clutter/signage/windhelm/signwhgeneralgoods.nif,9F309C2F7D6AC845
-06 Chains 3D - Signs/meshes/clutter/signage/windhelm/signwhpost01.nif,929BF6F36F8607E0
-06 Chains 3D - Signs/meshes/clutter/signage/windhelm/signwhstables01.nif,B5253CF28ED4E7D5
-06 Chains 3D - Signs/textures/smim/clutter/signage/metalwork01_brown.dds,EC6D1D0DEB249E38
-06 Chains 3D - Signs/textures/smim/clutter/signage/metalwork01_brown_n.dds,D7732E6E282E1D36
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_centurion_core.dds,795FAFDF22A2FC67
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_centurion_core_g.dds,8FE629E05D1DA1D3
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_centurion_core_m.dds,38D950DA649CC79D
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_centurion_core_n.dds,7336FE644833EC71
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_clutter_bowl.dds,D407523274326949
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_clutter_bowl_n.dds,338339BD390D6C3E
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_clutter_cup.dds,C8D1BC56869B20CD
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_clutter_cup_n.dds,8E0A7A248A222ABD
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_gyro.dds,7B8D8BE81115FB0E
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_gyro_m.dds,2F3BF5CD06E89509
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_gyro_n.dds,C1EE2356125D0175
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_scrap3.dds,AEB2C1919789727D
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_scrap3_m.dds,8BAA8FC5459E656C
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_scrap3_n.dds,A5C054B1031005DC
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_scrap4.dds,1E46C40DD9B98CFB
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_scrap4_m.dds,1B7668B3E3783269
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_scrap4_n.dds,43DB6B90865584BD
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_cog01.dds,2D3F6AD018D375FF
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_cog01_m.dds,CCCF796EF2DAAFAF
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_cog01_n.dds,B53F9D7E252D0816
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_gear.dds,B55E3843C41FD499
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_gear_m.dds,F1B51E206EAB7B8D
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_gear_n.dds,6C593D29F69C623D
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_scrap1_sides.dds,1F5B8F15D5D31CDB
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_scrap1_sides_m.dds,FEA79EC6F2C5EDD9
-09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_scrap1_sides_n.dds,13B1717F5BAF335E
-10 Nordic Tables and Benches/textures/smim/furniture/nordic/ruinstable_smim_vanillamix.dds,6BA0DFA195D32D35
-10 Nordic Tables and Benches/textures/smim/furniture/nordic/ruinstable_smim_vanillamix_n.dds,2A24309B4C8AAE6F
-11 Bridges/textures/smim/landscape/bridges/bridge_pillar_top.dds,A7BB1DAF63664B
-11 Bridges/textures/smim/landscape/bridges/bridge_pillar_top_n.dds,12F14019A8BE32F2
-11 Bridges/textures/smim/landscape/bridges/bridge_road_stone_tile.dds,C7DE7318851CEC00
-11 Bridges/textures/smim/landscape/bridges/bridge_road_stone_tile_n.dds,528B908FE4D56702
-11 Bridges/textures/smim/landscape/bridges/smim_bridge_dirt.dds,B1CE69993F7C8136
-11 Bridges/textures/smim/landscape/bridges/smim_bridge_dirt_n.dds,8ED62FE518091682
-11 Bridges Old Stonework/textures/smim/landscape/bridges/bridge_pillar_top.dds,A7BB1DAF63664B
-11 Bridges Old Stonework/textures/smim/landscape/bridges/bridge_pillar_top_n.dds,12F14019A8BE32F2
-11 Bridges Old Stonework/textures/smim/landscape/bridges/bridge_road_stone_tile.dds,5882A6D523B517D5
-11 Bridges Old Stonework/textures/smim/landscape/bridges/bridge_road_stone_tile_n.dds,5468AF59D9377594
-11 Bridges Real Roads/textures/smim/landscape/bridges/bridge_pillar_top.dds,A7BB1DAF63664B
-11 Bridges Real Roads/textures/smim/landscape/bridges/bridge_pillar_top_n.dds,12F14019A8BE32F2
-11 Bridges Real Roads/textures/smim/landscape/bridges/bridge_road_stone_tile.dds,C7DE7318851CEC00
-11 Bridges Real Roads/textures/smim/landscape/bridges/bridge_road_stone_tile_n.dds,528B908FE4D56702
-11 Bridges Real Roads/textures/smim/landscape/bridges/smim_bridge_dirt.dds,B1CE69993F7C8136
-11 Bridges Real Roads/textures/smim/landscape/bridges/smim_bridge_dirt_n.dds,8ED62FE518091682
-13 Lanterns/textures/smim/clutter/common/smim_lantern.dds,D0F1B96EF1443AF6
-13 Lanterns/textures/smim/clutter/common/smim_lantern_n.dds,95A22F90622874E0
-15 Clothing Fixes/meshes/armor/studded/male/body_go.nif,BD8AA41D0BEA056D
-16 Tankard Bright Brushed Metal/textures/smim/clutter/diningset/smim_tankard.dds,211FFFB202DA6E9F
-16 Tankard Bright Brushed Metal/textures/smim/clutter/diningset/smim_tankard_em.dds,95C0A7CE6712EB95
-16 Tankard Bright Brushed Metal/textures/smim/clutter/diningset/smim_tankard_n.dds,C68BB8AADD4EF929
-16 Tankard Bright Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody.dds,77BF82370383BEDF
-16 Tankard Bright Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_em.dds,345CAE275EDA52FE
-16 Tankard Bright Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_n.dds,65B5D3CA55A914E1
-16 Tankard Dark Brushed Metal/textures/smim/clutter/diningset/smim_tankard.dds,2E8FF748EDA83518
-16 Tankard Dark Brushed Metal/textures/smim/clutter/diningset/smim_tankard_em.dds,9B69429FE990B4DC
-16 Tankard Dark Brushed Metal/textures/smim/clutter/diningset/smim_tankard_n.dds,7FBC7A49A6EE21D4
-16 Tankard Dark Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody.dds,ACD8AD155B2344A6
-16 Tankard Dark Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_em.dds,305D2047C881B716
-16 Tankard Dark Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_n.dds,42674B0BC7580408
-16 Tankard Pewter Metal/textures/smim/clutter/diningset/smim_tankard.dds,ADBD73FA2E7A4908
-16 Tankard Pewter Metal/textures/smim/clutter/diningset/smim_tankard_em.dds,2BF5F8894C3C97DE
-16 Tankard Pewter Metal/textures/smim/clutter/diningset/smim_tankard_n.dds,7E9166A0BDB3C4CC
-16 Tankard Pewter Metal/textures/smim/dlc01/clutter/smim_tankard_bloody.dds,5CBE7EFE60863E17
-16 Tankard Pewter Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_em.dds,B1697E6F3BCC2504
-16 Tankard Pewter Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_n.dds,BAE3DF70E3198776
-19 Smelter/textures/smim/furniture/smelter/smim_smelter_dome.dds,85A6150FE5926FD4
-19 Smelter/textures/smim/furniture/smelter/smim_smelter_dome_n.dds,22BD767C262FC3D8
-19 Smelter/textures/smim/furniture/smelter/smim_smelter_door.dds,966DD7FAE49EDCCE
-19 Smelter/textures/smim/furniture/smelter/smim_smelter_door_n.dds,DBC6AA654FB87E55
-19 Smelter/textures/smim/furniture/smelter/smim_smelter_metal.dds,EAFF40BDEE5E0546
-19 Smelter/textures/smim/furniture/smelter/smim_smelter_metal_n.dds,AA1DD0AC5BA1D98D
-19 Smelter/textures/smim/furniture/smelter/smim_smelter_spout.dds,B7F47E22180752B4
-19 Smelter/textures/smim/furniture/smelter/smim_smelter_spout_n.dds,271D22C2C55436E2
-19 Smelter/textures/smim/furniture/smelter/smim_smelter_stonework.dds,48BB184AE8254BEA
-19 Smelter/textures/smim/furniture/smelter/smim_smelter_stonework_n.dds,A22E4D0597629C53
-19 Smelter/textures/smim/furniture/smelter/smim_smelter_stucco.dds,B75FC1491F1162A6
-19 Smelter/textures/smim/furniture/smelter/smim_smelter_stucco_n.dds,57DFDFED7C24D76A
-20 Furniture Skyrim HD Appearance/textures/smim/clutter/common/dresser01.dds,36AB54D2262DEA9B
-20 Furniture Skyrim HD Appearance/textures/smim/clutter/common/dresser01_n.dds,82E8B306166D141D
-20 Furniture Skyrim HD Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece.dds,9D0F205142393E88
-20 Furniture Skyrim HD Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece_n.dds,D57071A649379EC5
-20 Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/dresser01.dds,B015EB7F370AD240
-20 Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/dresser01_n.dds,CEC68363CDFC0AB
-20 Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece.dds,D3A504B4E5AA86A1
-20 Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece_n.dds,9D2F819869D43744
-21 Dwemer Animated Lifts SE/meshes/dungeons/dwemer/facades/dwefacadeliftleverloaddown01.nif,53B942C98C6D47D4
-21 Dwemer Animated Lifts SE/meshes/dungeons/dwemer/facades/dwefacadeliftleverloadup01.nif,248516DADA30D74E
-22 Solitude Docks Ropes SE/meshes/architecture/solitude/clutter/slightpost01.nif,D1484E234C00467C
-22 Solitude Docks Ropes SE/textures/smim/architecture/docks/smim_docks_ropes.dds,B9E611B5E3E4EF08
-22 Solitude Docks Ropes SE/textures/smim/architecture/docks/smim_docks_ropes_n.dds,2225C41AADF76B06
-23 Tomato Pure Red without Blemish/textures/smim/clutter/ingredients/tomato_smim.dds,6E79367E74EA614F
-23 Tomato Pure Red without Blemish/textures/smim/clutter/ingredients/tomato_smim_n.dds,8811B6C66506F194
-25 Solitude Gate Doors/meshes/architecture/solitude/doors/sgatedoor.nif,B70356870393A939
-25 Solitude Gate Doors/meshes/architecture/solitude/doors/slgdoor01.nif,849238E2392843A4
-25 Solitude Gate Doors/textures/smim/architecture/solitude/smim_sdoorgate01.dds,97805E1EA6FC2C91
-25 Solitude Gate Doors/textures/smim/architecture/solitude/smim_sdoorgate01_n.dds,1F5D16E23FBBB177
-25 Solitude Gate Doors/textures/smim/architecture/solitude/smim_solitude_door_pattern.dds,20B51FC4B1ADE476
-25 Solitude Gate Doors/textures/smim/architecture/solitude/smim_solitude_door_pattern_n.dds,4809BB53D4D4782E
-26 Human Skull Fixes/meshes/actors/draugr/character assets/draugrskeleton.nif,9D1AC600AAE3620
-26 Human Skull Fixes/meshes/landscape/rocks/cairns/rockcairnevil01.nif,EE138B41712407AB
-26 Human Skull Fixes/meshes/landscape/rocks/cairns/rockcairnevil02.nif,919759DCFEEE9EB6
-26 Human Skull Fixes/meshes/landscape/rocks/cairns/rockcairnevil03.nif,7FB1B8E799CBE59A
-26 Human Skull Fixes/meshes/landscape/rocks/cairns/rockcairnevil04.nif,EC8534F1CE1E98A4
-27 Hawk/textures/smim/critters/fchawk/smim_hawk.dds,2FB32C2C9C46379E
-27 Hawk/textures/smim/critters/fchawk/smim_hawk_b.dds,7F335C8D992D4358
-27 Hawk/textures/smim/critters/fchawk/smim_hawk_n.dds,7D02BF61B0F1AF58
-27 Hawk/textures/smim/dlc02/critters/smim_tern.dds,45FF22892E7FD235
-29 Raven Rock 3D Ropes/textures/smim/architecture/riften/smim_riften_rope.dds,FE6C8C29D5A27B7E
-29 Raven Rock 3D Ropes/textures/smim/architecture/riften/smim_riften_rope_n.dds,7C72DBC596639122
-30 Rocks - Generic/meshes/dungeons/mines/rocks/minecboulderl02.nif,EC2C18E6BAF31A74
-33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood.dds,FFDBBAC430223E2E
-33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood_n.dds,F6EDC9094DF933E9
-33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood_segments.dds,2052FF0B1D7D757E
-33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood_segments_doorway.dds,9C71277BC88C2CFF
-33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood_segments_doorway_n.dds,395A238CA97E61DE
-33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood_segments_house.dds,F171D19E177CA638
-33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood_segments_house2.dds,30C059DC95CC658
-33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood_segments_middle.dds,D1A6A9FB49703F96
-35 Shack Kit/textures/smim/architecture/shackkit/smim_shack_roof.dds,D56B35A1973D048F
-35 Shack Kit/textures/smim/architecture/shackkit/smim_shack_roof_n.dds,9E2DC29F504CEFCE
-37 Riften 3D Ropes/meshes/architecture/riften/docks/dockmooring01.nif,593FC61F57D28D44
-37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbld3waydwn01.nif,225EA3F8F870A95A
-37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldcor01.nif,F4634F924034CD01
-37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldcorin01.nif,6B29DB789766D9D5
-37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldcorpier01.nif,7DBAA2A49559C447
-37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldcorpier02.nif,42BB439B11203F30
-37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldcorramp01.nif,320CA1563F88CB28
-37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldcortostairs01.nif,F25B7901CE9EB7FF
-37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldstr01.nif,5CF5E0D3499152A7
-37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldstrbridge01.nif,F117DC1825AD7527
-37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldstrdbl01.nif,D73D18C7B519F283
-37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldstrdbl02.nif,7657903177053ACA
-37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldstrstairst01.nif,8F2E9BFEA74E717B
-37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldtallstairs01.nif,8C0FF5A00F9D64FC
-37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockpier01.nif,CC553F3EFAE43D3C
-37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockpier02.nif,80CF42399B3E89F8
-37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockpier03.nif,3A99CBBF493FFF95
-37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockpier03SMIM.nif,74F6E833364C9019
-37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockstairsturn01.nif,4D568F0AEB4F8F3C
-37 Riften 3D Ropes/textures/smim/architecture/riften/smim_riften_rope.dds,FE6C8C29D5A27B7E
-37 Riften 3D Ropes/textures/smim/architecture/riften/smim_riften_rope_n.dds,7C72DBC596639122
-38 Riften 3D Ropes Better Ropes Texture/textures/smim/architecture/riften/smim_riften_rope.dds,94953C9161F48D6F
-38 Riften 3D Ropes Better Ropes Texture/textures/smim/architecture/riften/smim_riften_rope_n.dds,2A241F0B38993531
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldbaseropediv01.nif,712F0E48C5772681
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldbridge01.nif,EB297532A861F74
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldbridge02.nif,4AC2E99784819D9B
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldbridge03.nif,D5926AD136F7C50C
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldbridge04.nif,ABB5D990155760F1
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreerope01.nif,C4181823075852A6
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreerope02.nif,76850ED707734A
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreerope03.nif,FF686A487B37F997
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreerope04.nif,7F7FC3DABCB60C4E
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreerope05.nif,3D7FFCC0250BA987
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreerope06.nif,7DF8464756F67BCF
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreeropeend01.nif,352BCA3BD26CA4B6
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreeropeend02.nif,DF25FFD6AA39B156
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldrope01.nif,A5E6A7DCD162C920
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldrope02.nif,3B2A5D88845BE381
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldrope03.nif,3EFADBF8FBB8E8BD
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldrope04.nif,8AE593A195696BCC
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldrope05.nif,16E49973621D79E7
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldrope06.nif,83BFD73F5AC86B6E
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldropelong01.nif,642D735E1D43B9BE
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldropelong02.nif,CB1E0411C5DA5D66
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldropelong03.nif,69341F552E1038AC
-39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldropelong04.nif,BAA8A353D595D935
-39 Dungeons 3D Ropes/textures/smim/dungeons/mines/smim_mines_rope.dds,AE24467508E61B5A
-39 Dungeons 3D Ropes/textures/smim/dungeons/mines/smim_mines_rope_n.dds,A7ECC2F2C8DD0E87
-39 Dungeons 3D Ropes/textures/smim/dungeons/mines/smim_wood_mine_smalltile.dds,E15DE2E1EED43EF4
-39 Dungeons 3D Ropes/textures/smim/dungeons/mines/smim_wood_mine_smalltile_n.dds,E9B44DB013145A3
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/genericwell01.nif,C6F5B10F93B7ACF
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodbeam01.nif,20160094AA515B51
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodbeam02.nif,8D9926843D0CADCE
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodbeam03.nif,70DD030D0814B29B
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodbeamshort01.nif,4FA927D1590F16ED
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodbeamshort02.nif,DE97457F948148ED
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodplanks01.nif,269E57087040E925
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodplanks02.nif,71AC6A66852D8BF9
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodplanks03.nif,B47604D7B753FB18
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodplanks04.nif,5C84997AF3E52E0A
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way01.nif,96E8D82C72193F7
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way128d01.nif,1732F317A0C53B8F
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way128l01.nif,18B947B0E60E0B21
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way128r01.nif,2237C5DE48884EDD
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way128short01.nif,8550B21F86E1C126
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way128u01.nif,A45FC4FAAF44721F
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way256short01.nif,8F393A815BD8B7BB
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way64d01.nif,6E94C33412C92B6A
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way64l01.nif,BCAFF9CA1E25A0E9
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way64r01.nif,5F56DDDDFB6C7183
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way64short01.nif,9AE2A6D8FA96978D
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way64u01.nif,FBFC9DAC3546513C
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall2way01.nif,D7623FD9FCFFA742
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall2way02.nif,CC34F4C3394557C6
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall3way01.nif,94D09250ED03920D
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall3way02.nif,393974C346D94AB4
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall4way01.nif,1AB9F98C66D560A
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhallcrossover01.nif,139EA9992A1D30CC
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhalldeadend01.nif,D0C62D15A90B56D2
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhalldeadend02.nif,87B7C28F5718D818
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhalldetwist01.nif,E1A8F4FE5303A438
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhalldetwist02.nif,C06163FE463F9171
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhallentrance01.nif,6CB477F3009F62FB
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhallentrance02.nif,5A67979D61EBBC43
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhallramp01.nif,5D25C84B325976B2
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhallramp02.nif,254017AA54980022
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minerailramp01.nif,2D2E7A50288BF2BE
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minerailtop1sided01.nif,E657E027B72E423F
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minerailtop2sided01.nif,547E21B048DA380A
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minerailtop2sided02.nif,DC3F95F6BBF7A68D
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minerailtop3sided01.nif,83CEB05515AC4851
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minerailtop4sided01.nif,2732A1398B2C5DA6
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbase0sided01.nif,7588C9831B94E261
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbase1sided01.nif,5D2AF5416C1E31A4
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbase2sided01.nif,1BC2EEBE37602FC7
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbase2sided02.nif,45D16CA0D0C9B24E
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbase3sided01.nif,16EE840B28384256
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbase4sided01.nif,6CB55998027E8F
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbaseropediv01.nif,712F0E48C5772681
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbasesupport01.nif,19D19971F23971E
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbasesupportw01.nif,99C993EADCD04803
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbridge01.nif,149AE7D45E59A9EF
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbridge02.nif,AE776040733A2171
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbridge03.nif,654A9EBE8D39636E
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbridge04.nif,8AE989F711FD88B1
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreerope01.nif,C4181823075852A6
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreerope02.nif,76850ED707734A
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreerope03.nif,FF686A487B37F997
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreerope04.nif,7F7FC3DABCB60C4E
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreerope05.nif,3D7FFCC0250BA987
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreerope06.nif,7DF8464756F67BCF
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreeropeend01.nif,352BCA3BD26CA4B6
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreeropeend02.nif,DF25FFD6AA39B156
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldramp01.nif,EDF4ED0F4363408C
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldrope01.nif,A5E6A7DCD162C920
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldrope02.nif,3B2A5D88845BE381
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldrope03.nif,3EFADBF8FBB8E8BD
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldrope04.nif,8AE593A195696BCC
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldrope05.nif,16E49973621D79E7
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldrope06.nif,83BFD73F5AC86B6E
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldropelong01.nif,642D735E1D43B9BE
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldropelong02.nif,CB1E0411C5DA5D66
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldropelong03.nif,69341F552E1038AC
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldropelong04.nif,BAA8A353D595D935
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldsupport01.nif,B0C49660A77C7ADE
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldtop0sided01.nif,5E59554F4A25E83E
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldtop1sided01.nif,AAD43A56800BE03C
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldtop2sided01.nif,5A7CB9A355DCAA36
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldtop2sided02.nif,B331280A15709D99
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldtop3sided01.nif,B287FFA5DB6997F8
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldtop4sided01.nif,FEAF5E33DA69FF93
-39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldtopcross01.nif,B33C2B8416ECD2AC
-39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_mines_rope.dds,AE24467508E61B5A
-39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_mines_rope_n.dds,A7ECC2F2C8DD0E87
-39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_beamsupport_thirdstile.dds,835460D5CC2DC092
-39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_beamsupport_thirdstile_n.dds,59D710BE2A33EE9
-39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_beams_1k_support_corners.dds,421827927A16C7CC
-39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_beams_1k_support_corners_n.dds,35BED5C625DBD31
-39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_beams_x4_seamless.dds,DFD82564FA928043
-39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_beams_x4_seamless_n.dds,4A8F4084CADCD22F
-39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_planks.dds,26579F49D1AF0B7D
-39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_planks_n.dds,68212FD78937326B
-39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_smalltile.dds,E15DE2E1EED43EF4
-39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_smalltile_n.dds,E9B44DB013145A3
-40 Furniture Chests/meshes/clutter/containers/chest01/chest01.nif,B2B90B00E1A640D
-40 Furniture Chests/textures/smim/clutter/upperclass/smim_upperchest.dds,23120579F6FB76AA
-40 Furniture Chests/textures/smim/clutter/upperclass/smim_upperchest_n.dds,AB62549D8E377DD
-40 Furniture Chests/textures/smim/clutter/upperclass/smim_upperchest_weathered.dds,487D6162A8D073FD
-40 Furniture Chests/textures/smim/clutter/upperclass/smim_upperchest_weathered_snow.dds,6C0998845BD6ABA7
-42 Furniture Noble/textures/smim/furniture/noble/SMIMNobleChair.dds,A3D55419893C918
-42 Furniture Noble/textures/smim/furniture/noble/SMIMNobleChair_n.dds,EDCEC610E48C094C
-43 Whiterun Castle Wood Carvings Celtic/meshes/uskp/architecture/whiterun/wrintcastlefreepillar01uskp.nif,DB95BA36768A5F64
-43 Whiterun Castle Wood Carvings Celtic/textures/smim/architecture/whiterun/wrcastlecarvings.dds,9834A23042553B88
-43 Whiterun Castle Wood Carvings Celtic/textures/smim/architecture/whiterun/wrcastlecarvings_n.dds,E04135B55740C14D
-43 Whiterun Castle Wood Carvings Moroccan/meshes/uskp/architecture/whiterun/wrintcastlefreepillar01uskp.nif,DB95BA36768A5F64
-43 Whiterun Castle Wood Carvings Moroccan/textures/smim/architecture/whiterun/wrcastlecarvings.dds,8647863771DD8062
-43 Whiterun Castle Wood Carvings Moroccan/textures/smim/architecture/whiterun/wrcastlecarvings_n.dds,5B6E202A6ED3D20B
-43 Whiterun Castle Wood Carvings Vanilla/meshes/uskp/architecture/whiterun/wrintcastlefreepillar01uskp.nif,DB95BA36768A5F64
-43 Whiterun Castle Wood Carvings Vanilla/textures/smim/architecture/whiterun/wrcastlecarvings.dds,365B2A3E3FE456F
-43 Whiterun Castle Wood Carvings Vanilla/textures/smim/architecture/whiterun/wrcastlecarvings_n.dds,C1F8D33E87590436
-44 Poor Coffin Custom Texture/textures/smim/furniture/noble/smim_poor_coffin.dds,49DA056D19147AA6
-44 Poor Coffin Custom Texture/textures/smim/furniture/noble/smim_poor_coffin_n.dds,95DEE84186689B94
-45 Hanging Rings/meshes/_byoh/clutter/dead animals/hanginganimalsring03.nif,68BCE0AE07626323
-45 Hanging Rings/textures/smim/clutter/deadanimals/smim_metalhanger_deadanimals.dds,9FC093155AFAF545
-45 Hanging Rings/textures/smim/clutter/deadanimals/smim_metalhanger_deadanimals_n.dds,817F56FD827A4AEB
-46 Carriage Seats and Fixes/meshes/Actors/horse/character assets/harness.nif,FC7E9F70BA7D82CA
-46 Carriage Seats and Fixes/textures/smim/furniture/prisonercarriage/smim_carriage_metal.dds,F1BBACCF4C2071F1
-46 Carriage Seats and Fixes/textures/smim/furniture/prisonercarriage/smim_carriage_metal_n.dds,A1C11EA84467067
-46 Carriage Seats and Fixes/textures/smim/furniture/prisonercarriage/smim_carriage_seat.dds,4BDA1DC014D43733
-46 Carriage Seats and Fixes/textures/smim/furniture/prisonercarriage/smim_carriage_seat_n.dds,B3B714230EE0F2B
-49 Tundra Tree/textures/smim/landscape/trees/smim_tundra_tree.dds,EF9ED9291C1A17E8
-49 Tundra Tree/textures/smim/landscape/trees/smim_tundra_tree_n.dds,C731EE68E03B36A9
-50 Dawnguard Soulcairn Bone Piles/textures/smim/dlc01/soulcairn/smim_soulcairn_bone.dds,C0148154214E61D7
-50 Dawnguard Soulcairn Bone Piles/textures/smim/dlc01/soulcairn/smim_soulcairn_bone_n.dds,86C12012B66CD2D6
-50 Dawnguard Soulcairn Bone Piles/textures/smim/dlc01/soulcairn/smim_soulcairn_skeleton.dds,A281C06B22763F05
-50 Dawnguard Soulcairn Bone Piles/textures/smim/dlc01/soulcairn/smim_soulcairn_skeleton_n.dds,5CEC730DADB3C56A
-52 Dawnguard Soulcairn Bone Piles (White Bones)/textures/smim/dlc01/soulcairn/smim_soulcairn_bone.dds,5E3DBC794B4E6FA0
-52 Dawnguard Soulcairn Bone Piles (White Bones)/textures/smim/dlc01/soulcairn/smim_soulcairn_skeleton.dds,FF6FFFF06E80A17C
-53 Imperial Jail/meshes/dungeons/imperial/jail/impjaildoor01.nif,151D98AFA912B54B
-53 Imperial Jail/meshes/dungeons/imperial/jail/impjaildoor02.nif,8FAEB72E750F8DFA
-53 Imperial Jail/meshes/dungeons/imperial/jail/impjaildoorframe01.nif,4FE61C31916A3227
-53 Imperial Jail/meshes/dungeons/imperial/jail/impjailpole01.nif,AD4FEA4C343AEFFF
-53 Imperial Jail/meshes/dungeons/imperial/jail/impjailtop01.nif,3144C4E752ECD26A
-53 Imperial Jail/meshes/dungeons/imperial/jail/impjailwall01.nif,27269114D053C91
-53 Imperial Jail/meshes/dungeons/imperial/jail/impjailwall02.nif,D7D03C77032FD561
-53 Imperial Jail/meshes/dungeons/imperial/jail/impjailwall03.nif,DE7B36C71041893A
-53 Imperial Jail/textures/smim/dungeons/imperial/smim_imp_gate_pole.dds,E01B640C97DBF5C7
-53 Imperial Jail/textures/smim/dungeons/imperial/smim_imp_gate_pole_n.dds,CB039CEA7080F72B
-54 Imperial Jail Brighter Metal/textures/smim/dungeons/imperial/smim_imp_gate_pole.dds,B3F57344B45C98ED
-55 Windmills Base Vanilla Version/meshes/architecture/farmhouse/farmhousewindmill/farmhousewindmillfan.nif,758E10A13F754C2C
-55 Windmills Base Vanilla Version/textures/smim/architecture/farmhouse/smim_windmill_fan.dds,FC1C69B53434BBAD
-55 Windmills Base Vanilla Version/textures/smim/architecture/farmhouse/smim_windmill_fan_n.dds,F06A9D8CA1A70E54
-55 Windmills Base Vanilla Version Sails/meshes/architecture/farmhouse/farmhousewindmill/farmhousewindmillfan.nif,51075E4E970A0B9
-55 Windmills Base Vanilla Version Sails/textures/smim/architecture/farmhouse/smim_windmill_fan.dds,FC1C69B53434BBAD
-55 Windmills Base Vanilla Version Sails/textures/smim/architecture/farmhouse/smim_windmill_fan_n.dds,F06A9D8CA1A70E54
-55 Windmills Base Vanilla Version Sails/textures/smim/architecture/farmhouse/smim_windmill_sail.dds,E2A487C6D8666060
-55 Windmills Base Vanilla Version Sails/textures/smim/architecture/farmhouse/smim_windmill_sail_n.dds,32A9BDE5AD76D277
-55 Windmills Base Vanilla Version Sails/textures/smim/architecture/farmhouse/smim_windmill_sail_solitude.dds,3A6848780301F804
-56 Windmills SkyMills Compatibility/meshes/architecture/farmhouse/farmhousewindmill/farmhousewindmillfan02.nif,BF64A470BA7E365B
-56 Windmills SkyMills Compatibility/meshes/architecture/farmhouse/farmhousewindmill/smfarmhousewindmillfan.nif,2E21E7310DA22334
-56 Windmills SkyMills Compatibility Sails/meshes/architecture/farmhouse/farmhousewindmill/farmhousewindmillfan02.nif,A08771E0A8066461
-56 Windmills SkyMills Compatibility Sails/meshes/architecture/farmhouse/farmhousewindmill/smfarmhousewindmillfan.nif,5F0304E8D62FD9C5
-57 Ruins Sarcophagus/meshes/clutter/ruins/sarcophaguslid/norsarcophagustopanim01.nif,AC893F87B9655743
-57 Ruins Sarcophagus/meshes/clutter/ruins/sarcophaguslidvert/sarcophagus_topvert01.nif,59CD74D2EC43A4C5
-57 Ruins Sarcophagus/textures/smim/clutter/ruins/smim_ruins_sarcophagus_parts.dds,C77CAC3D15F3E2D7
-57 Ruins Sarcophagus/textures/smim/clutter/ruins/smim_ruins_sarcophagus_parts_n.dds,6A035BB842AB3114
-57 Ruins Sarcophagus/textures/smim/clutter/ruins/smim_ruins_sarcophagus_tub.dds,41F0D2EC8C4C5342
-57 Ruins Sarcophagus/textures/smim/clutter/ruins/smim_ruins_sarcophagus_tub_n.dds,379BD85074D2A52B
-58 Jewelry Rings/textures/smim/armor/amuletsandrings/smim_my_precious.dds,B2685D0966576F86
-58 Jewelry Rings/textures/smim/armor/amuletsandrings/smim_my_precious_n.dds,F67D6574BCB8D25E
-60 Hearthfires Stuff/meshes/_byoh/clutter/house crafting/lock01.nif,5788344CB13E1BBA
-61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_bonemeal.dds,82D29725F9F8A14C
-61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_bonemeal_n.dds,88C5AA2700B296E3
-61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_ectoplasm.dds,3D0BF5EF7E1FC4D6
-61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_ectoplasm_g.dds,5799AE06B888A4F5
-61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_ectoplasm_n.dds,B7109FE07F29A813
-61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_ingredient_bowl.dds,7CC6788629112805
-61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_ingredient_bowl_n.dds,673FB73261834871
-61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_ingredient_bowl_spriggansap.dds,F2DBB9FD45349BC2
-61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_ingredient_bowl_vampire.dds,9F6EA4907D5B5905
-61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_moonsugar_bowl.dds,CE5A2DE3B60A9A79
-61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_moonsugar_bowl_n.dds,744A8B27C388F598
-61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_saltglow.dds,A0965F37D32DC671
-61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_saltpile.dds,DD22069EC69B4D2A
-61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_saltpile_n.dds,59343460C67F3B3D
-61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_stew_bowl.dds,5FDF09CE597C3077
-61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_stew_bowl_n.dds,7DFC4B5248574B96
-70 Rabbit/textures/smim/actors/hare/smim_rabbit.dds,238DE76C5218E6B5
-70 Rabbit/textures/smim/actors/hare/smim_rabbit_blood.dds,2140648E0AF54248
-70 Rabbit/textures/smim/actors/hare/smim_rabbit_n.dds,837AD775EC451136
-71 Candelabras Sconces Walltorches/textures/smim/clutter/common/smim_imperial_torch.dds,3B43FBB039B26AD3
-71 Candelabras Sconces Walltorches/textures/smim/clutter/common/smim_imperial_torch_n.dds,2CCFAD18A41CD3E4
-71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_candelabra.dds,AEC7EF3E25EA0E25
-71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_candelabra_gray.dds,5E5E6EA629F4933B
-71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_candelabra_n.dds,C8559CB0A970EEFD
-71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_imperial_brazier.dds,B8E3A5B90D9FF09B
-71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_imperial_brazier_n.dds,DC27BB16E9F8E6E8
-71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_imperial_sconce.dds,CA12B1C69710FC01
-71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_imperial_sconce_n.dds,994D4D4C0B8740B8
-71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_trap_pressure_plate.dds,D9FD9CF76C8BD3E9
-71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_trap_pressure_plate_n.dds,65A3F2EB9C859ED9
-72 Chandeliers/meshes/uskp/clutter/chandellier/impchandelliercandle01uskp.nif,3A3594674D18BC13
-72 Chandeliers/meshes/uskp/clutter/chandellier/impchandellierextensionmeduskp.nif,EF887A92051DB6CD
-72 Chandeliers/meshes/uskp/clutter/chandellier/impchandellierextensionshortuskp.nif,3A0DDF4F9A1AD49D
-72 Chandeliers/textures/smim/clutter/imperial/smim_candelabra.dds,AEC7EF3E25EA0E25
-72 Chandeliers/textures/smim/clutter/imperial/smim_candelabra_gray.dds,5E5E6EA629F4933B
-72 Chandeliers/textures/smim/clutter/imperial/smim_candelabra_n.dds,C8559CB0A970EEFD
-72 Chandeliers/textures/smim/clutter/imperial/smim_imperial_chains.dds,BCFDA412A954CEA5
-72 Chandeliers/textures/smim/clutter/imperial/smim_imperial_chains_gray.dds,99518B7B543C4C32
-72 Chandeliers/textures/smim/clutter/imperial/smim_imperial_chains_n.dds,DB39C8BC609DA89
-72 Chandeliers/textures/smim/clutter/imperial/smim_imperial_sconce_gray.dds,8F2BF03E40947112
-72 Chandeliers/textures/smim/clutter/imperial/smim_imperial_sconce_n.dds,994D4D4C0B8740B8
-73 Chandeliers No 3D Chains Addon/meshes/uskp/clutter/chandellier/impchandelliercandle01uskp.nif,59B5D7940CD81F2B
-73 Chandeliers No 3D Chains Addon/meshes/uskp/clutter/chandellier/impchandellierextensionmeduskp.nif,38F973790C19698C
-73 Chandeliers No 3D Chains Addon/meshes/uskp/clutter/chandellier/impchandellierextensionshortuskp.nif,29F02306C8CAAF2A
-80 Half-Sized Textures/textures/smim/architecture/docks/smim_docks_ropes.dds,A6E72B86092358C8
-80 Half-Sized Textures/textures/smim/architecture/docks/smim_docks_ropes_n.dds,7347422001A0C652
-80 Half-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_fan.dds,F94061A2CDAC03FE
-80 Half-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_fan_n.dds,A781EE19FE3EE8FC
-80 Half-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_sail.dds,432F267B8B8C58F6
-80 Half-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_sail_n.dds,6E91B6AA5ED4323C
-80 Half-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_sail_solitude.dds,5D7FBA278F841994
-80 Half-Sized Textures/textures/smim/architecture/riften/smim_RiftenDoor01.dds,46FA7DA51B53BA2F
-80 Half-Sized Textures/textures/smim/architecture/riften/smim_RiftenDoor01_n.dds,672A2C6C97AF875
-80 Half-Sized Textures/textures/smim/architecture/shackkit/smim_shack_roof.dds,71F6708FEE6CB4BD
-80 Half-Sized Textures/textures/smim/architecture/shackkit/smim_shack_roof_n.dds,81E30757AA7E7D9F
-80 Half-Sized Textures/textures/smim/architecture/solitude/smim_solitude_door_pattern.dds,A2E6EA4F7F785089
-80 Half-Sized Textures/textures/smim/architecture/solitude/smim_solitude_door_pattern_n.dds,48F1FD3C573A0645
-80 Half-Sized Textures/textures/smim/architecture/whiterun/smim_wr_bench.dds,70C567BDFBB1C261
-80 Half-Sized Textures/textures/smim/architecture/whiterun/smim_wr_bench_n.dds,3DD0DC1A9051888A
-80 Half-Sized Textures/textures/smim/armor/amuletsandrings/smim_my_precious.dds,3C12050A0D03CEA4
-80 Half-Sized Textures/textures/smim/armor/amuletsandrings/smim_my_precious_n.dds,27C4ED90BB3A08C3
-80 Half-Sized Textures/textures/smim/clutter/common/dresser01.dds,7E15D594DEBC12AA
-80 Half-Sized Textures/textures/smim/clutter/common/dresser01_n.dds,4B19AD8165185A58
-80 Half-Sized Textures/textures/smim/clutter/common/smim_imperial_torch.dds,9CF6C276F5647FD5
-80 Half-Sized Textures/textures/smim/clutter/common/smim_imperial_torch_n.dds,DD03972CF86F860F
-80 Half-Sized Textures/textures/smim/clutter/common/smim_lantern.dds,B01D47CA5ECAF0B1
-80 Half-Sized Textures/textures/smim/clutter/common/smim_lantern_n.dds,14CFAEB63533ED3A
-80 Half-Sized Textures/textures/smim/clutter/common/smim_quill.dds,C1EF0B939C29C3F4
-80 Half-Sized Textures/textures/smim/clutter/common/smim_quill_n.dds,E22F7A89A8C19DE3
-80 Half-Sized Textures/textures/smim/clutter/common/Stump_Bottom_for_Furniture.dds,FF48EB31AB4E14BF
-80 Half-Sized Textures/textures/smim/clutter/common/Stump_Bottom_for_Furniture_n.dds,E723258FDFEDBE77
-80 Half-Sized Textures/textures/smim/clutter/common/Table_Leg_Bark.dds,17E1004979F33140
-80 Half-Sized Textures/textures/smim/clutter/common/Table_Leg_Bark_n.dds,F36391AD49850122
-80 Half-Sized Textures/textures/smim/clutter/common/Table_Leg_Bark_Seamless.dds,BB46513138670A16
-80 Half-Sized Textures/textures/smim/clutter/common/Table_Leg_Bark_Seamless_n.dds,FB4978F9804F364C
-80 Half-Sized Textures/textures/smim/clutter/common/Table_Leg_Bark_Thin.dds,8ED2131440EFF2C2
-80 Half-Sized Textures/textures/smim/clutter/common/Table_Leg_Bark_Thin_n.dds,8F8A40C3649C16A3
-80 Half-Sized Textures/textures/smim/clutter/common/Table_Wood_SinglePiece.dds,C1312AFE19ADC2B2
-80 Half-Sized Textures/textures/smim/clutter/common/Table_Wood_SinglePiece_n.dds,DF39549E883DCD1C
-80 Half-Sized Textures/textures/smim/clutter/deadanimals/smim_metalhanger_deadanimals.dds,C9CC4C8073AEAD21
-80 Half-Sized Textures/textures/smim/clutter/deadanimals/smim_metalhanger_deadanimals_n.dds,204D32CCC7DEFE13
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_centurion_core.dds,41E6B1A38D4D6C6C
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_centurion_core_g.dds,C240B06BAA294CA5
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_centurion_core_m.dds,B85BEC2747C4740A
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_centurion_core_n.dds,2D241BF9BC55E76
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_clutter_bowl.dds,FB0DE7BDE74639CE
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_clutter_bowl_n.dds,9C410C574749DF9C
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_clutter_cup.dds,113E26859FCE2EB
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_clutter_cup_n.dds,17B3FF039D436EDA
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_gyro.dds,D0CC627E5DF50600
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_gyro_m.dds,26EE0FDE5017FB3
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_gyro_n.dds,4810B0192C984263
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_scrap3.dds,A65BEBF49BC1BD50
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_scrap3_m.dds,83AD606DCCDEED75
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_scrap3_n.dds,7D661AC63DEC50F3
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_scrap4.dds,43EDF1D0813AE706
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_scrap4_m.dds,71F3E2CCA79D20A0
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_scrap4_n.dds,570C1EAD305DF5C3
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_cog01.dds,4150938599AC1D82
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_cog01_m.dds,310C4CEA18C12FD2
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_cog01_n.dds,C773775C6FE453B5
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_gear.dds,A963DE60EA9A50C6
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_gear_m.dds,2AE5A676A85451DB
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_gear_n.dds,2950557864EE2CC9
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_scrap1_sides.dds,72289EF379AACF4E
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_scrap1_sides_m.dds,13C751501422AFF
-80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_scrap1_sides_n.dds,6AC8B5BC91FC3C89
-80 Half-Sized Textures/textures/smim/clutter/food/apple01_semi-circle-UV.dds,9679ED3DCDCBA653
-80 Half-Sized Textures/textures/smim/clutter/food/apple01_semi-circle-UV_n.dds,95E4793CAEF776B4
-80 Half-Sized Textures/textures/smim/clutter/food/apple02_semi-circle-UV.dds,32B3A327AF902605
-80 Half-Sized Textures/textures/smim/clutter/food/apple02_semi-circle-UV_n.dds,95E4793CAEF776B4
-80 Half-Sized Textures/textures/smim/clutter/imperial/smim_candelabra.dds,FC891DCFC0D39412
-80 Half-Sized Textures/textures/smim/clutter/imperial/smim_candelabra_gray.dds,7C4DD4AD2B4F6E02
-80 Half-Sized Textures/textures/smim/clutter/imperial/smim_candelabra_n.dds,D0BD96FA1499FC53
-80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_brazier.dds,8C91FC8500DBE2B0
-80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_brazier_n.dds,397E05094844E17C
-80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_chains.dds,89ABB6FEF00E82ED
-80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_chains_gray.dds,8DA2FBFD5C269E45
-80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_chains_n.dds,7C99BEEA52D48A89
-80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_sconce.dds,E1A3DCA9ABE750BA
-80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_sconce_gray.dds,1B0D2BAAC18015D1
-80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_sconce_n.dds,7B6EE5129BAD27AA
-80 Half-Sized Textures/textures/smim/clutter/imperial/smim_trap_pressure_plate.dds,93781D18719FF71F
-80 Half-Sized Textures/textures/smim/clutter/imperial/smim_trap_pressure_plate_n.dds,225B6506CD9C43A4
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_bonemeal.dds,47BBEB65F5EFE470
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_bonemeal_n.dds,5ADD524FDB297B11
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_dwarven_oil.dds,BE8B528DC9ABD995
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_dwarven_oilspill.dds,FC39A42D7D01D3A0
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_dwarven_oilspill_n.dds,E981012EC23D737F
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_dwarven_oil_m.dds,7567F85C559DBF6F
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_dwarven_oil_n.dds,B5BBFBE933CDD406
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_ectoplasm.dds,EF33BC7A357ADC3E
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_ectoplasm_g.dds,5B7EA8751D130F28
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_ectoplasm_n.dds,715D313E5278AC6E
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_hagclaw.dds,A2C3EAB2E0076D89
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_hagclaw_n.dds,2BED1FB5BECD07D4
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_ingredient_bowl.dds,7CC6788629112805
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_ingredient_bowl_n.dds,673FB73261834871
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_ingredient_bowl_spriggansap.dds,9FDF16BA2A4B6652
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_ingredient_bowl_vampire.dds,C5EA870EC78498FA
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_moonsugar_bowl.dds,E6E5B7E8D444B227
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_moonsugar_bowl_n.dds,7675548AB49AFEC1
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_sabrecat_tooth.dds,47DBF59AC2EB524D
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_sabrecat_tooth_n.dds,53F1C51941DAB01A
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_saltglow.dds,3D2FE16981DFA894
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_saltpile.dds,23462FE15A32BE8C
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_saltpile_n.dds,39FCD447AA7285D9
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_stew_bowl.dds,EFEED27C50AEF712
-80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_stew_bowl_n.dds,F6D6DED49F226427
-80 Half-Sized Textures/textures/smim/clutter/quest/smim_giant_mortar.dds,CCCD562668D40D81
-80 Half-Sized Textures/textures/smim/clutter/quest/smim_giant_mortar_n.dds,B7D5865622124711
-80 Half-Sized Textures/textures/smim/clutter/ruins/ruinschest.dds,E04A2A46D187A3B5
-80 Half-Sized Textures/textures/smim/clutter/ruins/ruinschestsmall.dds,9E9646B60A8C86E9
-80 Half-Sized Textures/textures/smim/clutter/ruins/ruinschestsmall_n.dds,97143E18715505F0
-80 Half-Sized Textures/textures/smim/clutter/ruins/ruinschest_n.dds,A5C7D6C0864BE40C
-80 Half-Sized Textures/textures/smim/clutter/ruins/smim_ruinspot01.dds,9B2548B668FBDC47
-80 Half-Sized Textures/textures/smim/clutter/ruins/smim_ruinspot01_n.dds,7574DAB7088267F5
-80 Half-Sized Textures/textures/smim/clutter/ruins/smim_ruins_sarcophagus_parts.dds,98FBCAD49910B4AB
-80 Half-Sized Textures/textures/smim/clutter/ruins/smim_ruins_sarcophagus_parts_n.dds,AF49D9BB5AFEAFFC
-80 Half-Sized Textures/textures/smim/clutter/ruins/smim_ruins_sarcophagus_tub.dds,915A7B00571F6A52
-80 Half-Sized Textures/textures/smim/clutter/ruins/smim_ruins_sarcophagus_tub_n.dds,2F04152ABB354528
-80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest.dds,DBA253EA87E1200E
-80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest_n.dds,624843675387C246
-80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest_weathered.dds,3B1C21E1DAA20894
-80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest_weathered_snow.dds,133000B536DBA1A3
-80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upper_bedpost.dds,CB23656DD27F1579
-80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upper_bedpost_n.dds,AB28F90F0C0DBB87
-80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upper_bench_legs.dds,F3B8EAB46C804AB2
-80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upper_bench_legs_n.dds,B6C80474D121A3AD
-80 Half-Sized Textures/textures/smim/clutter/upperclass/Table_Leg_Bark_Thin.dds,50FFACE2FFCD02E4
-80 Half-Sized Textures/textures/smim/clutter/upperclass/Table_Leg_Bark_Thin_n.dds,996E53E715BCFDA7
-80 Half-Sized Textures/textures/smim/clutter/upperclass/Table_Wood_SinglePiece.dds,B01E75E25406D9C6
-80 Half-Sized Textures/textures/smim/clutter/upperclass/Table_Wood_SinglePiece_n.dds,DF39549E883DCD1C
-80 Half-Sized Textures/textures/smim/clutter/woodfires/smim_campfire_rocks.dds,9E1986A09F5DA0A5
-80 Half-Sized Textures/textures/smim/clutter/woodfires/smim_campfire_rocks_n.dds,D1D5746772AC9E39
-80 Half-Sized Textures/textures/smim/critters/fchawk/smim_hawk.dds,E26E3A3CC56C508
-80 Half-Sized Textures/textures/smim/critters/fchawk/smim_hawk_b.dds,A428B727825AA0B2
-80 Half-Sized Textures/textures/smim/critters/fchawk/smim_hawk_n.dds,2AC59A3DF921503B
-80 Half-Sized Textures/textures/smim/dlc02/critters/smim_tern.dds,BF9A1086AA02326A
-80 Half-Sized Textures/textures/smim/dungeons/dwemer/smim_dwemer_focus_rock.dds,19C770B640344638
-80 Half-Sized Textures/textures/smim/dungeons/dwemer/smim_dwemer_focus_rock_n.dds,8674D37B2A0CE976
-80 Half-Sized Textures/textures/smim/dungeons/mines/smim_wood_mine_beams_x4_seamless.dds,CB342F5895E8CD3D
-80 Half-Sized Textures/textures/smim/dungeons/mines/smim_wood_mine_beams_x4_seamless_n.dds,D3D4256206FBC473
-80 Half-Sized Textures/textures/smim/dungeons/mines/smim_wood_mine_planks.dds,7F7C0752772E4F0F
-80 Half-Sized Textures/textures/smim/dungeons/mines/smim_wood_mine_planks_n.dds,1E4C9EB2ED336D65
-80 Half-Sized Textures/textures/smim/dungeons/mines/smim_wood_mine_smalltile.dds,E15DE2E1EED43EF4
-80 Half-Sized Textures/textures/smim/dungeons/mines/smim_wood_mine_smalltile_n.dds,E9B44DB013145A3
-80 Half-Sized Textures/textures/smim/furniture/noble/smim_poor_coffin.dds,7A0A8B87D05D71AB
-80 Half-Sized Textures/textures/smim/furniture/noble/smim_poor_coffin_n.dds,86D13AC1E63A0FA7
-80 Half-Sized Textures/textures/smim/furniture/nordic/ruinstable_smim_vanillamix.dds,1E5F8E718305E6F8
-80 Half-Sized Textures/textures/smim/furniture/nordic/ruinstable_smim_vanillamix_n.dds,A1E497D6A265EFA
-80 Half-Sized Textures/textures/smim/furniture/prisonercarriage/smim_carriage_metal.dds,EE88AEDCB774B9DA
-80 Half-Sized Textures/textures/smim/furniture/prisonercarriage/smim_carriage_metal_n.dds,C58BFCC52B1B35E4
-80 Half-Sized Textures/textures/smim/furniture/prisonercarriage/smim_carriage_seat.dds,E466B0F72A230B61
-80 Half-Sized Textures/textures/smim/furniture/prisonercarriage/smim_carriage_seat_n.dds,F0BCE043E223EC0
-80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_dome.dds,9F3FE782EBE940E6
-80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_dome_n.dds,274CEAAF4D5B00A6
-80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_door.dds,648F819C6EA53ACB
-80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_door_n.dds,D4C6858296B2C6FD
-80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_metal.dds,8370F3C0789D9132
-80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_metal_n.dds,61AD8ADB827A95E5
-80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_spout.dds,D58F066E91AB71E9
-80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_spout_n.dds,17612DB1888DDB5B
-80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stonework.dds,A592362F2D0ED117
-80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stonework_n.dds,C0E1828C684BBFA0
-80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stucco.dds,35B095E23D57D0A6
-80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stucco_n.dds,B1C6DD30C2EA5323
-80 Half-Sized Textures/textures/smim/landscape/bridges/bridge_pillar_top.dds,D8F0D330190BEBF7
-80 Half-Sized Textures/textures/smim/landscape/bridges/bridge_pillar_top_n.dds,8FD67D13F90BD768
-80 Half-Sized Textures/textures/smim/landscape/bridges/bridge_road_stone_tile.dds,DCFACDE8B51F9551
-80 Half-Sized Textures/textures/smim/landscape/bridges/bridge_road_stone_tile_n.dds,8496F4AF42B11410
-80 Half-Sized Textures/textures/smim/landscape/bridges/smim_bridge_dirt.dds,58EAF4C8E7A77C66
-80 Half-Sized Textures/textures/smim/landscape/bridges/smim_bridge_dirt_n.dds,2460CE3121C73933
-80 Half-Sized Textures/textures/smim/landscape/trees/smim_tundra_tree.dds,FBB18A4E0C90FDFA
-80 Half-Sized Textures/textures/smim/landscape/trees/smim_tundra_tree_n.dds,445202ABCD4AC489
-81 Half-Sized Furniture Skyrim HD Appearance/textures/smim/clutter/common/dresser01.dds,4370C241934045EC
-81 Half-Sized Furniture Skyrim HD Appearance/textures/smim/clutter/common/dresser01_n.dds,E8ABB307D4A1BD3B
-81 Half-Sized Furniture Skyrim HD Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece.dds,A7F4417FFDF8270D
-81 Half-Sized Furniture Skyrim HD Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece_n.dds,5C1F529A2639B68A
-81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/dresser01.dds,2A88C06AD81B53AD
-81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/dresser01_n.dds,E2500A3B1EC47D3D
-81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece.dds,AB6B20E93AECA20C
-81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece_n.dds,CE40022AF9E1A044
-84 Half-Sized Textures Tankard Bright Brushed Metal/textures/smim/clutter/diningset/smim_tankard.dds,50DDE6CB9E45F31D
-84 Half-Sized Textures Tankard Bright Brushed Metal/textures/smim/clutter/diningset/smim_tankard_em.dds,3B89DE1D4C18A4CC
-84 Half-Sized Textures Tankard Bright Brushed Metal/textures/smim/clutter/diningset/smim_tankard_n.dds,24E39D0700FA9D9D
-84 Half-Sized Textures Tankard Bright Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody.dds,1021FDB95267FEE4
-84 Half-Sized Textures Tankard Bright Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_em.dds,384301ED314CA93D
-84 Half-Sized Textures Tankard Bright Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_n.dds,2C276FDEB261964D
-84 Half-Sized Textures Tankard Dark Brushed Metal/textures/smim/clutter/diningset/smim_tankard.dds,D035F280A1F7AFE2
-84 Half-Sized Textures Tankard Dark Brushed Metal/textures/smim/clutter/diningset/smim_tankard_em.dds,1429E76DB5F1C905
-84 Half-Sized Textures Tankard Dark Brushed Metal/textures/smim/clutter/diningset/smim_tankard_n.dds,1756A29429F33439
-84 Half-Sized Textures Tankard Dark Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody.dds,F5CAC14EA674D7E3
-84 Half-Sized Textures Tankard Dark Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_em.dds,57AB7B3BEAFE8C1
-84 Half-Sized Textures Tankard Dark Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_n.dds,262FE896A35688BF
-84 Half-Sized Textures Tankard Pewter Metal/textures/smim/clutter/diningset/smim_tankard.dds,C7F8F4199F9EFFA1
-84 Half-Sized Textures Tankard Pewter Metal/textures/smim/clutter/diningset/smim_tankard_em.dds,D6D5495A1D3A4908
-84 Half-Sized Textures Tankard Pewter Metal/textures/smim/clutter/diningset/smim_tankard_n.dds,B1C2CB2DB81C7686
-84 Half-Sized Textures Tankard Pewter Metal/textures/smim/dlc01/clutter/smim_tankard_bloody.dds,56A48F1682D90FCA
-84 Half-Sized Textures Tankard Pewter Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_em.dds,381A32AF383154E2
-84 Half-Sized Textures Tankard Pewter Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_n.dds,F5A120A9B0B3FA
-90 Ultra-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_fan.dds,9CAA4F8200011A4E
-90 Ultra-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_fan_n.dds,5103C44EE98EA744
-90 Ultra-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_sail.dds,B19D96A3AE118E50
-90 Ultra-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_sail_n.dds,3B8A7F246039C68F
-90 Ultra-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_sail_solitude.dds,49C70759477C97B4
-90 Ultra-Sized Textures/textures/smim/architecture/shackkit/smim_shack_roof.dds,4B90946C4FA1831C
-90 Ultra-Sized Textures/textures/smim/architecture/shackkit/smim_shack_roof_n.dds,21D21F306FC88B23
-90 Ultra-Sized Textures/textures/smim/architecture/whiterun/smim_wr_bench.dds,796EB6565C7B2612
-90 Ultra-Sized Textures/textures/smim/architecture/whiterun/smim_wr_bench_n.dds,B3DBFC1F7E01F4DB
-90 Ultra-Sized Textures/textures/smim/clutter/common/smim_lantern.dds,BEF46910FBFFD60B
-90 Ultra-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest.dds,5B4602448C274FEE
-90 Ultra-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest_n.dds,AC601766FC50945B
-90 Ultra-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest_weathered.dds,928EDEBC8479FBCD
-90 Ultra-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest_weathered_snow.dds,486F2C7D5C10CA1E
-90 Ultra-Sized Textures/textures/smim/clutter/woodfires/smim_campfire_rocks.dds,591D8FC74E5EE038
-90 Ultra-Sized Textures/textures/smim/clutter/woodfires/smim_campfire_rocks_n.dds,B2B8BDA39B4795AB
-90 Ultra-Sized Textures/textures/smim/critters/fchawk/smim_hawk.dds,1E4F59105916DA48
-90 Ultra-Sized Textures/textures/smim/critters/fchawk/smim_hawk_b.dds,2D7A85877428419F
-90 Ultra-Sized Textures/textures/smim/critters/fchawk/smim_hawk_n.dds,FEF0843F90C17C90
-90 Ultra-Sized Textures/textures/smim/furniture/prisonercarriage/smim_carriage_metal.dds,D9F12237FAF4D7B6
-90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_door.dds,1545B5B7A1AF1546
-90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_door_n.dds,3FFC41B3D92FFD8F
-90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_metal.dds,4621C3DF34E5CAFD
-90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_metal_n.dds,FE98D6AABBF1656D
-90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_spout.dds,B7F47E22180752B4
-90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_spout_n.dds,271D22C2C55436E2
-90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stonework.dds,B49EC7E157174296
-90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stonework_n.dds,E60FFDC355B44E51
-90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stucco.dds,99E6DEBA49283E84
-90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stucco_n.dds,1042C0B252DDD969
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbcolumn01.nif,FDEE27BE4AF67153
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbcolumn02.nif,F54CCE87ACF5FB65
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbcorner01.nif,AE7B6A456724DDFB
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbcorner02.nif,115C08B136CB9D1F
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbcorner03.nif,D644F6F08B7CF2CD
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbcorner04.nif,CB45AEA36C8C922A
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbdivider01.nif,134C01963E82BF38
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbdivider02.nif,2F58D2E5A3E8DD93
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbdivider03.nif,E9D8A5848F18DC10
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbdivider04.nif,F5D9926B755B4620
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbicorner01.nif,6C9203E0153494AC
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbicorner02.nif,6F5E1D3EE6FBBF8B
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbicorner03.nif,44C4720B689635AE
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbicorner04.nif,C01D985AEFEDCC2B
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbmiddle01.nif,6746DD5172B81604
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbmiddle02.nif,FB1E1E40F13A1AB8
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbtrapdoor01.nif,536DE88DE5C8712E
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbtrapdoor02.nif,FD1CBD7CD3FC2CE6
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbwall01.nif,EBABF72B7735C04A
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbwall02.nif,C03C8448091D4F
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbwall03.nif,FE6314DE629D9FDF
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbwall04.nif,CDFEAD7D11BD51F8
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbwallentrance01.nif,7073ECC30142448
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbwallentrance02.nif,5BC5102B72F8BDF
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbwallentrance03.nif,5906E51E5B7CDECD
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbwallentrance04.nif,C2AF2E39C1CA0054
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbwallentrance05.nif,CAE2161357375989
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbwalltrapdoor01.nif,CB6490632BBBF6BE
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbwell01.nif,52AA424A2C97E8A6
-00 Core/meshes/architecture/farmhouse/interior/basement/farmbwellent01.nif,46FBFBFC63A9E780
-00 Core/meshes/architecture/farmhouse/interior/basement/farmhousejaildoor01.nif,319EAE0AC8C40D55
-00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01mid.nif,C3B338AD006EBC9D
-00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01top.nif,9EAE89171CC30EE1
-00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam04.nif,5EFEF3EFFC991BCC
-00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam05.nif,F648AE99358DA217
-00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeamloft01.nif,E4F52E2A8F6BECFE
-00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeamwing01.nif,CAED51A757570515
-00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestrdouble02.nif,4CD58FDDB24A971C
-00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrchimney01.nif,DE709420DD632853
-00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrdoortrans01.nif,18B584E705514FFA
-00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrmaindoor01.nif,9C314DAC66117825
-00 Core/meshes/architecture/whiterun/wrinteriors/wrdungeon/wrdunintstairsdown01.nif,C71CD6FD6C632831
-00 Core/meshes/architecture/whiterun/wrinteriors/wrskyforgeunderforge/caveghall2way02uf.nif,7562384E23F5F986
-00 Core/meshes/dlc02/dungeons/dwemer/facades/dlc2dwefacadeliftdown01.nif,DA09A55B29D59E31
-00 Core/meshes/dlc02/dungeons/dwemer/facades/dlc2dwefacadeliftup01.nif,E81AC3967857EA9C
-00 Core/meshes/dungeons/caves/green/balcony/cavegbalconycorner02.nif,C62D95012CFB73B
-00 Core/meshes/dungeons/caves/green/balcony/cavegbalconycurve01.nif,524CDD24EB28C02
-00 Core/meshes/dungeons/caves/green/balcony/cavegbalconycurve02.nif,CFA426AAB9C94F02
-00 Core/meshes/dungeons/caves/green/balcony/cavegbalconycurve03.nif,A7A3D79C91BD76C5
-00 Core/meshes/dungeons/caves/green/balcony/cavegbalconycurve04.nif,B6CAFFDE08E70930
-00 Core/meshes/dungeons/caves/green/balcony/cavegbalconyramp01.nif,D83C2A967712D40D
-00 Core/meshes/dungeons/caves/green/balcony/cavegbalconyramp02.nif,EE95872764F51E3C
-00 Core/meshes/dungeons/caves/green/balcony/cavegbalconystraight01.nif,FCC29DBCBE5DB55F
-00 Core/meshes/dungeons/caves/green/balcony/cavegbalconystraight02.nif,C26678525F305646
-00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffs01.nif,A2E3A29856850B9C
-00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffs02.nif,47EB68C433DDE761
-00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffs03.nif,922117601748264B
-00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffs03ns.nif,715D35ED60CBF049
-00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffscornerin01.nif,98108400462F6FCD
-00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffscornerin01ns.nif,A0E9D2039E976E48
-00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffscornerout01.nif,284CD5E62AFEC392
-00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffscornerout01ns.nif,BED76A5E307372DA
-00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffsisland01.nif,1473F7D8BC31ABE4
-00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffsisland01ns.nif,50C14B9F66636A1A
-00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconycurve01.nif,390E949E795D2939
-00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconycurve02.nif,C1A6EE6A38445D41
-00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconycurve03.nif,E51DBE251D697DB
-00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconycurve04.nif,C5BB6DB1A41DDAD4
-00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconyramp01.nif,8385C861E0DDC04F
-00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconyramp02.nif,FEA138F4BBF549D3
-00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconystraight01.nif,F2BF96AA386EDB9F
-00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconystraight02.nif,F5E74E2AB1E2438B
-00 Core/meshes/dungeons/caves/green/largewall/caveglewalldoor01.nif,3D61D9A6848462EA
-00 Core/meshes/dungeons/caves/green/largewall/caveglwalldoor01.nif,CB0BC46F4C0A3594
-00 Core/meshes/dungeons/caves/green/pillars/cavegepillar01.nif,C524D4FD2E791131
-00 Core/meshes/dungeons/caves/green/pillars/cavegepillar02.nif,545892AC2761ED15
-00 Core/meshes/dungeons/caves/green/pillars/cavegepillar03.nif,679C9219E01EFC41
-00 Core/meshes/dungeons/caves/green/pillars/cavegepillar04.nif,E3C0AB77BA7B5E72
-00 Core/meshes/dungeons/caves/green/pillars/cavegepillar05.nif,83022A7DC68DEF13
-00 Core/meshes/dungeons/caves/green/pillars/cavegepillar06.nif,368D1CC767850B2B
-00 Core/meshes/dungeons/caves/green/smallhall/caveghall2way02.nif,5DEA7E3B9F6E3D73
-00 Core/meshes/dungeons/caves/green/smallhall/caveghall2way02c.nif,583DAA29CA4890F5
-00 Core/meshes/dungeons/caves/green/smallwall/cavegwalldoor01.nif,67FB520236C56311
-00 Core/meshes/dungeons/caves/ice/cliffs/caveicliffs01.nif,9E7FCBFC65A63041
-00 Core/meshes/dungeons/caves/ice/cliffs/caveicliffs02.nif,437C8621068FAB19
-00 Core/meshes/dungeons/caves/ice/frozenwall/caveifwalldoorl01.nif,F2E96A1818ABE7C3
-00 Core/meshes/dungeons/caves/ice/largewall/caveilwalldoorl01.nif,373DA46F3F05077A
-00 Core/meshes/dungeons/caves/ice/rockwall/caveirwalldoorl01.nif,E9112E7B875AB977
-00 Core/meshes/dungeons/caves/ice/rockwall/caveirwalldoorlb01.nif,E1FFE3752D960F3D
-00 Core/meshes/dungeons/caves/ice/rockwall/caveirwalldoorlb03.nif,EC0664304D22327C
-00 Core/meshes/dungeons/caves/ice/rockwall/caveirwalldoorlr01.nif,CAACB21CE9E282FE
-00 Core/meshes/dungeons/caves/ice/shaftwall/caveiswalldoorl01.nif,33B821608467A288
-00 Core/meshes/dungeons/dwemer/animated/blackreachlock/atunementsphere01.nif,27E7DA6B71B9B5C5
-00 Core/meshes/dungeons/dwemer/animated/observatory/dweobservatorychamber01.nif,29CB218118C38466
-00 Core/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg1way01.nif,25CFA435DFB07D56
-00 Core/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg1way02.nif,3331A2A4CF29F0F1
-00 Core/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg1wayendcap01.nif,2F6F823D12F4CFE7
-00 Core/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg1wayramp256.nif,776FA12B65EF5F1A
-00 Core/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg2way01.nif,C537BFC276274FE
-00 Core/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg3way01.nif,A97A0DE7B9FB15E5
-00 Core/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg3way02.nif,68958164CD9FB4C2
-00 Core/meshes/dungeons/nordic/levers/ruinslever01/norlever01.nif,73B97CFABA136900
-00 Core/meshes/dungeons/nordic/levers/ruinslever02/norlever02.nif,E22E56CB21F8136C
-00 Core/textures/smim/dlc02/clutter/ingredients/smim_tern_ingredient.dds,930B04AF5619B33B
-00 Core/textures/smim/dungeons/caves/green/smim_caveg_dirtcliffsroots.dds,8B981FD847EF6CF0
-00 Core/textures/smim/dungeons/caves/green/smim_caveg_dirtcliffsroots_n.dds,D95E74049ABCF709
-01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfacenobletableroundchairs01.nif,D5AFCA7EEBDAA112
-01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfacenobletablesquarechairs01.nif,566C2AF482104CD5
-01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceupperbedsingle01.nif,97BAE00D292844BD
-01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceupperbench01.nif,6A84BE10FB9F0FE0
-01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceupperchair01.nif,B7B63F75C0019B61
-01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceupperdresser01.nif,CF8F78FFABB84476
-01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceupperendtable01.nif,A99A7EE29AA07CA4
-01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceuppershelf01.nif,C97F352A66248271
-01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceuppershelfdisplay01.nif,F17A2FE4CB40379C
-01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceuppertabledrawers01.nif,AA90EB3A611AFAC4
-01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceuppertabledrawersdisplay02.nif,693939B77CC44F75
-01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceuppertableround01.nif,F82A0FAFF2ED0223
-01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceuppertablesquare01.nif,1B692FBA4AAA1E3C
-01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceupperwardrobe01.nif,57B7AE626E882727
-04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/interior/basement/farmbwell01.nif,50C5C17790E6D1EC
-04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/interior/basement/farmbwell01.nif,50C5C17790E6D1EC
-05 Chains 3D - Misc/meshes/dlc02/dungeons/dwemer/clutter/dlc2dweclutterfirepot01.nif,1071383DBE3B3C22
+--- Screenshots ---/3D Chains Misc.jpg,823faa976fffa5a7
+--- Screenshots ---/3D Chains Pull Levers.jpg,0531c1d59bdbb5bc
+--- Screenshots ---/3D Chains Signs.jpg,1b8baee8fe4793d2
+--- Screenshots ---/3D Chains Whiterun.jpg,be5a218aee811065
+--- Screenshots ---/3DDungeonRopes.jpg,c87c16e91e7928d1
+--- Screenshots ---/barrels.jpg,d4374f386d555c2b
+--- Screenshots ---/Barrels_NewTextures.jpg,da5cf5a08bb97bee
+--- Screenshots ---/Barrels_NewTexturesAnimate.jpg,3016e45dc86f94f9
+--- Screenshots ---/Barrels_Rustic.jpg,9a0f9d7497693511
+--- Screenshots ---/Barrels_VanillaTextures.jpg,7264b7aff1b8f20b
+--- Screenshots ---/Barrels_VanillaTexturesAnimate.jpg,bd68cffb065ee737
+--- Screenshots ---/Blurry.jpg,626d3a4d61716945
+--- Screenshots ---/Bonemeal.jpg,f299a646e185d524
+--- Screenshots ---/BridgeSMIMComp.jpg,66e0f1621105883a
+--- Screenshots ---/BridgesRealRoads.jpg,111846e6cae49ed2
+--- Screenshots ---/Bridges_Stonework_Comp.jpg,36afce964aab2cbf
+--- Screenshots ---/Candelabras.jpg,8b8668a7444770e3
+--- Screenshots ---/CarriageSeat.jpg,954193044fd8a81d
+--- Screenshots ---/Chandeliers.jpg,223a449f0318f0c7
+--- Screenshots ---/Clothing _Fix.jpg,c27a1759505a2df7
+--- Screenshots ---/Custom.jpg,a7ea6c53e1de0a16
+--- Screenshots ---/CustomOS.jpg,7901fa5dedf318cc
+--- Screenshots ---/CustomSE.jpg,51caba4f4056e89c
+--- Screenshots ---/DraugrCorpses-Comp.jpg,a635c81f598cce19
+--- Screenshots ---/Dwemer Clutter Comp.jpg,d3e91981b8a917d7
+--- Screenshots ---/DwemerAnimatedLifts.jpg,251c3088243a19ff
+--- Screenshots ---/Empty.jpg,c6be01a0a6b86518
+--- Screenshots ---/Everything.jpg,7aa6e3ba7ed50f16
+--- Screenshots ---/EverythingNoDragonborn.jpg,6b7cf3b1b6adac83
+--- Screenshots ---/EverythingSE.jpg,d3ca67f825e473e2
+--- Screenshots ---/EverythingWithDragonborn.jpg,5155795a895afaa6
+--- Screenshots ---/farmhouse.jpg,ebc6c9db787a1973
+--- Screenshots ---/FarmhouseWoodPost_Comp.jpg,8381705ccb259556
+--- Screenshots ---/FarmhouseWovenFenceComp.jpg,54e19cd051680a03
+--- Screenshots ---/FarmhouseWovenFenceGray.jpg,d06c59a36559cc49
+--- Screenshots ---/FarmhouseWovenFenceLessFlicker.jpg,68b424a9b4639dd2
+--- Screenshots ---/Farmhouse_3D_Ropes.jpg,cf1b48b89e85df3e
+--- Screenshots ---/food.jpg,7531b0682fbe8323
+--- Screenshots ---/Food_SMIM.jpg,a79a093dc9d44b5f
+--- Screenshots ---/Furniture_Chest_SMIM.jpg,5c576a34346b2fad
+--- Screenshots ---/Furniture_SMIM.jpg,e46b147ac95e080c
+--- Screenshots ---/Hanging_Rings.jpg,727b072963db4f24
+--- Screenshots ---/Hawk.jpg,63827444ad072a6a
+--- Screenshots ---/Hearthfire-Lock.jpg,b644b8e53daf3ac9
+--- Screenshots ---/Imperial_Jail.jpg,1fc5402428c3fe39
+--- Screenshots ---/Imperial_Jail_Brighter.jpg,8f2b541c04b2b7f3
+--- Screenshots ---/JuniperComp.jpg,ce59a31bb20771de
+--- Screenshots ---/Lantern-Comp.jpg,fda0635626b18ecf
+--- Screenshots ---/LiteNoDragonborn.jpg,a396b455a3ec56d1
+--- Screenshots ---/LiteSE.jpg,7b0635358f71f8b4
+--- Screenshots ---/LiteWithDragonborn.jpg,ceef3b087af7cf8e
+--- Screenshots ---/MergedPlugin.jpg,9dcc9007175e0ae1
+--- Screenshots ---/MinesRopesAndScaffolding.jpg,f96da23b75d18efd
+--- Screenshots ---/NobleChairComp.jpg,f9c79c7263adc1cf
+--- Screenshots ---/Nordic_Marble_Comp.jpg,2add9a45a16795f4
+--- Screenshots ---/OrcBeams.jpg,0b74cbc114ec1a13
+--- Screenshots ---/PoorCoffin.jpg,860039e4ac93f36f
+--- Screenshots ---/PullLever_Full.jpg,2bc93913aa1045ac
+--- Screenshots ---/PullLever_Full_Smaller_Chain.jpg,d29c109cefc4b274
+--- Screenshots ---/PullLever_Lite.jpg,1bce8afc618042d3
+--- Screenshots ---/RabbitComp.jpg,15bbfe69862ee082
+--- Screenshots ---/Raven_Rock_Ropes.jpg,91c23454b4da80ae
+--- Screenshots ---/RiftenRopes.jpg,13b2034932fffbbf
+--- Screenshots ---/RiftenRopesTextureComp.jpg,627ef15af2ab7007
+--- Screenshots ---/Rings.jpg,ed7e27e4aec455d6
+--- Screenshots ---/Rocks_Blackreach_Comp.jpg,db4e94e262c4f445
+--- Screenshots ---/Rocks_Render_Comp.jpg,146810d78c65894c
+--- Screenshots ---/Sarcophagus.jpg,f6262d5dbf77f880
+--- Screenshots ---/ShackRoof.jpg,451e4e69a7b765de
+--- Screenshots ---/Signs_SMIM.jpg,234e2f0088b88477
+--- Screenshots ---/Skeleton-Comp.jpg,959861d4c6d42166
+--- Screenshots ---/SkullFixComp.jpg,cdeae9a314f5c807
+--- Screenshots ---/Smelter-Full.jpg,6c52d3b212f96938
+--- Screenshots ---/SMIM_CoverImage_Bnet-XBoxLite.jpg,4e8d954123286829
+--- Screenshots ---/SnowSkirtFix.jpg,82ab313ce50c361d
+--- Screenshots ---/SolitudeDocksRopes.jpg,1d1fc99cc59cede4
+--- Screenshots ---/SolitudeGate.jpg,e1bfea712176b8cc
+--- Screenshots ---/Soulcairn_Comparison.jpg,8d17b4a96c110530
+--- Screenshots ---/StockadePosts-Comp.jpg,42cd3d20c4af5359
+--- Screenshots ---/Table_SkyrimHD.jpg,9662948b53ae2285
+--- Screenshots ---/Table_SkyrimHD_Weathered.jpg,58fd0810c42797e4
+--- Screenshots ---/Table_SMIM_Default.jpg,13c7ae67a7168afa
+--- Screenshots ---/Tankard_Comp-4Way.jpg,0f2cd3ddf3471a82
+--- Screenshots ---/Tomato_Comparison.jpg,77b8d364e6eb3452
+--- Screenshots ---/TundraTree.jpg,285c4ad97a9f8942
+--- Screenshots ---/Whiterun_Wood_Carvings_Options.jpg,f35ad445e7377dd1
+--- Screenshots ---/Windmills.jpg,95b0d9379ed41882
+--- Screenshots ---/Windmill_Sails.jpg,bce93a7590980369
+--- Screenshots ---/WRDrawbridge_SMIM.jpg,f29fb6516d82689c
+--- Screenshots ---/WR_Door_Comp.jpg,7a045c5ad1f2d78a
+00 Core/meshes/animobjects/animobjectquill.nif,be4440b2e235f5e5
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbcolumn01.nif,fdee27be4af67153
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbcolumn02.nif,f54cce87acf5fb65
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbcorner01.nif,ae7b6a456724ddfb
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbcorner02.nif,115c08b136cb9d1f
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbcorner03.nif,d644f6f08b7cf2cd
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbcorner04.nif,cb45aea36c8c922a
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbdivider01.nif,134c01963e82bf38
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbdivider02.nif,2f58d2e5a3e8dd93
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbdivider03.nif,e9d8a5848f18dc10
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbdivider04.nif,f5d9926b755b4620
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbicorner01.nif,6c9203e0153494ac
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbicorner02.nif,6f5e1d3ee6fbbf8b
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbicorner03.nif,44c4720b689635ae
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbicorner04.nif,c01d985aefedcc2b
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbmiddle01.nif,6746dd5172b81604
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbmiddle02.nif,fb1e1e40f13a1ab8
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbtrapdoor01.nif,536de88de5c8712e
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbtrapdoor02.nif,fd1cbd7cd3fc2ce6
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwall01.nif,ebabf72b7735c04a
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwall02.nif,00c03c8448091d4f
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwall03.nif,fe6314de629d9fdf
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwall04.nif,cdfead7d11bd51f8
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwallentrance01.nif,07073ecc30142448
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwallentrance02.nif,05bc5102b72f8bdf
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwallentrance03.nif,5906e51e5b7cdecd
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwallentrance04.nif,c2af2e39c1ca0054
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwallentrance05.nif,cae2161357375989
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwalltrapdoor01.nif,cb6490632bbbf6be
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwell01.nif,52aa424a2c97e8a6
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwellent01.nif,46fbfbfc63a9e780
+00 Core/meshes/architecture/farmhouse/interior/basement/farmhousejaildoor01.nif,319eae0ac8c40d55
+00 Core/meshes/architecture/farmhouse/interior/basement - Shortcut.lnk,a8106a400220d6a8
+00 Core/meshes/architecture/farmhouse/interior/farmint2basementent01.nif,5bb3dca6bf93c3fc
+00 Core/meshes/architecture/farmhouse/interior/farmint2doorway02nodoor.nif,53c19f42c1af4f39
+00 Core/meshes/architecture/farmhouse/interior/farmint2doorway03.nif,25b0c93012ac43f8
+00 Core/meshes/architecture/farmhouse/interior/farmint2doorway04.nif,0ec46593853023da
+00 Core/meshes/architecture/farmhouse/interior/farmint2end01.nif,ee790b9f626dbc3c
+00 Core/meshes/architecture/farmhouse/interior/farmint2end02.nif,27e12e5d35add3fb
+00 Core/meshes/architecture/farmhouse/interior/farmint2end03.nif,b48dafd01b67d9d9
+00 Core/meshes/architecture/farmhouse/interior/farmint2hearth02.nif,60e3f326ba4a0f2a
+00 Core/meshes/architecture/farmhouse/interior/farmint2wall01.nif,57e925339403776b
+00 Core/meshes/architecture/farmhouse/interior/farmintcorner01.nif,edd54f510dd17d86
+00 Core/meshes/architecture/farmhouse/interior/farmintdoorway01.nif,0f916bc4d9eb1ed6
+00 Core/meshes/architecture/farmhouse/interior/farmintend01.nif,c2084c9b3afa4e4e
+00 Core/meshes/architecture/farmhouse/interior/farmintend02.nif,c4dac9085e8a4384
+00 Core/meshes/architecture/farmhouse/interior/farmintend03.nif,4479668ba6122004
+00 Core/meshes/architecture/farmhouse/interior/farmintinnend01.nif,3c672480511ff580
+00 Core/meshes/architecture/farmhouse/interior/farmintinnend02.nif,b3431bd77afd12fc
+00 Core/meshes/architecture/farmhouse/interior/farmintinnend03.nif,211c8dc2dcfcf502
+00 Core/meshes/architecture/farmhouse/interior/farmintinnend04.nif,ee14095105935e44
+00 Core/meshes/architecture/farmhouse/interior/farmintinnend05.nif,a78b2b23a5ff2dce
+00 Core/meshes/architecture/farmhouse/interior/farmintinnend06.nif,4276aa21c4cf8e29
+00 Core/meshes/architecture/farmhouse/interior/farmintinnwall01.nif,188932b388300414
+00 Core/meshes/architecture/farmhouse/interior/farmintinnwallentrance01.nif,2cc5ef95770fc43e
+00 Core/meshes/architecture/farmhouse/interior/farmintlhback01.nif,b9278d6c5f93ed24
+00 Core/meshes/architecture/farmhouse/interior/farmintlhend01.nif,8734bc172c627db4
+00 Core/meshes/architecture/farmhouse/interior/farmintlhend02.nif,6c5b89208425be6d
+00 Core/meshes/architecture/farmhouse/interior/farmintlhfirepit01.nif,97622dddc06e166b
+00 Core/meshes/architecture/farmhouse/interior/farmintlhfirepit03.nif,1672891c7d2620a1
+00 Core/meshes/architecture/farmhouse/interior/farmintlhfront01.nif,97b41ba959bbbd57
+00 Core/meshes/architecture/farmhouse/interior/farmintlhloft01.nif,5edb8f6ddc83ca6a
+00 Core/meshes/architecture/farmhouse/interior/farmintlhloft02.nif,058b4fcfd7592b90
+00 Core/meshes/architecture/farmhouse/interior/farmintlhlofttop01.nif,c24bfd555bcdbcc8
+00 Core/meshes/architecture/farmhouse/interior/farmintlhmid01.nif,a3aa93972104ded8
+00 Core/meshes/architecture/farmhouse/interior/farmintwall01.nif,ea1a190648305e2a
+00 Core/meshes/architecture/farmhouse/interior/farmintwallhearth01.nif,9fe475c059273ce8
+00 Core/meshes/architecture/farmhouse/interior/farmintwallhearth02.nif,87284e7cab8a3c7d
+00 Core/meshes/architecture/farmhouse/interior/farmintwbasementent01.nif,cc5bce7c4a746cc7
+00 Core/meshes/architecture/farmhouse/interior/farmintwooddoorway01.nif,dd5148e501be2db1
+00 Core/meshes/architecture/farmhouse/interior/farmintwoodend01.nif,7b9e6e123163d26c
+00 Core/meshes/architecture/farmhouse/interior/farmintwoodend02.nif,630b2a1c269fc647
+00 Core/meshes/architecture/farmhouse/interior/farmintwoodwall01.nif,0d683afc917d8fc1
+00 Core/meshes/architecture/farmhouse/rubble/farmhousebrubble01.nif,90dcf046f08ab4f9
+00 Core/meshes/architecture/farmhouse/walkway/walkway01.nif,27b6c77faa4d6eb8
+00 Core/meshes/architecture/farmhouse/walkway/walkway02.nif,3610cbbb6314ad4c
+00 Core/meshes/architecture/farmhouse/walkway/walkwaybend01.nif,1488f105ba0fd0bd
+00 Core/meshes/architecture/farmhouse/walkway/walkwaybend02.nif,96b7eb6e7050af8f
+00 Core/meshes/architecture/farmhouse/walkway/walkwaybend03.nif,e5d778b13bf29a0e
+00 Core/meshes/architecture/farmhouse/walkway/walkwayc01.nif,d08cc391b7b9ca73
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycend01.nif,d5aaafdbbc5ac9ed
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycend02.nif,8aa41afe7b16e220
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycentwall01.nif,d8ae00b27f53eb73
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycentwall02.nif,a84c08dae30caf57
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycwall01.nif,41734632fec85f33
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycwallend01.nif,787bcddeccac3250
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycwallend02.nif,3e3706562b596a2a
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycwallend03.nif,011be387772dc816
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycwallend04.nif,125311d3cf7a9336
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycwallgate01.nif,bee934405a9b4d78
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycwallgate02.nif,b4d6cf9bb35f5a67
+00 Core/meshes/architecture/farmhouse/walkway/walkwayend01.nif,362f8078f24ce4c0
+00 Core/meshes/architecture/farmhouse/walkway/walkwayfull01.nif,d005e5072297f432
+00 Core/meshes/architecture/farmhouse/walkway/walkwayfull02.nif,cf09d272cf3099b5
+00 Core/meshes/architecture/farmhouse/walkway/walkwayfull03.nif,d6ca219cd7ad48dc
+00 Core/meshes/architecture/farmhouse/walkway/walkwayramp01.nif,09e2ba187374cd4f
+00 Core/meshes/architecture/farmhouse/walkway/walkwayrend01.nif,19a07a636363f585
+00 Core/meshes/architecture/farmhouse/walkway/walkwaystairs1.nif,fa3773c281852501
+00 Core/meshes/architecture/farmhouse/walkway/walkwaystairs15.nif,e1885cbec16fe7ed
+00 Core/meshes/architecture/farmhouse/walkway/walkwaystairs3.nif,48cc50b675c7b8c7
+00 Core/meshes/architecture/farmhouse/walkway/walkwaystairs4.nif,5cb2d5ec50bd65c3
+00 Core/meshes/architecture/farmhouse/walkway/walkwaystairs8.nif,fdcea87754889af5
+00 Core/meshes/architecture/farmhouse/farmbannerpost01.nif,aa56a68884eeff3d
+00 Core/meshes/architecture/farmhouse/farmhouse01.nif,7b21a396b3e8e5b1
+00 Core/meshes/architecture/farmhouse/farmhouse01walkway.nif,6d44cbef75bba9ef
+00 Core/meshes/architecture/farmhouse/farmhouse02.nif,7bd8516e44d2ed81
+00 Core/meshes/architecture/farmhouse/farmhouse02walkway.nif,351371b0b61cb847
+00 Core/meshes/architecture/farmhouse/farmhouse03.nif,bf6bcd1c50d3bdbd
+00 Core/meshes/architecture/farmhouse/farmhouse03walkway.nif,6c31f3cc2752337f
+00 Core/meshes/architecture/farmhouse/farmhouse04.nif,4b0efaf3fd85ff49
+00 Core/meshes/architecture/farmhouse/farmhouse04walkway.nif,1dee9de7fb505c17
+00 Core/meshes/architecture/farmhouse/farmhouse05.nif,f8bd11651a084f4e
+00 Core/meshes/architecture/farmhouse/farmhouse05destroyed01.nif,92406ecde5a485d4
+00 Core/meshes/architecture/farmhouse/farmhouse05destroyed02.nif,aab82abbe213ea34
+00 Core/meshes/architecture/farmhouse/farmhouse06.nif,ef052f5a04bfd31d
+00 Core/meshes/architecture/farmhouse/farmhouse06destroyed01.nif,32a48cbfe9cbf3a4
+00 Core/meshes/architecture/farmhouse/farmhouse06destroyed02.nif,6a991b17e23dafd8
+00 Core/meshes/architecture/farmhouse/farmlonghouse01.nif,ba18aca872189447
+00 Core/meshes/architecture/farmhouse/farmwell01.nif,a0886c1e7f290f6a
+00 Core/meshes/architecture/farmhouse/inn01.nif,f759ad05898435b9
+00 Core/meshes/architecture/farmhouse/inndestroyed01.nif,dcd6d877991331b8
+00 Core/meshes/architecture/farmhouse/inndestroyed02.nif,4d7407e9450ad203
+00 Core/meshes/architecture/farmhouse/lumbermill01.nif,e4bcb62767bcf115
+00 Core/meshes/architecture/farmhouse/lumbermill01waterwheel01.nif,c7a7a59e6879c612
+00 Core/meshes/architecture/farmhouse/lumbermill01waterwheel02.nif,3cd096743cbd1aae
+00 Core/meshes/architecture/farmhouse/smith01.nif,bca491a04ac0ea70
+00 Core/meshes/architecture/highhrothgar/mqetchedshrine.nif,0ae8f91990f99f08
+00 Core/meshes/architecture/markarth/mrkmillroof01.nif,f8ac5745564ea8f6
+00 Core/meshes/architecture/markarth/mrksilverfishinnpart01.nif,538d3459473e8c9b
+00 Core/meshes/architecture/riften/riftenkeepdoor01.nif,1c657ee1ac629aeb
+00 Core/meshes/architecture/shackkit/shackwalll01.nif,07ff20b273f05f55
+00 Core/meshes/architecture/shackkit/shackwalll02.nif,e2a830e30f08d192
+00 Core/meshes/architecture/shackkit/shackwallr01.nif,f069af1daad3f5b3
+00 Core/meshes/architecture/shackkit/shackwallr02.nif,0d00022cfbe348c5
+00 Core/meshes/architecture/shackkit/shackwalltop01.nif,5a162a9f5e525308
+00 Core/meshes/architecture/shackkit/shackwalltopwindow01.nif,3e8cda35c6524633
+00 Core/meshes/architecture/solitude/farms/slumbermill01.nif,ea17dbeb6b69d9bb
+00 Core/meshes/architecture/solitude/interiors/slgdarchfire02.nif,c0220ee4967400f9
+00 Core/meshes/architecture/solitude/sblacksmith.nif,abe0fad8aa1d8bfb
+00 Core/meshes/architecture/solitude/sbridge01.nif,6375aea41fc38514
+00 Core/meshes/architecture/solitude/seastempireco.nif,2a2492e8f659b641
+00 Core/meshes/architecture/solitude/spatiowallentrance.nif,87dbcaf56585866c
+00 Core/meshes/architecture/solitude/sthalmorembassy.nif,37cf2367e6d21f33
+00 Core/meshes/architecture/tents/largeimperialtent01.nif,b89ba1908cdbfa79
+00 Core/meshes/architecture/whiterun/wrbuildings/wrcastleentrance01.nif,ce30051bdbfb94c2
+00 Core/meshes/architecture/whiterun/wrbuildings/wrcastlemainbuilding01.nif,5e423a559a686fa3
+00 Core/meshes/architecture/whiterun/wrbuildings/wrcastlestonetowertop01.nif,cc1e9c4451d99295
+00 Core/meshes/architecture/whiterun/wrbuildings/wrmarketstand01.nif,d7f8c207ccb0b36c
+00 Core/meshes/architecture/whiterun/wrbuildings/wrmarketstand03.nif,abf050f043dab799
+00 Core/meshes/architecture/whiterun/wrbuildings/wrmarketstand03destroyed.nif,2065d2a98022a494
+00 Core/meshes/architecture/whiterun/wrbuildings/wrtempleofk01.nif,883c40326f6258b4
+00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01mid.nif,c3b338ad006ebc9d
+00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01top.nif,9eae89171cc30ee1
+00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam04.nif,5efef3effc991bcc
+00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam05.nif,f648ae99358da217
+00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeamloft01.nif,e4f52e2a8f6becfe
+00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeamwing01.nif,caed51a757570515
+00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestrdouble02.nif,4cd58fddb24a971c
+00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrchimney01.nif,de709420dd632853
+00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrdoortrans01.nif,18b584e705514ffa
+00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrmaindoor01.nif,9c314dac66117825
+00 Core/meshes/architecture/whiterun/wrinteriors/wrdungeon/wrdunintstairsdown01.nif,c71cd6fd6c632831
+00 Core/meshes/architecture/whiterun/wrinteriors/wrskyforgeunderforge/caveghall2way02uf.nif,7562384e23f5f986
+00 Core/meshes/architecture/whiterun/wrinteriors/wrintfreewallcolumwall01.nif,8701daac1b94cb1a
+00 Core/meshes/architecture/whiterun/wrinteriors/wrintroofwall03.nif,85b337ce2de803b8
+00 Core/meshes/architecture/whiterun/wrscaffold/wrscafguardtower01.nif,c2a5b74bebd7646c
+00 Core/meshes/architecture/whiterun/wrscaffold/wrscafguardtower02.nif,873efcd02c6a6695
+00 Core/meshes/architecture/whiterun/wrscaffold/wrscafguardtowerlarge01.nif,9414401fa9059423
+00 Core/meshes/architecture/whiterun/wrscaffold/wrscafguardtowerspikes01.nif,51f8323e4211970a
+00 Core/meshes/architecture/whiterun/wrscaffold/wrscafrailcor01.nif,e63a359b00dcccf9
+00 Core/meshes/architecture/whiterun/wrscaffold/wrscafrailstr01.nif,b005385f5ff1a133
+00 Core/meshes/architecture/whiterun/wrscaffold/wrscafstr01spikes.nif,3de022cab1baf6a2
+00 Core/meshes/architecture/whiterun/wrterrain/wrmainroadmarket.nif,0d9a1bd8ab90e867
+00 Core/meshes/architecture/whiterun/wrterrain/wrstairsplatform01.nif,fb13a87b2839fbe1
+00 Core/meshes/architecture/whiterun/wrterrain/wrterwind01.nif,12c01701034e91e4
+00 Core/meshes/architecture/whiterun/wrterrain/wrtreecircle01.nif,f202faa4a453a205
+00 Core/meshes/architecture/windhelm/whwallwulfharth.nif,411693c0cf9c4f0c
+00 Core/meshes/betterdynamicsnow/shader/snowshader.nif,20508f83cc27e1ad
+00 Core/meshes/clutter/blackreach/blackreachcrystall01.nif,dd9d87fd87973d84
+00 Core/meshes/clutter/blackreach/blackreachcrystall02.nif,c1d5894b9d0f20a0
+00 Core/meshes/clutter/blackreach/blackreachcrystall04.nif,771050b0d2801848
+00 Core/meshes/clutter/blackreach/blackreachcrystalm02.nif,bac7119b8bca568c
+00 Core/meshes/clutter/blackreach/blackreachcrystalm03.nif,9c100271938e08bf
+00 Core/meshes/clutter/blackreach/blackreachcrystalpiles02.nif,18db8dc2010a3d75
+00 Core/meshes/clutter/blackreach/blackreachcrystalpiles04.nif,5be85680d40e0f55
+00 Core/meshes/clutter/blackreach/blackreachcrystals02.nif,d089472c7672f9e2
+00 Core/meshes/clutter/blackreach/blackreachcrystals03.nif,205b7e75e4661073
+00 Core/meshes/clutter/blackreach/blackreachtinymushroom01.nif,2c0654953ab4b337
+00 Core/meshes/clutter/blackreach/blackreachtinymushroom02.nif,0211c0c68438615d
+00 Core/meshes/clutter/caves/cave_lamp01.nif,af80b172660b812a
+00 Core/meshes/clutter/caves/cave_lamp02.nif,91d8be1182df9316
+00 Core/meshes/clutter/common/archerytarget01.nif,4540292b1bf7619e
+00 Core/meshes/clutter/common/archerytargettripod01.nif,a981c5417529430c
+00 Core/meshes/clutter/common/cratesmall01.nif,90b6c67b9b9e2059
+00 Core/meshes/clutter/common/cratesmall01eeco.nif,63ed76d680822581
+00 Core/meshes/clutter/common/cratesmall02.nif,348b39c6ef590e74
+00 Core/meshes/clutter/common/cratesmalllong01.nif,8cf0f1e71a011662
+00 Core/meshes/clutter/common/cratesmalllong01eeco.nif,99ebaa1e6b7714c3
+00 Core/meshes/clutter/common/cratesmalllong02.nif,d73918841d900e63
+00 Core/meshes/clutter/common/lockpick.nif,0113ad2e17e1ec6b
+00 Core/meshes/clutter/common/quill01.nif,fecf24bbfee38c12
+00 Core/meshes/clutter/deadanimals/rabbitmeat01.nif,28edf4519eeb20d5
+00 Core/meshes/clutter/deadanimals/rabbitmeatcooked01.nif,45388f050283a125
+00 Core/meshes/clutter/dwemer/dwarvenscraplarge1.nif,e702e43c6854896f
+00 Core/meshes/clutter/giant/giantobelisk01.nif,32de27a1687cf67f
+00 Core/meshes/clutter/giant/giantobeliskblue01.nif,9bc7af9041964291
+00 Core/meshes/clutter/giant/giantskewer01.nif,56c581f83850b260
+00 Core/meshes/clutter/giant/giantsmokestack01.nif,1c1b676ed37494a0
+00 Core/meshes/clutter/giant/giantspit01.nif,df42b745b3d87da7
+00 Core/meshes/clutter/ingredients/dwarvenoil.nif,1cf81c7bf31bfcb1
+00 Core/meshes/clutter/ingredients/hagclaw.nif,c46ca921bc3acedd
+00 Core/meshes/clutter/ingredients/hawkfeather01.nif,c4132bb8940c9216
+00 Core/meshes/clutter/ingredients/sabrecattooth.nif,8a59d53a76ed8dde
+00 Core/meshes/clutter/quest/giantmortar.nif,684a5a867f267b3c
+00 Core/meshes/clutter/ruins/ruinsfurniturerubble01.nif,d2be4e399e71cceb
+00 Core/meshes/clutter/ruins/ruinsfurniturerubble02.nif,2181d6ae7f806f7b
+00 Core/meshes/clutter/ruins/ruinsfurniturerubble12.nif,0ddf5c87592a8cb4
+00 Core/meshes/clutter/ruins/ruinsfurniturerubble13.nif,5a785ca2ae617a3d
+00 Core/meshes/clutter/ruins/ruinspot01.nif,9bdd5d6bf289152c
+00 Core/meshes/clutter/ruins/ruinspot02.nif,2dbdafd6aa64eaaa
+00 Core/meshes/clutter/ruins/ruinspot03.nif,9e55b9618f0b356b
+00 Core/meshes/clutter/ruins/ruinspot03static.nif,3b289be0648f36fc
+00 Core/meshes/clutter/ruins/ruinspot04.nif,e81f2530b3b22436
+00 Core/meshes/clutter/ruins/ruinspot05.nif,e5bd884fa271e7e3
+00 Core/meshes/clutter/ruins/ruinspot06.nif,0fe641210e04e401
+00 Core/meshes/clutter/ruins/ruinssarcophagusverthole.nif,8fb6009bd3766b0b
+00 Core/meshes/clutter/ruins/ruinssarcophagus_bottom01.nif,3793db7b803014ec
+00 Core/meshes/clutter/ruins/ruins_largechest.nif,ceba219fc89ae146
+00 Core/meshes/clutter/ruins/ruins_smallchest.nif,ea527454bb3d847c
+00 Core/meshes/clutter/statues/statuenamira.nif,0170fd4e37e072bf
+00 Core/meshes/clutter/woodfires/campfire01burning.nif,3ee7b0022a5618f5
+00 Core/meshes/clutter/woodfires/campfire01landburning.nif,3126a557ca24e2e1
+00 Core/meshes/clutter/woodfires/campfire01landoff.nif,6e8bca68714d4aee
+00 Core/meshes/clutter/woodfires/campfire01off.nif,2b521cde741080d8
+00 Core/meshes/clutter/brewerycasklargeclosed01.nif,fa891ad876ac93da
+00 Core/meshes/clutter/brewerycasklargeclosed02.nif,0e35809a16719f80
+00 Core/meshes/clutter/brewerycasklargeopen01.nif,da93a6e8a3575120
+00 Core/meshes/clutter/cookingstone01.nif,8b4a66f0cad81ad1
+00 Core/meshes/clutter/wallbasket02.nif,ab36ed26512a7747
+00 Core/meshes/clutter/wallbaskethex02.nif,dca488156b9d3dc0
+00 Core/meshes/clutter/wallbaskethex03.nif,d5ebfd6b738fa619
+00 Core/meshes/clutter/wallbasketlarge01.nif,cec8fa81c85c43bb
+00 Core/meshes/clutter/wallbasketlarge02.nif,1a001fe35aecaeb1
+00 Core/meshes/dlc01/clutter/vampirecoffinhoriz/vampirecoffinhoriz01.nif,f4ee62a53ab6a09d
+00 Core/meshes/dlc01/clutter/vampirecoffinhoriz/vampirecoffinhoriz02.nif,a5d797a40cc8cfd2
+00 Core/meshes/dlc01/landscape/rocks/dlc01rockcaveentrance01.nif,eaa5ee8ba65352c1
+00 Core/meshes/dlc02/dungeons/dwemer/facades/dlc2dwefacadeliftdown01.nif,da09a55b29d59e31
+00 Core/meshes/dlc02/dungeons/dwemer/facades/dlc2dwefacadeliftup01.nif,e81ac3967857ea9c
+00 Core/meshes/dungeons/caves/green/balcony/cavegbalconycorner02.nif,0c62d95012cfb73b
+00 Core/meshes/dungeons/caves/green/balcony/cavegbalconycurve01.nif,0524cdd24eb28c02
+00 Core/meshes/dungeons/caves/green/balcony/cavegbalconycurve02.nif,cfa426aab9c94f02
+00 Core/meshes/dungeons/caves/green/balcony/cavegbalconycurve03.nif,a7a3d79c91bd76c5
+00 Core/meshes/dungeons/caves/green/balcony/cavegbalconycurve04.nif,b6caffde08e70930
+00 Core/meshes/dungeons/caves/green/balcony/cavegbalconyramp01.nif,d83c2a967712d40d
+00 Core/meshes/dungeons/caves/green/balcony/cavegbalconyramp02.nif,ee95872764f51e3c
+00 Core/meshes/dungeons/caves/green/balcony/cavegbalconystraight01.nif,fcc29dbcbe5db55f
+00 Core/meshes/dungeons/caves/green/balcony/cavegbalconystraight02.nif,c26678525f305646
+00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffs01.nif,a2e3a29856850b9c
+00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffs02.nif,47eb68c433dde761
+00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffs03.nif,922117601748264b
+00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffs03ns.nif,715d35ed60cbf049
+00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffscornerin01.nif,98108400462f6fcd
+00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffscornerin01ns.nif,a0e9d2039e976e48
+00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffscornerout01.nif,284cd5e62afec392
+00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffscornerout01ns.nif,bed76a5e307372da
+00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffsisland01.nif,1473f7d8bc31abe4
+00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffsisland01ns.nif,50c14b9f66636a1a
+00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconycurve01.nif,390e949e795d2939
+00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconycurve02.nif,c1a6ee6a38445d41
+00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconycurve03.nif,0e51dbe251d697db
+00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconycurve04.nif,c5bb6db1a41ddad4
+00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconyramp01.nif,8385c861e0ddc04f
+00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconyramp02.nif,fea138f4bbf549d3
+00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconystraight01.nif,f2bf96aa386edb9f
+00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconystraight02.nif,f5e74e2ab1e2438b
+00 Core/meshes/dungeons/caves/green/largewall/caveglewalldoor01.nif,3d61d9a6848462ea
+00 Core/meshes/dungeons/caves/green/largewall/caveglwalldoor01.nif,cb0bc46f4c0a3594
+00 Core/meshes/dungeons/caves/green/pillars/cavegepillar01.nif,c524d4fd2e791131
+00 Core/meshes/dungeons/caves/green/pillars/cavegepillar02.nif,545892ac2761ed15
+00 Core/meshes/dungeons/caves/green/pillars/cavegepillar03.nif,679c9219e01efc41
+00 Core/meshes/dungeons/caves/green/pillars/cavegepillar04.nif,e3c0ab77ba7b5e72
+00 Core/meshes/dungeons/caves/green/pillars/cavegepillar05.nif,83022a7dc68def13
+00 Core/meshes/dungeons/caves/green/pillars/cavegepillar06.nif,368d1cc767850b2b
+00 Core/meshes/dungeons/caves/green/smallhall/caveghall2way02.nif,5dea7e3b9f6e3d73
+00 Core/meshes/dungeons/caves/green/smallhall/caveghall2way02c.nif,583daa29ca4890f5
+00 Core/meshes/dungeons/caves/green/smallwall/cavegwalldoor01.nif,67fb520236c56311
+00 Core/meshes/dungeons/caves/ice/cliffs/caveicliffs01.nif,9e7fcbfc65a63041
+00 Core/meshes/dungeons/caves/ice/cliffs/caveicliffs02.nif,437c8621068fab19
+00 Core/meshes/dungeons/caves/ice/frozenwall/caveifwalldoorl01.nif,f2e96a1818abe7c3
+00 Core/meshes/dungeons/caves/ice/largewall/caveilwalldoorl01.nif,373da46f3f05077a
+00 Core/meshes/dungeons/caves/ice/rockwall/caveirwalldoorl01.nif,e9112e7b875ab977
+00 Core/meshes/dungeons/caves/ice/rockwall/caveirwalldoorlb01.nif,e1ffe3752d960f3d
+00 Core/meshes/dungeons/caves/ice/rockwall/caveirwalldoorlb03.nif,ec0664304d22327c
+00 Core/meshes/dungeons/caves/ice/rockwall/caveirwalldoorlr01.nif,caacb21ce9e282fe
+00 Core/meshes/dungeons/caves/ice/shaftwall/caveiswalldoorl01.nif,33b821608467a288
+00 Core/meshes/dungeons/dwemer/animated/blackreachlock/atunementsphere01.nif,27e7da6b71b9b5c5
+00 Core/meshes/dungeons/dwemer/animated/observatory/armillary/dweobservatoryarmillary01.nif,4a1212fca14ba3f0
+00 Core/meshes/dungeons/dwemer/animated/observatory/armillary/focusingcrystal01.nif,135a93be15a7f5bd
+00 Core/meshes/dungeons/dwemer/animated/observatory/dome01/dweobservatorydome01.nif,4f88737d08687237
+00 Core/meshes/dungeons/dwemer/animated/observatory/dome02/dweobservatorydome02.nif,be61132bf5770381
+00 Core/meshes/dungeons/dwemer/animated/observatory/dome03/dweobservatorydome03.nif,1bb00904f8b06ae1
+00 Core/meshes/dungeons/dwemer/animated/observatory/dweobservatorychamber01.nif,29cb218118c38466
+00 Core/meshes/dungeons/dwemer/clutter/dwecenturionbust01.nif,95ac05e7282ca86f
+00 Core/meshes/dungeons/dwemer/facades/dwefacadeliftdown01.nif,817f8d58175ec54a
+00 Core/meshes/dungeons/dwemer/facades/dwefacadeliftup01.nif,a3f480ea48c88b2e
+00 Core/meshes/dungeons/imperial/clutterkits/impfloorchunk01.nif,aa970df40ffddc5c
+00 Core/meshes/dungeons/imperial/clutterkits/impfloorchunk02.nif,d882a0725ce0d158
+00 Core/meshes/dungeons/imperial/clutterkits/imprubblepiece01.nif,7ac6ca71a2aa6bee
+00 Core/meshes/dungeons/imperial/clutterkits/imprubblepiece02.nif,ed88fe5e95542b50
+00 Core/meshes/dungeons/imperial/clutterkits/imprubblepiece03.nif,610dbbb0ac7f6e0b
+00 Core/meshes/dungeons/imperial/clutterkits/imprubblepiece04.nif,a029f6ce63e6d36f
+00 Core/meshes/dungeons/imperial/clutterkits/imprubblepiece05.nif,cd4c3a4f0b114a74
+00 Core/meshes/dungeons/imperial/clutterkits/imprubblepile01.nif,1ce7628838f60f84
+00 Core/meshes/dungeons/imperial/clutterkits/imprubblepile02.nif,8f366f36e64522de
+00 Core/meshes/dungeons/imperial/clutterkits/imprubblepile03.nif,3f5f8b23a9edb09e
+00 Core/meshes/dungeons/imperial/clutterkits/imprubblepile04.nif,8abd33503c73bef7
+00 Core/meshes/dungeons/imperial/clutterkits/imprubblepile05.nif,09dae60bb410f273
+00 Core/meshes/dungeons/mines/caveroom/minecroomdoor03.nif,e98e4b869c679c03
+00 Core/meshes/dungeons/mines/cavesmallhall/minechall2way02.nif,5ebccd0da5b45d17
+00 Core/meshes/dungeons/mines/cavesmallhall/minechall2way02c.nif,1df52482f4f866e4
+00 Core/meshes/dungeons/mines/cavesmallwall/minecwalldoor01.nif,7d33a7677774c29b
+00 Core/meshes/dungeons/mines/cavewall/mineclewalldoor01.nif,5cae2f98539b0e85
+00 Core/meshes/dungeons/mines/cavewall/mineclwalldoor01.nif,2e52c64450ff5b9d
+00 Core/meshes/dungeons/mines/cliffs/minecliffs01.nif,7b946b0a20a26d00
+00 Core/meshes/dungeons/mines/cliffs/minecliffs02.nif,324e51d321d2fb44
+00 Core/meshes/dungeons/mines/cliffs/minecliffs03.nif,79a10dc60ae38b98
+00 Core/meshes/dungeons/mines/cliffs/minecliffs03ns.nif,ede41c8d8e2953e1
+00 Core/meshes/dungeons/mines/cliffs/minecliffscornerin01.nif,e9fadc3f15ab3577
+00 Core/meshes/dungeons/mines/cliffs/minecliffscornerin01ns.nif,521dc61fea7a6a3f
+00 Core/meshes/dungeons/mines/cliffs/minecliffscornerout01.nif,a81c3fb81139e549
+00 Core/meshes/dungeons/mines/cliffs/minecliffscornerout01ns.nif,10798e1a9a39a3ce
+00 Core/meshes/dungeons/mines/cliffs/minecliffsisland01.nif,cc35b707ccf74614
+00 Core/meshes/dungeons/mines/cliffs/minecliffsisland01ns.nif,83a193dbff4ff405
+00 Core/meshes/dungeons/mines/clutter/genericwell01.nif,95eb47fabc491bbe
+00 Core/meshes/dungeons/mines/minelargehall/minelhall4way01.nif,de16d85641ea430e
+00 Core/meshes/dungeons/mines/minelargehall/minelhallentrance01.nif,3c6ae89d12254b15
+00 Core/meshes/dungeons/mines/minelargehall/minelhallentrance02.nif,7c3b0821a2336b2b
+00 Core/meshes/dungeons/mines/ore/ingotdwarven.nif,41a3926f1e7a5095
+00 Core/meshes/dungeons/mines/ore/ingotgold.nif,24c33ff6e115448f
+00 Core/meshes/dungeons/mines/rocks/minecboulderl02.nif,66213a095648ee8e
+00 Core/meshes/dungeons/mines/scaffolding/minescaffoldbridge01.nif,8580f8a7d572d028
+00 Core/meshes/dungeons/mines/scaffolding/minescaffoldbridge02.nif,3d458dfb7c0bfdc0
+00 Core/meshes/dungeons/mines/scaffolding/minescaffoldbridge03.nif,347c98834086b7c6
+00 Core/meshes/dungeons/mines/scaffolding/minescaffoldbridge04.nif,7978ffb73aac576f
+00 Core/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg1way01.nif,25cfa435dfb07d56
+00 Core/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg1way02.nif,3331a2a4cf29f0f1
+00 Core/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg1wayendcap01.nif,2f6f823d12f4cfe7
+00 Core/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg1wayramp256.nif,776fa12b65ef5f1a
+00 Core/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg2way01.nif,0c537bfc276274fe
+00 Core/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg3way01.nif,a97a0de7b9fb15e5
+00 Core/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg3way02.nif,68958164cd9fb4c2
+00 Core/meshes/dungeons/nordic/doors/animated/mediumdoor/volunruudleftsworddoor.nif,2e93a2dacff32d04
+00 Core/meshes/dungeons/nordic/doors/animated/mediumdoor/volunruudrightaxedoor.nif,3e691640e622b220
+00 Core/meshes/dungeons/nordic/exterior/nortmpextplanter01.nif,2ae60bbac1dfb823
+00 Core/meshes/dungeons/nordic/exterior/nortmpextplattower01.nif,fb63b82b74cb522e
+00 Core/meshes/dungeons/nordic/exterior/nortmpextplattower02.nif,18178ea66f52ab1f
+00 Core/meshes/dungeons/nordic/levers/ruinslever01/norlever01.nif,73b97cfaba136900
+00 Core/meshes/dungeons/nordic/levers/ruinslever02/norlever02.nif,e22e56cb21f8136c
+00 Core/meshes/dungeons/nordic/platforms/norplatbgcordblend01.nif,8c22774d5c2365d6
+00 Core/meshes/dungeons/nordic/rubble/norrubblepile01.nif,e0e9fd60179ba5a3
+00 Core/meshes/dungeons/nordic/rubble/norrubblepile02.nif,73a5d71609222785
+00 Core/meshes/dungeons/nordic/rubble/norrubblepile03.nif,045550675d46aa7e
+00 Core/meshes/dungeons/nordic/rubble/norrubblepile04.nif,3004d57b378a10bd
+00 Core/meshes/dungeons/nordic/rubble/norrubblepile06.nif,b350ad8fc695d590
+00 Core/meshes/dungeons/nordic/rubble/norrubblepile07.nif,a251c890d713dbde
+00 Core/meshes/dungeons/nordic/rubble/norrubblepile08.nif,371a4348b9baad17
+00 Core/meshes/effects/fxcreekflatlong01.nif,2a8754add3c65796
+00 Core/meshes/furniture/cart/cartfurnstatic01.nif,0b2d9a4c59477ce1
+00 Core/meshes/furniture/clutter/leveranimating.nif,684dcb550e7325a5
+00 Core/meshes/furniture/clutter/milllogpile.nif,1ed80e030b458dc8
+00 Core/meshes/furniture/noble/noblechair01.nif,77d4a5f8b2373a1e
+00 Core/meshes/furniture/noble/noblechair02.nif,b835747fe8cf7f54
+00 Core/meshes/furniture/noble/scoffinpoor.nif,8c16c5e779fdd7b9
+00 Core/meshes/furniture/nordic/ruins_chair01.nif,1381d10b261a7516
+00 Core/meshes/furniture/nordic/ruins_chairshadow01.nif,af1338f01847b22c
+00 Core/meshes/furniture/prisonercarriage/prisonercarriage01.nif,3f57273a98db1d42
+00 Core/meshes/furniture/prisonercarriage/prisonercarriage01static.nif,2bd6d5cad6e76c33
+00 Core/meshes/furniture/prisonercarriage/prisonercarriagefurniture01.nif,30a1d8ec0b61ad33
+00 Core/meshes/furniture/blacksmithforgemarker.nif,d7905383221f7abe
+00 Core/meshes/furniture/blacksmithforgemarkerwr.nif,4799f21a2e729a48
+00 Core/meshes/furniture/smeltermarker.nif,fb056a0a0541da0f
+00 Core/meshes/landscape/dirtcliffs/dirtcliffs01moss.nif,06feb1fd8f6417a5
+00 Core/meshes/landscape/dirtcliffs/dirtcliffs02moss.nif,11c5a18dd6a2c685
+00 Core/meshes/landscape/dirtcliffs/dirtcliffs03moss.nif,978fccac123c5907
+00 Core/meshes/landscape/dirtcliffs/dirtcliffs04moss.nif,9e92d3ea36fb71ab
+00 Core/meshes/landscape/dirtcliffs/dirtcliffs05moss.nif,1dd65959cd8ee146
+00 Core/meshes/landscape/mountains/mountaincliff02.nif,2b69fcbfacb704db
+00 Core/meshes/landscape/mountains/mountaincliffsm01.nif,d45db4bf0812bee5
+00 Core/meshes/landscape/rocks/wetrocks/rockl01wet.nif,cced600d06c5a1ee
+00 Core/meshes/landscape/rocks/wetrocks/rockl04wet.nif,7dd0c1ca380b757e
+00 Core/meshes/landscape/rocks/wetrocks/rockm03wet.nif,46865651b9938b42
+00 Core/meshes/landscape/rocks/wetrocks/rockpilem02wet.nif,206876ead1dec15c
+00 Core/meshes/landscape/rocks/rockanimalden01.nif,d611dc310c8054f2
+00 Core/meshes/landscape/rocks/rockl01.nif,b49cd689d23c760e
+00 Core/meshes/landscape/rocks/rockl02.nif,09ebba7ee5f1d33b
+00 Core/meshes/landscape/rocks/rockl04.nif,bb6be12a8286e63a
+00 Core/meshes/landscape/rocks/rockm03.nif,d0dc5ee84e5ff6e6
+00 Core/meshes/landscape/rocks/rockpilel01.nif,6f57a9aa99eb3b35
+00 Core/meshes/landscape/rocks/rockpilem02.nif,21c561acbb0ab3eb
+00 Core/meshes/landscape/rocks/rockpilem02tundra.nif,a81e131659a264ff
+00 Core/meshes/landscape/rocks/rockpiles02.nif,6b9076c41ca4580a
+00 Core/meshes/landscape/rocks/rockpiles04.nif,cca0ad26f756c462
+00 Core/meshes/landscape/trees/coastdriftwood01.nif,aab9eaddb91118a8
+00 Core/meshes/landscape/trees/coastdriftwood02.nif,466591844b5fc11b
+00 Core/meshes/landscape/trees/coastdriftwood03.nif,bf653a7bedc0c8ae
+00 Core/meshes/loadscreenart/loadscreenadventure01.nif,84d478bbe1459bf8
+00 Core/meshes/loadscreenart/loadscreendragonpriest.nif,5120dae821e1a056
+00 Core/meshes/loadscreenart/loadscreenhagraven01.nif,80b82f720cd87855
+00 Core/meshes/loadscreenart/loadscreenhagraven02.nif,9badd8140536f3d2
+00 Core/meshes/loadscreenart/loadscreenmoney01.nif,4ff967b8a18be713
+00 Core/meshes/loadscreenart/loadscreenpotions01.nif,94e5c6ef0d391ae6
+00 Core/meshes/loadscreenart/loadscreenreagent01.nif,5a12076d82db8a72
+00 Core/meshes/loadscreenart/loadscreenshopsmagic01.nif,faf4a2a1c6e4e13e
+00 Core/meshes/loadscreenart/loadscreenwrtempletree02.nif,01c796723b2d5ae5
+00 Core/meshes/plants/coinbaglarge.nif,35d91f8d507ce64f
+00 Core/meshes/plants/coinbagmed.nif,8802e164d563c503
+00 Core/meshes/plants/coinbagsmall.nif,e3598bf524424e8e
+00 Core/meshes/traps/doordeadbolt/doordeadbolt01.nif,452681404cadea04
+00 Core/meshes/traps/doordeadboltdbl/doordeadboltdbl01.nif,617830255ad0836c
+00 Core/textures/architecture/farmhouse/woodpost02.dds,afef4d6a0b8c244e
+00 Core/textures/architecture/farmhouse/woodpost02_n.dds,49ac117d42ec48b1
+00 Core/textures/architecture/whiterun/wrslate02.dds,1b7ef5cc8368c80d
+00 Core/textures/architecture/whiterun/wrslate02_n.dds,d7e7ecceda0763d6
+00 Core/textures/architecture/whiterun/wrwoodbeam01.dds,a475e49576504e01
+00 Core/textures/architecture/whiterun/wrwoodbeam01_n.dds,d09bb42d776d8654
+00 Core/textures/clutter/caves/caves_lamp01.dds,d49df9fc7eb49af3
+00 Core/textures/clutter/caves/caves_lamp01_n.dds,ac5108644f6d5dfb
+00 Core/textures/clutter/deadanimals/rabbitmeatcooked.dds,f126ef3408c8d9c5
+00 Core/textures/clutter/ingredients/hagfeathers.dds,816ad08debb0ebee
+00 Core/textures/clutter/ruins/ruinschest01snow.dds,fddb0382ee50009d
+00 Core/textures/dungeons/azurasstar/azuracrystal01.dds,2f2000c320b2aa92
+00 Core/textures/dungeons/azurasstar/azuracrystal01_n.dds,f2c98e8703d8fbbd
+00 Core/textures/dungeons/caves/CaveRocks01_n.dds,a65c028f09eb7486
+00 Core/textures/dungeons/mines/mineroots01.dds,38d5124c46e90572
+00 Core/textures/dungeons/candles01.dds,ad5e42f32c9805ad
+00 Core/textures/dungeons/candles01_g.dds,4f7b7aa1f717eed4
+00 Core/textures/dungeons/candles01_n.dds,7f772e51a499dee4
+00 Core/textures/smim/architecture/farmhouse/farmhouse_int_jaillock.dds,3ebb9d196b6921f3
+00 Core/textures/smim/architecture/farmhouse/farmhouse_int_jaillock_n.dds,c060b1c9bc5bed5f
+00 Core/textures/smim/architecture/farmhouse/metalwork01_jailring.dds,d6f23a28a4bfbde1
+00 Core/textures/smim/architecture/farmhouse/metalwork01_jailring_n.dds,553fcf5e0628a21a
+00 Core/textures/smim/architecture/whiterun/metalwork01_drawbridge.dds,d6f23a28a4bfbde1
+00 Core/textures/smim/architecture/whiterun/metalwork01_drawbridge_n.dds,553fcf5e0628a21a
+00 Core/textures/smim/architecture/whiterun/wrstockade_properwood.dds,7a681a431bd6082d
+00 Core/textures/smim/architecture/whiterun/wrstockade_properwood_n.dds,856aa25e82e3c988
+00 Core/textures/smim/architecture/whiterun/wrwoodplanks_512_tiling.dds,f322297f45fe959f
+00 Core/textures/smim/architecture/whiterun/wrwoodplanks_512_tiling_n.dds,0f8fe9ac43c05250
+00 Core/textures/smim/chains/metalwork01_brown.dds,ec6d1d0deb249e38
+00 Core/textures/smim/chains/metalwork01_brown_n.dds,d7732e6e282e1d36
+00 Core/textures/smim/chains/metalwork01_gray.dds,ccdfbed05c08cf08
+00 Core/textures/smim/chains/metalwork01_gray_n.dds,553fcf5e0628a21a
+00 Core/textures/smim/clutter/charcoal/charcoal01.dds,6f330c055916777b
+00 Core/textures/smim/clutter/charcoal/charcoal01_n.dds,b224234a28240fff
+00 Core/textures/smim/clutter/common/archery_target_wood.dds,d18b30138085a711
+00 Core/textures/smim/clutter/common/archery_target_wood_n.dds,154a80fbc170bd1d
+00 Core/textures/smim/clutter/common/rope01_beige.dds,52e3642356d315ca
+00 Core/textures/smim/clutter/common/rope01_bright.dds,d913ee7bbe8bebec
+00 Core/textures/smim/clutter/common/rope01_midburn.dds,f5e79a5380ca2a8f
+00 Core/textures/smim/clutter/common/rope01_n.dds,86229cdf8c7822ab
+00 Core/textures/smim/clutter/common/smim_quill.dds,6b82bf2b69047ecc
+00 Core/textures/smim/clutter/common/smim_quill_n.dds,6c677520fb031327
+00 Core/textures/smim/clutter/ingredients/smim_dwarven_oil.dds,8702db8c31eae1a8
+00 Core/textures/smim/clutter/ingredients/smim_dwarven_oilspill.dds,4872a17fe6a3397f
+00 Core/textures/smim/clutter/ingredients/smim_dwarven_oilspill_n.dds,9ed2124174cc19a2
+00 Core/textures/smim/clutter/ingredients/smim_dwarven_oil_m.dds,0df25a5dd0073bf9
+00 Core/textures/smim/clutter/ingredients/smim_dwarven_oil_n.dds,521095f0ecd30e19
+00 Core/textures/smim/clutter/ingredients/smim_hagclaw.dds,3007096f671ff0c6
+00 Core/textures/smim/clutter/ingredients/smim_hagclaw_n.dds,350dfb5975298d79
+00 Core/textures/smim/clutter/ingredients/smim_sabrecat_tooth.dds,f1e9dd9aacdef569
+00 Core/textures/smim/clutter/ingredients/smim_sabrecat_tooth_n.dds,aeed390189743245
+00 Core/textures/smim/clutter/quest/smim_giant_mortar.dds,ef35cba95352d47a
+00 Core/textures/smim/clutter/quest/smim_giant_mortar_n.dds,d4f54fcfa5788c5c
+00 Core/textures/smim/clutter/ruins/ruinschest.dds,342538d715a871aa
+00 Core/textures/smim/clutter/ruins/ruinschestnails.dds,1c46182610707e90
+00 Core/textures/smim/clutter/ruins/ruinschestnails_n.dds,749c430f28f9a795
+00 Core/textures/smim/clutter/ruins/ruinschestsmall.dds,4d179227a74e70d5
+00 Core/textures/smim/clutter/ruins/ruinschestsmall_n.dds,e1560d62a839d3c3
+00 Core/textures/smim/clutter/ruins/ruinschest_n.dds,d3677362c369b1e4
+00 Core/textures/smim/clutter/ruins/smim_ruinspot01.dds,29aadb6fd2cd04be
+00 Core/textures/smim/clutter/ruins/smim_ruinspot01_n.dds,b012cb4b932cfc4b
+00 Core/textures/smim/clutter/woodfires/smim_campfire_rocks.dds,27f53d9a543738a0
+00 Core/textures/smim/clutter/woodfires/smim_campfire_rocks_n.dds,2a8d9c11f30bc509
+00 Core/textures/smim/clutter/barrel02.dds,aa89afadf99fba33
+00 Core/textures/smim/clutter/barrel02_n.dds,087e2b710d2b532f
+00 Core/textures/smim/clutter/barrel_smim_metal.dds,89e7c9f747c18b96
+00 Core/textures/smim/clutter/barrel_smim_metal_n.dds,96e6a701490a9e32
+00 Core/textures/smim/clutter/barrel_smim_wood.dds,045ba154ba4d89ac
+00 Core/textures/smim/clutter/barrel_smim_wood_n.dds,ee038180ea601238
+00 Core/textures/smim/clutter/smim_ingotdwemer.dds,da161f73549cb8bf
+00 Core/textures/smim/clutter/smim_ingotdwemer_n.dds,3b4bee947c4af6f3
+00 Core/textures/smim/dlc02/clutter/ingredients/smim_tern_ingredient.dds,930b04af5619b33b
+00 Core/textures/smim/dungeons/caves/green/smim_caveg_dirtcliffsroots.dds,8b981fd847ef6cf0
+00 Core/textures/smim/dungeons/caves/green/smim_caveg_dirtcliffsroots_n.dds,d95e74049abcf709
+00 Core/textures/smim/dungeons/dwemer/smim_dwemer_focus_rock.dds,ffbd845e45fa0ff9
+00 Core/textures/smim/dungeons/dwemer/smim_dwemer_focus_rock_n.dds,4abf641cd2353958
+00 Core/textures/smim/traps/smim_trap_deadbolt.dds,8bdeeb2b12a29710
+00 Core/textures/smim/traps/smim_trap_deadbolt_n.dds,6a41fad94c006443
+00 Core/SMIM Readme.txt,8f34c1376be4b69a
+00 Core/SMIM-FarmhouseFlickeringFix.esp,ffaf8dc7555d3ff3
+00 Core/SMIM-SE-FarmhouseFlickeringFix.esp,17b246d2153a68d4
+01 Furniture/meshes/architecture/whiterun/wrclutter/wrtemplebench01.nif,83dd0e2233b7a078
+01 Furniture/meshes/architecture/whiterun/wrclutter/wrtemplebench01static.nif,38e1d95cd2578401
+01 Furniture/meshes/clutter/common/commonshelfsecretdoor01/commonshelfsecretdoor01.nif,13bbc240af073fc5
+01 Furniture/meshes/clutter/common/commonchair02.nif,e252797c3fef89d0
+01 Furniture/meshes/clutter/common/commonchair02static.nif,8b674c828b203ae6
+01 Furniture/meshes/clutter/common/commoncrate01.nif,8399e59417b9c31b
+01 Furniture/meshes/clutter/common/commoncrate02.nif,be046339a377ddcc
+01 Furniture/meshes/clutter/common/commonshelf01.nif,417e76e4c52fab28
+01 Furniture/meshes/clutter/common/commonshelf03.nif,33d2523688139a42
+01 Furniture/meshes/clutter/common/commonshelf04.nif,b8d8ab715eec4775
+01 Furniture/meshes/clutter/common/commonshelf04open.nif,489746f39a7d0578
+01 Furniture/meshes/clutter/common/commonshelf05.nif,33fe02cfa3558bf5
+01 Furniture/meshes/clutter/common/commontable01.nif,f2d656c1aa648a4f
+01 Furniture/meshes/clutter/common/commontable02.nif,f38b36b2dacef945
+01 Furniture/meshes/clutter/common/commontablelow01.nif,25ae63205601cb16
+01 Furniture/meshes/clutter/common/commontablelow02.nif,a8d7bc9293ad4bd6
+01 Furniture/meshes/clutter/common/commontableround01.nif,798083a21f76c455
+01 Furniture/meshes/clutter/common/commontablesquare01.nif,aef20499af731ee8
+01 Furniture/meshes/clutter/common/commontablethin01.nif,f7102e6866762fb4
+01 Furniture/meshes/clutter/common/cupboard01.nif,992dd2747714a1f7
+01 Furniture/meshes/clutter/common/dresser01.nif,a342d5f6e6501ca2
+01 Furniture/meshes/clutter/common/endtable01.nif,3fef591cda3513b6
+01 Furniture/meshes/clutter/common/wardrobe01.nif,7d666fcd553d7128
+01 Furniture/meshes/clutter/upperclass/upperbeddouble01.nif,be768b64c4085028
+01 Furniture/meshes/clutter/upperclass/upperbedsingle01.nif,c3c8751e4554422a
+01 Furniture/meshes/clutter/upperclass/upperbench01.nif,5e51fca85b2986e7
+01 Furniture/meshes/clutter/upperclass/upperbench02.nif,43598f6d7afd8f5b
+01 Furniture/meshes/clutter/upperclass/upperbench03.nif,eda3475790c89127
+01 Furniture/meshes/clutter/upperclass/upperchair01.nif,33d19598c05088d9
+01 Furniture/meshes/clutter/upperclass/uppercupboard01.nif,971b17bdab2b2a29
+01 Furniture/meshes/clutter/upperclass/upperdresser01.nif,096201a651a3ad79
+01 Furniture/meshes/clutter/upperclass/upperendtable01.nif,e14a5b09e5fa1179
+01 Furniture/meshes/clutter/upperclass/upperendtable02.nif,f2a5e2a8a5453273
+01 Furniture/meshes/clutter/upperclass/uppernightstand01.nif,99fd9b6600661faa
+01 Furniture/meshes/clutter/upperclass/uppershelf01.nif,bb0bece4b700f8d3
+01 Furniture/meshes/clutter/upperclass/uppershelf02.nif,67d01750f2eae509
+01 Furniture/meshes/clutter/upperclass/uppertable01.nif,ef4972f65f1afc0c
+01 Furniture/meshes/clutter/upperclass/uppertable01custom01.nif,a33ff5ba3a4f9d81
+01 Furniture/meshes/clutter/upperclass/uppertable01custom01cloth01.nif,5984c13a86196d13
+01 Furniture/meshes/clutter/upperclass/uppertablebench01.nif,c1bafe6510cebc57
+01 Furniture/meshes/clutter/upperclass/uppertablebench02.nif,a0fd9ba3c93c306f
+01 Furniture/meshes/clutter/upperclass/uppertableround01.nif,1dd70eda50f679be
+01 Furniture/meshes/clutter/upperclass/uppertablesquare01.nif,bc2d8abd0658d4c6
+01 Furniture/meshes/clutter/upperclass/upperwardrobe01.nif,26440697df4a2c4b
+01 Furniture/meshes/clutter/table01.nif,ef3a3f1b6757480a
+01 Furniture/meshes/dungeons/riften/thievesguild/tgsecretdoor01.nif,f3c811730cb2cbdb
+01 Furniture/meshes/furniture/common/commonbench01.nif,4bdb12bde5421a45
+01 Furniture/meshes/furniture/common/commonchair01.nif,625a7fd172c199e7
+01 Furniture/meshes/furniture/farm/farmbench01.nif,cca62fb399c4c48b
+01 Furniture/meshes/furniture/farm/farmtable01.nif,ef3a3f1b6757480a
+01 Furniture/meshes/furniture/farm/farmtablebench01.nif,238056ff5f83c7ba
+01 Furniture/meshes/furniture/farm/farmtablebench02.nif,a1415da1d80a30bf
+01 Furniture/meshes/furniture/commontableonebench.nif,589986d5b798aeb0
+01 Furniture/meshes/furniture/commontabletwobenches.nif,87774f6f4b8f994f
+01 Furniture/meshes/furniture/woodenchair01.nif,59fc51023fdeaf30
+01 Furniture/meshes/furniture/woodenchair01static.nif,ff960c7e8233f62d
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfacenobletableroundchairs01.nif,d5afca7eebdaa112
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfacenobletablesquarechairs01.nif,566c2af482104cd5
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceupperbedsingle01.nif,97bae00d292844bd
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceupperbench01.nif,6a84be10fb9f0fe0
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceupperchair01.nif,b7b63f75c0019b61
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceupperdresser01.nif,cf8f78ffabb84476
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceupperendtable01.nif,a99a7ee29aa07ca4
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceuppershelf01.nif,c97f352a66248271
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceuppershelfdisplay01.nif,f17a2fe4cb40379c
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceuppertabledrawers01.nif,aa90eb3a611afac4
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceuppertabledrawersdisplay02.nif,693939b77cc44f75
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceuppertableround01.nif,f82a0faff2ed0223
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceuppertablesquare01.nif,1b692fba4aaa1e3c
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceupperwardrobe01.nif,57b7ae626e882727
+01 Furniture/meshes/_byoh/furniture/byohupperendtable02.nif,7916b38b6df30ad3
+01 Furniture/textures/clutter/common/dresser01.dds,e1ac4c65a127f3f4
+01 Furniture/textures/clutter/common/dresser01_n.dds,5bea1adf32bca51b
+01 Furniture/textures/clutter/furniturewood01.dds,149bc3ee8f72ace6
+01 Furniture/textures/clutter/furniturewood01_n.dds,094905a18d662740
+01 Furniture/textures/smim/architecture/whiterun/smim_wr_bench.dds,f422456f91b317dc
+01 Furniture/textures/smim/architecture/whiterun/smim_wr_bench_n.dds,34197122fcfb462b
+01 Furniture/textures/smim/clutter/common/dresser01.dds,443fcf99dad2f211
+01 Furniture/textures/smim/clutter/common/dresser01_n.dds,693b96d4edb99cd3
+01 Furniture/textures/smim/clutter/common/Stump_Bottom_for_Furniture.dds,ff48eb31ab4e14bf
+01 Furniture/textures/smim/clutter/common/Stump_Bottom_for_Furniture_n.dds,2cddc5de9cdb11cc
+01 Furniture/textures/smim/clutter/common/Table_Leg_Bark.dds,6d9bbc55ef3b3ebd
+01 Furniture/textures/smim/clutter/common/Table_Leg_Bark_n.dds,471aacf7b7fa705d
+01 Furniture/textures/smim/clutter/common/Table_Leg_Bark_Seamless.dds,664272d497b20cd4
+01 Furniture/textures/smim/clutter/common/Table_Leg_Bark_Seamless_n.dds,bf4115d2470e188e
+01 Furniture/textures/smim/clutter/common/Table_Leg_Bark_Thin.dds,8ed2131440eff2c2
+01 Furniture/textures/smim/clutter/common/Table_Leg_Bark_Thin_n.dds,66ced87fb58fde92
+01 Furniture/textures/smim/clutter/common/Table_Wood_SinglePiece.dds,d1277b75cf5bbea9
+01 Furniture/textures/smim/clutter/common/Table_Wood_SinglePiece_n.dds,52b16dd5fc457314
+01 Furniture/textures/smim/clutter/upperclass/smim_upper_bedpost.dds,42ad711376d9cb65
+01 Furniture/textures/smim/clutter/upperclass/smim_upper_bedpost_n.dds,e03d979e30f934c7
+01 Furniture/textures/smim/clutter/upperclass/smim_upper_bench_legs.dds,bdaaf1dca9b58891
+01 Furniture/textures/smim/clutter/upperclass/smim_upper_bench_legs_n.dds,8d691d67a79cfdd8
+01 Furniture/textures/smim/clutter/upperclass/Stump_Bottom_for_FurnitureUC.dds,2c8cbe5f1ab287cf
+01 Furniture/textures/smim/clutter/upperclass/Stump_Bottom_for_FurnitureUC_n.dds,2cddc5de9cdb11cc
+01 Furniture/textures/smim/clutter/upperclass/Table_Leg_Bark_Thin.dds,e3f17ed5a7856c39
+01 Furniture/textures/smim/clutter/upperclass/Table_Leg_Bark_Thin_n.dds,d93e8c6b0d2195a6
+01 Furniture/textures/smim/clutter/upperclass/Table_Wood_SinglePiece.dds,02ab5152b4d10e11
+01 Furniture/textures/smim/clutter/upperclass/Table_Wood_SinglePiece_n.dds,52b16dd5fc457314
+01 Furniture/textures/smim/clutter/furniturewood01.dds,5ffae78bd5600579
+01 Furniture/textures/smim/clutter/furniturewood01_n.dds,31dfd2d87198f2cf
+01 Furniture/textures/smim/furniture/smim_wooden_chair.dds,c5de24915ae25eda
+01 Furniture/textures/smim/furniture/smim_wooden_chair_n.dds,f655882ede099d16
+02 SMIM Barrel Textures Animations/meshes/clutter/barrel01.nif,0e2a652958aaddc4
+02 SMIM Barrel Textures Animations/meshes/clutter/barrel02.nif,fef06beffede5461
+02 SMIM Barrel Textures Animations/meshes/clutter/tgbarrel01.nif,690a842b09a38662
+02 SMIM Barrel Textures Animations Original Movement/meshes/clutter/barrel01.nif,8a658062cb5d0c1b
+02 SMIM Barrel Textures Animations Original Movement/meshes/clutter/barrel02.nif,fef06beffede5461
+02 SMIM Barrel Textures Animations Original Movement/meshes/clutter/tgbarrel01.nif,51f1b76c277e5980
+02 SMIM Barrel Textures No Animations/meshes/clutter/barrel01.nif,44bde7f95dfb31a8
+02 SMIM Barrel Textures No Animations/meshes/clutter/barrel02.nif,fef06beffede5461
+02 SMIM Barrel Textures No Animations/meshes/clutter/tgbarrel01.nif,d1ebaa1a84dc7b21
+02 SMIM Rustic Barrel Textures Animations/meshes/clutter/barrel01.nif,0e2a652958aaddc4
+02 SMIM Rustic Barrel Textures Animations/meshes/clutter/barrel02.nif,fef06beffede5461
+02 SMIM Rustic Barrel Textures Animations/meshes/clutter/tgbarrel01.nif,690a842b09a38662
+02 SMIM Rustic Barrel Textures Animations/textures/smim/clutter/barrel_smim_wood.dds,e9f17b41386b7da7
+02 SMIM Rustic Barrel Textures Animations/textures/smim/clutter/barrel_smim_wood_n.dds,94ef176ea22db6bb
+02 SMIM Rustic Barrel Textures No Animations/meshes/clutter/barrel01.nif,44bde7f95dfb31a8
+02 SMIM Rustic Barrel Textures No Animations/meshes/clutter/barrel02.nif,fef06beffede5461
+02 SMIM Rustic Barrel Textures No Animations/meshes/clutter/tgbarrel01.nif,d1ebaa1a84dc7b21
+02 SMIM Rustic Barrel Textures No Animations/textures/smim/clutter/barrel_smim_wood.dds,e9f17b41386b7da7
+02 SMIM Rustic Barrel Textures No Animations/textures/smim/clutter/barrel_smim_wood_n.dds,94ef176ea22db6bb
+02 Vanilla Barrel Textures Animations/meshes/clutter/barrel01.nif,7388b387da86b40e
+02 Vanilla Barrel Textures Animations/meshes/clutter/barrel02.nif,42ecaec346b4e936
+02 Vanilla Barrel Textures Animations/meshes/clutter/tgbarrel01.nif,e6ea8c23176389df
+02 Vanilla Barrel Textures No Animations/meshes/clutter/barrel01.nif,b29ea75f8ebc0212
+02 Vanilla Barrel Textures No Animations/meshes/clutter/barrel02.nif,42ecaec346b4e936
+02 Vanilla Barrel Textures No Animations/meshes/clutter/tgbarrel01.nif,fa857fc2224a42a7
+03 Food/meshes/animobjects/animobjectbread.nif,064dcf9d31ac12c5
+03 Food/meshes/clutter/food/apple01.nif,8800a499bbdddfe7
+03 Food/meshes/clutter/food/apple02.nif,85dbba7d1eff6b0f
+03 Food/meshes/clutter/food/bread01a.nif,adee99eafcc0b5a1
+03 Food/meshes/clutter/food/bread01b.nif,aab8eebd63874c00
+03 Food/meshes/clutter/food/grilledpotatoes01.nif,5e379395f022bc27
+03 Food/meshes/clutter/ingredients/tomato.nif,8ba8bb9926bf49eb
+03 Food/meshes/loadscreenart/loadscreenmarket01.nif,76a8893ecfcb5b82
+03 Food/meshes/plants/cabbage01.nif,36aed65ab194724a
+03 Food/meshes/plants/potato01.nif,5cce73f93b2a01cb
+03 Food/textures/smim/clutter/food/apple01_semi-circle-UV.dds,47f82715590f9764
+03 Food/textures/smim/clutter/food/apple01_semi-circle-UV_n.dds,aed2d3cc8c229673
+03 Food/textures/smim/clutter/food/apple02_semi-circle-UV.dds,78796fe12aa982ad
+03 Food/textures/smim/clutter/food/apple02_semi-circle-UV_n.dds,aed2d3cc8c229673
+03 Food/textures/smim/clutter/ingredients/tomato_smim.dds,c86985a0381bfdb5
+03 Food/textures/smim/clutter/ingredients/tomato_smim_n.dds,aa739fde6a3449fe
+03 Food/textures/smim/plants/potato01_properUVmap.dds,e393e2d39e44e60b
+03 Food/textures/smim/plants/potato01_properUVmap_n.dds,9dbb1f5e4a72b840
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/interior/basement/farmbwell01.nif,50c5c17790e6d1ec
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkway01.nif,b75dba7450e1f6d1
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkway02.nif,f3b22bbb480085c3
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaybend01.nif,38eafe817bd34110
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaybend02.nif,bee0b76cd61bb7ad
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaybend03.nif,aa0adcf267b30155
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwayc01.nif,bac89d56e388fe66
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycend01.nif,f889d1b91d74cf09
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycend02.nif,3eff3e7a412ad93c
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycentwall01.nif,cd9776aecf56d8da
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycentwall02.nif,9a5ed120b26b9120
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycwall01.nif,004335d59f9fc1fc
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycwallend01.nif,87a9c3ae73b66c8b
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycwallend02.nif,e3d82c581e91b58e
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycwallend03.nif,237016c8ae8ef858
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycwallend04.nif,c7c20cbddbc2ec43
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycwallgate01.nif,e77398296d823323
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycwallgate02.nif,f922441903947263
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwayend01.nif,2fbb9ecd86a03c14
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwayfull02.nif,c5a17194c0f3c2f5
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwayfull03.nif,a3d8a132015ac46d
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwayrend01.nif,0ecba7c1a8a16c0d
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaystairs1.nif,2df96e5fb1585d19
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaystairs15.nif,7fe28b0d7d859f76
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaystairs3.nif,75abf2b4c9d6c145
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaystairs4.nif,bb4105eb6b7fafec
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaystairs8.nif,a9c51ef2d755a700
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmbannerpost01.nif,c631accaf8924d44
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse01walkway.nif,45d07c38940a6db9
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse02.nif,853c7cfaa33ee352
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse02walkway.nif,ce648483addabe55
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse03.nif,de114eea33593ca3
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse03walkway.nif,4fac71c91408d426
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse04.nif,90643d567205aa1d
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse04walkway.nif,f0b55d66dee91a88
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse06.nif,b694f7c7e90390a8
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmwell01.nif,3b0cd6188fb67a69
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/inn01.nif,eaa89663303adc7e
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/lumbermill01.nif,db1d30e035e39017
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/solitude/farms/slumbermill01.nif,81a9b5eacff9595c
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/interior/basement/farmbwell01.nif,50c5c17790e6d1ec
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkway01.nif,faa14ecd3fbe82ca
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkway02.nif,30f7d9d13ae09173
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaybend01.nif,b89ba3fe8ce55ed3
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaybend02.nif,15213958a9cd6b08
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaybend03.nif,2291ba40bd292840
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwayc01.nif,8f22899ed1834399
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycend01.nif,898b3d5a0de51b06
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycend02.nif,81f5fea3b153bb02
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycentwall01.nif,1e751f6e699ea0e1
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycentwall02.nif,0607c7e86a687b6a
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycwall01.nif,273f3be3ee57d6dc
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycwallend01.nif,af53554da722208f
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycwallend02.nif,26b360021b0aacd5
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycwallend03.nif,9b282e5c2a2dd8eb
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycwallend04.nif,9148392834d81a17
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycwallgate01.nif,3a8e077c24063761
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycwallgate02.nif,0d55017fd0c719ee
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwayend01.nif,ec316fc5a34860f4
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwayfull02.nif,6e6311411dd96b70
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwayfull03.nif,eabf4ca923098f7a
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwayrend01.nif,e847401ecb5af2ff
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaystairs1.nif,2279199762f2a8f9
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaystairs15.nif,9f83deb1250738fd
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaystairs3.nif,83e1ee6c3ff37fd8
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaystairs4.nif,90eea9ae894b8895
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaystairs8.nif,1f36a51fcba748f2
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmbannerpost01.nif,c631accaf8924d44
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse01walkway.nif,2d602701afedd20b
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse02.nif,0ba49a9d19cef88d
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse02walkway.nif,9ad3d66d74c648aa
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse03.nif,4a82033407d4ab9d
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse03walkway.nif,aabbeb3119f518ec
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse04.nif,5172474efb3e67de
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse04walkway.nif,b57e39df0ff9da5d
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse06.nif,b694f7c7e90390a8
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmwell01.nif,3b0cd6188fb67a69
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/inn01.nif,eaa89663303adc7e
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/lumbermill01.nif,a8897c6b94ee6d75
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/solitude/farms/slumbermill01.nif,412224cf230879f2
+05 Chains 3D - Misc/meshes/architecture/markarth/mrkapoth01.nif,bd3b010d1218127d
+05 Chains 3D - Misc/meshes/architecture/markarth/mrkbrazierhanging01.nif,ffbf45edb49b133f
+05 Chains 3D - Misc/meshes/architecture/markarth/mrkbrazierhanging02.nif,6133635b1abcbc2c
+05 Chains 3D - Misc/meshes/architecture/markarth/mrksilverfishinnpart03.nif,cf195de06b6fd630
+05 Chains 3D - Misc/meshes/architecture/markarth/mrksilverfishinnpart05.nif,bc9845739bf52aaa
+05 Chains 3D - Misc/meshes/architecture/markarth/mrktempledoorl01.nif,de1aaeabab411bc1
+05 Chains 3D - Misc/meshes/architecture/markarth/mrktempledoorr01.nif,217853e77ce7ae80
+05 Chains 3D - Misc/meshes/architecture/riften/ratwayhall/riftenrwdoorspecial01.nif,f3063e74f153fad8
+05 Chains 3D - Misc/meshes/architecture/riften/riftendoor01.nif,2da97f50eb41ab96
+05 Chains 3D - Misc/meshes/architecture/riften/riftendoor02.nif,f27c8cea1ec52da5
+05 Chains 3D - Misc/meshes/architecture/whiterun/wrclutter/wrherbdryingrack01.nif,3331f9753dc8a23d
+05 Chains 3D - Misc/meshes/clutter/common/metalcage01.nif,67180e32079a87a2
+05 Chains 3D - Misc/meshes/clutter/common/torturerack01.nif,8dcb88dcff66fca1
+05 Chains 3D - Misc/meshes/dlc02/dungeons/dwemer/clutter/dlc2dweclutterfirepot01.nif,1071383dbe3b3c22
 05 Chains 3D - Misc/meshes/dlc02/dungeons/dwemer/readingroom/dlc2dwereadrmfirepot01.nif,7977522120657531
-08 Chains 3D - Pull Levers/meshes/dungeons/nordic/levers/pullchain/genpullchain01.nif,1034904FE1B85A9E
-08 Chains 3D - Pull Levers/meshes/dungeons/nordic/levers/pullchain/norpullchain01.nif,8963048171F50C6F
-08 Chains 3D - Pull Levers/meshes/dungeons/nordic/levers/pullchainanim/genpullchainanim01.nif,4DBB8E2F251D395
-08 Chains 3D - Pull Levers/meshes/dungeons/nordic/levers/pullchainanim/norpullchainanim01.nif,B95C6868DA4BC5C1
-08 Chains 3D - Pull Levers Lite/meshes/dungeons/nordic/levers/pullchain/genpullchain01.nif,93521EDDDA245D2
-08 Chains 3D - Pull Levers Lite/meshes/dungeons/nordic/levers/pullchain/norpullchain01.nif,C554A2F8723FB0E4
-08 Chains 3D - Pull Levers Lite/meshes/dungeons/nordic/levers/pullchainanim/genpullchainanim01.nif,2D652279AFF22165
-08 Chains 3D - Pull Levers Lite/meshes/dungeons/nordic/levers/pullchainanim/norpullchainanim01.nif,2AC788CB5A6D7F4F
-08 Chains 3D - Pull Levers Small Rings/meshes/dungeons/nordic/levers/pullchain/genpullchain01.nif,523C658C541586ED
-08 Chains 3D - Pull Levers Small Rings/meshes/dungeons/nordic/levers/pullchain/norpullchain01.nif,2DBC6794547FCD9C
-08 Chains 3D - Pull Levers Small Rings/meshes/dungeons/nordic/levers/pullchainanim/genpullchainanim01.nif,9B9296C23B5A895D
-08 Chains 3D - Pull Levers Small Rings/meshes/dungeons/nordic/levers/pullchainanim/norpullchainanim01.nif,5ADC86A5CE28BF51
-12 Whiterun Doors/meshes/arthmoor/opencitiesskyrim/architecture/whiterun/ocswhiterunmaingatenew.nif,358CB098DE07306C
-17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg1way01.nif,7C279A861334506B
-17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg1wayendcap01.nif,CBDADBBD196441A2
-17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg2way01.nif,D18999D5D041A41F
-17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg3way01.nif,B109DC23EDDE34C5
-17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm1way01.nif,894908CC45A362BD
-17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm1way02.nif,9CF50811F9628AC7
-17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm1way03.nif,BD1FC438C0066E4F
-17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm2way01.nif,EFA314B5DC57BBE4
-17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm3way01.nif,BDA1F3192D0EC578
-17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm3way02.nif,B8C81363CEECDDB9
-17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm4way01.nif,E717C89473EC5CF9
-17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm4way02.nif,44F2E55AD28EBA6F
-17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/temple/bghalls/nortmphallbg1waywall01.nif,D0081656AF861E31
-17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/temple/bghalls/nortmphallbg1waywall02.nif,F24717A653C2424C
-17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/temple/bghalls/nortmphallbg1waywall03.nif,20D4DA69C063A2E9
-17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/temple/bghalls/nortmphallbgcolumn01.nif,A990791129A6C121
-17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/temple/bghalls/nortmphallbgcolumn03.nif,BCE2C998A61577CC
-17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/temple/bghalls/nortmphallbgcolumnsm01.nif,AEC2FBC7A25DC2CA
-17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/temple/bghalls/nortmphallbgcolumnsm02.nif,A5F591CB1F6E842B
-17 Nordic Catacombs Skeletal Remains/textures/smim/dungeons/nordic/temple/smim_nordic_bonedirt.dds,EAED2C4DCEE58F5F
-17 Nordic Catacombs Skeletal Remains/textures/smim/dungeons/nordic/temple/smim_nordic_bonedirt_n.dds,8CAF3965AF9E909F
-17 Nordic Catacombs Skeletal Remains/textures/smim/dungeons/nordic/temple/smim_nordic_skeleton.dds,90FEB2E90DD25A07
-18 Farmhouse Woven Fence/meshes/_byoh/clutter/house crafting/inventory/invanimalpen01.nif,9CFADBC1BB16F17B
-18 Farmhouse Woven Fence/meshes/_byoh/clutter/house crafting/inventory/invgarden01.nif,52F530392D0A6E4B
-18 Farmhouse Woven Fence Less Flicker/meshes/_byoh/clutter/house crafting/inventory/invanimalpen01.nif,C7ADEDC25F8D53A
-18 Farmhouse Woven Fence Less Flicker/meshes/_byoh/clutter/house crafting/inventory/invgarden01.nif,A63830041D60AB6
-19 Smelter/meshes/_byoh/clutter/house crafting/inventory/invsmelter01.nif,A1C5A9E1581B4A0D
-21 Dwemer Animated Lifts SE/meshes/dlc02/dungeons/dwemer/door/dlc2dwefacadeliftleverloaddown01.nif,93AFEDE1DFEB1141
-21 Dwemer Animated Lifts SE/meshes/dlc02/dungeons/dwemer/door/dlc2dwefacadeliftleverloaddown02.nif,E3150946E491FB5A
-21 Dwemer Animated Lifts SE/meshes/dlc02/dungeons/dwemer/door/dlc2dwefacadeliftleverloadup01.nif,B2E6B2062EB19438
-21 Dwemer Animated Lifts SE/meshes/dlc02/dungeons/dwemer/door/dlc2dwefacadeliftleverloadup02.nif,827C30D6C40F9C97
-25 Solitude Gate Doors/meshes/arthmoor/opencitiesskyrim/architecture/solitude/ocssoldoorfrontgate.nif,DC068E98C071E378
-26 Human Skull Fixes/meshes/_byoh/architecture/byohhouse/trophy/byohhousetrophyskeleton01.nif,8085A96EA000B56C
-29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdock01.nif,C657590C3467E3AE
-29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdock02.nif,F1FF86E21A7121CE
-29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockpier01.nif,82D4E625668D0D9C
-29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockpier01a.nif,77F22F3ADA4BD868
-29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockpier02.nif,A5B158E6997C0044
-29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockstepsdownend01.nif,932B426D85ED711A
-29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockstr01.nif,811DB82C3A83EF26
-29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockstr02.nif,8B5C7824F35F6ABE
-29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockstr02a.nif,E2220DD9514EDABF
-29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockstr3way01.nif,D5E541A9359C951C
-29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockstr4way01.nif,44D76A58F5A6A378
-29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/fences/dlc2rrbannerpost01.nif,599B514556DD91B
-29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/fences/dlc2rrfence01.nif,C346FAEC2B056B17
-29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/fences/dlc2rrfence01a.nif,760F94849E3731A3
-29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/fences/dlc2rrfence01ramp.nif,2B1BB4700F3FE3B0
-29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/fences/dlc2rrfence05ramp.nif,4B7633876032AC91
-29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/fences/dlc2rrfencepost01.nif,CE6AA3E00DCA815C
-29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/fences/dlc2rrlanternpost01.nif,1D638C8D2FA72D13
-40 Furniture Chests/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceupperchest01.nif,B78DBD0F3A95B129
-42 Furniture Noble/meshes/_byoh/architecture/byohhouse/interface/byohinterfacenoblechair01.nif,89248AC9B24D9092
-42 Furniture Noble/meshes/_byoh/architecture/byohhouse/interface/byohinterfacenoblechair02.nif,FDB6030608C8FD8E
-42 Furniture Noble/meshes/_byoh/architecture/byohhouse/interface/byohinterfacenobletablelong01.nif,C5FD6CAAE8AF16BD
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01.nif,1278EC2F17314F80
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01midendnubs.nif,4B53E672DCCF7034
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar02.nif,112BC5EFCD02850B
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorinltrans01.nif,8696C57D8F284660
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorinrtrans01.nif,AFC8F40302D0824C
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorl01.nif,E3DC6F8A58DE0A91
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorr01.nif,32346A07B34A5E8A
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam02nub.nif,D48D248908CB6562
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam02nubdouble.nif,22B51B5E049D11D8
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam03.nif,121FA52F96A80AAA
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestr01.nif,B6418B11E3D12DE8
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestrdouble01.nif,F14BD636F3B447BF
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestrdouble01ext.nif,D10817065052CAE0
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallcor01.nif,97EBAC410C96FFAB
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallcor01doorl.nif,FF5228A4EB6D65C8
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstr01.nif,F3B199DB10C4E027
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstr01double.nif,2B3C05E9B33AD6A8
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrchimney01.nif,91A37C2B9515FC4D
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrmaindoor01.nif,8A36811E62CF1C95
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrtrans512.nif,C8341A88B30A92FC
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrtrans512r.nif,F39476FD58ECD94E
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewalltallfreestr01top.nif,EB7A11E7F1AEDA7D
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrtemple/wrtempintpromarch02.nif,62FD3B810DA5AD62
-43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrtemple/wrtempintpromarchnub01.nif,D2121A62162D59F4
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01.nif,1278EC2F17314F80
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01midendnubs.nif,1C1B96FE703DE75D
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar02.nif,112BC5EFCD02850B
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorinltrans01.nif,6FA903CA030410F4
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorinrtrans01.nif,F2E7AC0C97F86184
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorl01.nif,756CA3938A31B4F4
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorr01.nif,7554466F8B2D9296
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam02nub.nif,88E828E1C43F39BD
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam02nubdouble.nif,CD22E4CDB40AFD72
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam03.nif,7441FA0BCBE71A29
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestr01.nif,CF1AA272D6D1A27A
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestrdouble01.nif,399F9B5E94AA8B5A
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestrdouble01ext.nif,BC03AB786923C5F2
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallcor01.nif,A4186340DAB3FC4A
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallcor01doorl.nif,2FC8598EE62AE331
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstr01.nif,6D54B482CF85A1B
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstr01double.nif,EF53D9B5EA645E4E
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrchimney01.nif,91A37C2B9515FC4D
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrmaindoor01.nif,DDF9AFFB751AABAD
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrtrans512.nif,9E706F1F4A24C4C3
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrtrans512r.nif,30017C032E18C0E1
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewalltallfreestr01top.nif,96AFDD4D72494D41
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrtemple/wrtempintpromarch02.nif,62FD3B810DA5AD62
-43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrtemple/wrtempintpromarchnub01.nif,D2121A62162D59F4
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01.nif,1278EC2F17314F80
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01midendnubs.nif,1C1B96FE703DE75D
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar02.nif,112BC5EFCD02850B
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorinltrans01.nif,C13F313E0C133423
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorinrtrans01.nif,87E780EDDB22F98E
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorl01.nif,2B2525625DBFAF6
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorr01.nif,C1707CD5FD9AEF4C
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam02nub.nif,88E828E1C43F39BD
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam02nubdouble.nif,CD22E4CDB40AFD72
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam03.nif,7441FA0BCBE71A29
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestr01.nif,51C4FC327E3F5EFD
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestrdouble01.nif,FD6E328A78B0CBE2
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestrdouble01ext.nif,FD7A202777089E6E
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallcor01.nif,3F1150BF5D950A78
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallcor01doorl.nif,4955D3AB8F2A3881
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstr01.nif,5DBD8EC44E448788
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstr01double.nif,C96F39689211EF62
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrchimney01.nif,ECD87594503BF5CB
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrmaindoor01.nif,A855C517B70747B9
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrtrans512.nif,7185B2B7A67BA57C
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrtrans512r.nif,EEEFA6E49B43A66C
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewalltallfreestr01top.nif,782BABC7B76139F0
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrtemple/wrtempintpromarch02.nif,31AB434DC4DCEEDB
-43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrtemple/wrtempintpromarchnub01.nif,26793CEC286ED2BF
-45 Hanging Rings/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceanimalring01.nif,5E4CE46DBEC166A9
-60 Hearthfires Stuff/meshes/_byoh/architecture/byohhouse/interface/byohinterfacearcherytarget01.nif,138AF29FCB1AB82
-60 Hearthfires Stuff/meshes/_byoh/architecture/byohhouse/interface/byohinterfacebasement01.nif,3B87C25C2A0D880C
-60 Hearthfires Stuff/meshes/_byoh/architecture/byohhouse/interface/byohinterfacenobletablelong01.nif,C5FD6CAAE8AF16BD
-60 Hearthfires Stuff/textures/smim/actors/character/malechild/upperbodymale.dds,4DD4DF3AECB37656
-60 Hearthfires Stuff/textures/smim/actors/character/malechild/upperbodymale_n.dds,160B182CDFBF0673
-60 Hearthfires Stuff/textures/smim/actors/character/malechild/upperbodymale_sk.dds,F22976D0CB36EC38
-70 Rabbit/meshes/actors/ambient/hare/character assets/rabbit.nif,7A71A03650FE3FDD
-72 Chandeliers/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceimpchandelier01.nif,8C52178BEC08C8B
-73 Chandeliers No 3D Chains Addon/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceimpchandelier01.nif,846DBEF1D4CEB03A
-75 Dungeons Cliffs Snow Skirts/textures/smim/dungeons/caves/green/smim_caveg_dirtcliffsroots_snow.dds,7AF48CB079D4FEA9
-80 Half-Sized Textures/textures/smim/dlc02/clutter/ingredients/smim_tern_ingredient.dds,CC86FF7B906C1B07
-80 Half-Sized Textures/textures/smim/dungeons/nordic/temple/smim_nordic_bonedirt.dds,66C405F452C0CEA8
-80 Half-Sized Textures/textures/smim/dungeons/nordic/temple/smim_nordic_bonedirt_n.dds,7FED9E4F6539BA7A
-80 Half-Sized Textures/textures/smim/dungeons/nordic/temple/smim_nordic_skeleton.dds,302654CE501C93C4
-00 Core/meshes/dungeons/dwemer/animated/observatory/armillary/dweobservatoryarmillary01.nif,4A1212FCA14BA3F0
-00 Core/meshes/dungeons/dwemer/animated/observatory/armillary/focusingcrystal01.nif,135A93BE15A7F5BD
-00 Core/meshes/dungeons/dwemer/animated/observatory/dome01/dweobservatorydome01.nif,4F88737D08687237
-00 Core/meshes/dungeons/dwemer/animated/observatory/dome02/dweobservatorydome02.nif,BE61132BF5770381
-00 Core/meshes/dungeons/dwemer/animated/observatory/dome03/dweobservatorydome03.nif,1BB00904F8B06AE1
-00 Core/meshes/dungeons/nordic/doors/animated/mediumdoor/volunruudleftsworddoor.nif,2E93A2DACFF32D04
-00 Core/meshes/dungeons/nordic/doors/animated/mediumdoor/volunruudrightaxedoor.nif,3E691640E622B220
-09 Dwemer Clutter/meshes/dlc02/dungeons/dwemer/animated/dwedynamotrigger01/dwedynamotrigger01.nif,933ADCF2132995B7
-75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffs01-SMIMICE.nif,F1329ADC5CB1BCAC
-75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffs02-SMIMICE.nif,E8CBBB2E6962A7A7
-75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffs03-SMIMICE.nif,ADF0A6BF08687A5B
-75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffs03ns-SMIMICE.nif,896AF8CF827FC454
-75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffscornerin01-SMIMICE.nif,ADE5A051B800B0F
-75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffscornerin01ns-SMIMICE.nif,EE5901A02BCE8DD5
-75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffscornerout01-SMIMICE.nif,5D858C7B95CD2DCE
-75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffscornerout01ns-SMIMICE.nif,E486C7F61C964774
-75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffsisland01-SMIMICE.nif,E75C8FA5516853C9
-75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffsisland01ns-SMIMICE.nif,2918A3F53BBECDF7
+05 Chains 3D - Misc/meshes/dungeons/ship/katariah/shipkatariahanchorchain01.nif,52945d382bdb6b55
+05 Chains 3D - Misc/meshes/dungeons/ship/katariah/shipkatariahanchorwheel01.nif,3cb1f77487de8b88
+05 Chains 3D - Misc/meshes/dungeons/ship/questitems/shipanchorchain01.nif,e020d82ac0d90a94
+05 Chains 3D - Misc/meshes/dungeons/ship/questitems/shipanchorwheel01.nif,5532cb792fddf591
+05 Chains 3D - Misc/meshes/loadscreenart/loadscreenmetalcage.nif,cf9e10f621b48eea
+05 Chains 3D - Misc/textures/smim/architecture/riften/smim_RiftenDoor01.dds,80782aaea3eda641
+05 Chains 3D - Misc/textures/smim/architecture/riften/smim_RiftenDoor01_n.dds,f74b7ab9ae0751ce
+06 Chains 3D - Signs/meshes/architecture/markarth/mrksigngeneralgoods01.nif,85ac77936a924f06
+06 Chains 3D - Signs/meshes/architecture/markarth/mrksignmrksilverbloodinnsign01.nif,bab3af258d371971
+06 Chains 3D - Signs/meshes/clutter/signage/generic/signalchemyshop01.nif,3509523d5f5b9900
+06 Chains 3D - Signs/meshes/clutter/signage/generic/signgeneralgoods01.nif,2dfcf5111e895d15
+06 Chains 3D - Signs/meshes/clutter/signage/inns/signbraidwoodinn01.nif,8632d282264ab59a
+06 Chains 3D - Signs/meshes/clutter/signage/inns/signdeadmansdrink01.nif,78419db61a406541
+06 Chains 3D - Signs/meshes/clutter/signage/inns/signfourshieldstavern01.nif,86a5fb7cc5f88e5d
+06 Chains 3D - Signs/meshes/clutter/signage/inns/signfrostfruitinn01.nif,9c1d6a3857a3c7bf
+06 Chains 3D - Signs/meshes/clutter/signage/inns/signfrozenhearth01.nif,10dfd8fd85b17858
+06 Chains 3D - Signs/meshes/clutter/signage/inns/signmoorsideinn01.nif,50225b52382275a1
+06 Chains 3D - Signs/meshes/clutter/signage/inns/signnightgateinn01.nif,aea02fbf9d95425f
+06 Chains 3D - Signs/meshes/clutter/signage/inns/signoldhroldan01.nif,7a5934c7a0b8430a
+06 Chains 3D - Signs/meshes/clutter/signage/inns/signvilemyrinn01.nif,bd5874d3324a3f7f
+06 Chains 3D - Signs/meshes/clutter/signage/inns/signwindpeakinn01.nif,d13e8dafd4092d15
+06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtalchemyshop01.nif,85097003e078eda5
+06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtbeeandbarb01.nif,6aba768d754706a6
+06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtblackbriarmeadery01.nif,8f4b3782e31421bb
+06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtblacksmith01.nif,0aba53eb6f559e0d
+06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtfishery01.nif,0e040704f17bde49
+06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtpawnshop.nif,d542a47ed18d3c72
+06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtpost01.nif,aedd3e3157580296
+06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtraggedflagon01.nif,64c280197ca76936
+06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtstables01.nif,4b6a76987129e0b3
+06 Chains 3D - Signs/meshes/clutter/signage/riverwood/signriverwoodriverwoodblacksmith01.nif,e54b30abb687297e
+06 Chains 3D - Signs/meshes/clutter/signage/riverwood/signriverwoodriverwoodtrader01.nif,6faaa60e607dc127
+06 Chains 3D - Signs/meshes/clutter/signage/riverwood/signriverwoodsleepinggiantinn01.nif,6991ed9b3af96b14
+06 Chains 3D - Signs/meshes/clutter/signage/solitude/signsangelinesaromatics.nif,e530facb6093be9e
+06 Chains 3D - Signs/meshes/clutter/signage/solitude/signsbitsandpieces.nif,0461845bd73e42fe
+06 Chains 3D - Signs/meshes/clutter/signage/solitude/signsfletcher.nif,5a21071f485d1723
+06 Chains 3D - Signs/meshes/clutter/signage/solitude/signsradiantraiments.nif,f19c68614e61ad91
+06 Chains 3D - Signs/meshes/clutter/signage/solitude/signswinkingskeever.nif,0b2f220f71a9ff8d
+06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwralchemyshop01.nif,be4bede54fb89efd
+06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwrbanneredmare01.nif,7e83657eeb2c984b
+06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwrblacksmith01.nif,35ee4f3ec8007a6d
+06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwrdrunkenhuntsman01.nif,635973b51468bec1
+06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwrgeneralgoods.nif,9dbe613b5c87ff77
+06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwrhonningbrewmeadery01.nif,7d6d7a6effb01269
+06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwrpost01.nif,55266c2604f96d2f
+06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwrstables01.nif,b5149cd9a98f5498
+06 Chains 3D - Signs/meshes/clutter/signage/windhelm/signwhalchemyshop01.nif,31033d90a0283a28
+06 Chains 3D - Signs/meshes/clutter/signage/windhelm/signwhblacksmith01.nif,70c34619ce6df06a
+06 Chains 3D - Signs/meshes/clutter/signage/windhelm/signwhcandlehearthinn.nif,775e52f2c924c2dc
+06 Chains 3D - Signs/meshes/clutter/signage/windhelm/signwhcandlehearthinn02.nif,1e1d6d805c7c5464
+06 Chains 3D - Signs/meshes/clutter/signage/windhelm/signwhgeneralgoods.nif,9f309c2f7d6ac845
+06 Chains 3D - Signs/meshes/clutter/signage/windhelm/signwhpost01.nif,929bf6f36f8607e0
+06 Chains 3D - Signs/meshes/clutter/signage/windhelm/signwhstables01.nif,b5253cf28ed4e7d5
+06 Chains 3D - Signs/meshes/clutter/signage/signtg03blackbriarmeadery.nif,38cb0c7b91b3f922
+06 Chains 3D - Signs/meshes/loadscreenart/loadscreenblackbriar01.nif,0da6fdcf9e957748
+06 Chains 3D - Signs/textures/smim/clutter/signage/metalwork01_brown.dds,ec6d1d0deb249e38
+06 Chains 3D - Signs/textures/smim/clutter/signage/metalwork01_brown_n.dds,d7732e6e282e1d36
+07 Chains 3D - Whiterun/meshes/architecture/whiterun/wrdrawbridge01.nif,7ab8050ac9d68b63
+07 Chains 3D - Whiterun/meshes/traps/whiterundragontrap/whiterundragontrap01.nif,e617ced45fca427e
+08 Chains 3D - Pull Levers/meshes/dungeons/nordic/levers/pullchain/genpullchain01.nif,1034904fe1b85a9e
+08 Chains 3D - Pull Levers/meshes/dungeons/nordic/levers/pullchain/norpullchain01.nif,8963048171f50c6f
+08 Chains 3D - Pull Levers/meshes/dungeons/nordic/levers/pullchainanim/genpullchainanim01.nif,04dbb8e2f251d395
+08 Chains 3D - Pull Levers/meshes/dungeons/nordic/levers/pullchainanim/norpullchainanim01.nif,b95c6868da4bc5c1
+08 Chains 3D - Pull Levers Lite/meshes/dungeons/nordic/levers/pullchain/genpullchain01.nif,093521eddda245d2
+08 Chains 3D - Pull Levers Lite/meshes/dungeons/nordic/levers/pullchain/norpullchain01.nif,c554a2f8723fb0e4
+08 Chains 3D - Pull Levers Lite/meshes/dungeons/nordic/levers/pullchainanim/genpullchainanim01.nif,2d652279aff22165
+08 Chains 3D - Pull Levers Lite/meshes/dungeons/nordic/levers/pullchainanim/norpullchainanim01.nif,2ac788cb5a6d7f4f
+08 Chains 3D - Pull Levers Small Rings/meshes/dungeons/nordic/levers/pullchain/genpullchain01.nif,523c658c541586ed
+08 Chains 3D - Pull Levers Small Rings/meshes/dungeons/nordic/levers/pullchain/norpullchain01.nif,2dbc6794547fcd9c
+08 Chains 3D - Pull Levers Small Rings/meshes/dungeons/nordic/levers/pullchainanim/genpullchainanim01.nif,9b9296c23b5a895d
+08 Chains 3D - Pull Levers Small Rings/meshes/dungeons/nordic/levers/pullchainanim/norpullchainanim01.nif,5adc86a5ce28bf51
+09 Dwemer Clutter/meshes/clutter/dwemer/armscrap.nif,8595d43e99b74af3
+09 Dwemer Clutter/meshes/clutter/dwemer/centuriondynamocore01.nif,63c5cf37eff5d911
+09 Dwemer Clutter/meshes/clutter/dwemer/dwarvengear.nif,a18dd997482ca82e
+09 Dwemer Clutter/meshes/clutter/dwemer/dwarvengyro.nif,1ce3a942d1f0608a
+09 Dwemer Clutter/meshes/clutter/dwemer/dwarvenplate.nif,3bfb85e4bddef65f
+09 Dwemer Clutter/meshes/clutter/dwemer/dwarvenscrap1.nif,f6bdcb8622e5ea8d
+09 Dwemer Clutter/meshes/clutter/dwemer/dwarvenscrap2.nif,fbeb74c960896e27
+09 Dwemer Clutter/meshes/clutter/dwemer/dwarvenscrap3.nif,6a087b530ec4dd06
+09 Dwemer Clutter/meshes/clutter/dwemer/dwarvenscrap4.nif,f4e97aa4ca4c6bd7
+09 Dwemer Clutter/meshes/clutter/dwemer/dwarvenscraplarge1.nif,2248eeec739c50f0
+09 Dwemer Clutter/meshes/clutter/dwemer/dwarvenscraplarge2.nif,dea5c420d0b5fc55
+09 Dwemer Clutter/meshes/clutter/dwemer/dwebowl01.nif,0da1f680e4243e7d
+09 Dwemer Clutter/meshes/clutter/dwemer/dwebowl02.nif,f330079bf0ecb0a2
+09 Dwemer Clutter/meshes/clutter/dwemer/dwecog01.nif,cbae2720b74dfec3
+09 Dwemer Clutter/meshes/clutter/dwemer/dwecup01.nif,98b789a3280b14d2
+09 Dwemer Clutter/meshes/clutter/dwemer/dwecup02.nif,6ad6fb7f6158f59c
+09 Dwemer Clutter/meshes/clutter/dwemer/dwecup03.nif,943970700f68f1f2
+09 Dwemer Clutter/meshes/clutter/dwemer/dwefork.nif,2a169f52a1befdf6
+09 Dwemer Clutter/meshes/clutter/dwemer/dweknife.nif,7e63aaf2d8e2249d
+09 Dwemer Clutter/meshes/clutter/dwemer/dweplate01.nif,41daca469b1141d1
+09 Dwemer Clutter/meshes/clutter/dwemer/dwepot01.nif,e473a437bbb12997
+09 Dwemer Clutter/meshes/clutter/dwemer/dwespoon.nif,1fa15f9e09cc5c45
+09 Dwemer Clutter/meshes/dlc02/dungeons/dwemer/animated/dwedynamotrigger01/dwedynamotrigger01.nif,933adcf2132995b7
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_centurion_core.dds,795fafdf22a2fc67
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_centurion_core_g.dds,8fe629e05d1da1d3
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_centurion_core_m.dds,38d950da649cc79d
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_centurion_core_n.dds,7336fe644833ec71
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_clutter_bowl.dds,d407523274326949
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_clutter_bowl_n.dds,338339bd390d6c3e
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_clutter_cup.dds,c8d1bc56869b20cd
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_clutter_cup_n.dds,8e0a7a248a222abd
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_gyro.dds,7b8d8be81115fb0e
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_gyro_m.dds,2f3bf5cd06e89509
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_gyro_n.dds,c1ee2356125d0175
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_scrap3.dds,aeb2c1919789727d
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_scrap3_m.dds,8baa8fc5459e656c
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_scrap3_n.dds,a5c054b1031005dc
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_scrap4.dds,1e46c40dd9b98cfb
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_scrap4_m.dds,1b7668b3e3783269
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_scrap4_n.dds,43db6b90865584bd
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_cog01.dds,2d3f6ad018d375ff
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_cog01_m.dds,cccf796ef2daafaf
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_cog01_n.dds,b53f9d7e252d0816
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_gear.dds,b55e3843c41fd499
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_gear_m.dds,f1b51e206eab7b8d
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_gear_n.dds,6c593d29f69c623d
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_scrap1_sides.dds,1f5b8f15d5d31cdb
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_scrap1_sides_m.dds,fea79ec6f2c5edd9
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_scrap1_sides_n.dds,13b1717f5baf335e
+10 Nordic Tables and Benches/meshes/clutter/ruins/ruinsfurniturerubble03.nif,bd1b5bc375d894ac
+10 Nordic Tables and Benches/meshes/clutter/ruins/ruinsfurniturerubble04.nif,15d3f9141df16fe1
+10 Nordic Tables and Benches/meshes/clutter/ruins/ruinsfurniturerubble09.nif,a82d35b177b33b72
+10 Nordic Tables and Benches/meshes/clutter/ruins/ruinsfurniturerubble10.nif,34064aaffae6d172
+10 Nordic Tables and Benches/meshes/clutter/ruins/ruinsfurniturerubble11.nif,3127e3256b95605d
+10 Nordic Tables and Benches/meshes/clutter/ruins/ruinsfurniturerubble15.nif,d5d3eaaf5b83b522
+10 Nordic Tables and Benches/meshes/clutter/ruins/ruinslongtable01.nif,e9f373a78a3cd61c
+10 Nordic Tables and Benches/meshes/clutter/ruins/ruinstable01.nif,fe7c2fe82cc14226
+10 Nordic Tables and Benches/meshes/clutter/ruins/ruins_altar01.nif,7e2c8d8d5645a7a7
+10 Nordic Tables and Benches/meshes/furniture/nordic/ruinsbenchtable1sided.nif,9474de23d04aa485
+10 Nordic Tables and Benches/meshes/furniture/nordic/ruinsbenchtable2sided.nif,d05140596001432d
+10 Nordic Tables and Benches/meshes/furniture/nordic/ruinsbookpedestal.nif,f328533b5cf15807
+10 Nordic Tables and Benches/meshes/furniture/nordic/ruinsbookpedestalshadow.nif,07082a8f3f2ffe4b
+10 Nordic Tables and Benches/meshes/furniture/nordic/ruins_bench01.nif,101686f1270ce507
+10 Nordic Tables and Benches/meshes/furniture/nordic/ruins_benchshadow01.nif,ebf3de61daf404d6
+10 Nordic Tables and Benches/textures/smim/furniture/nordic/ruinstable_smim_vanillamix.dds,6ba0dfa195d32d35
+10 Nordic Tables and Benches/textures/smim/furniture/nordic/ruinstable_smim_vanillamix_n.dds,2a24309b4c8aae6f
+11 Bridges/meshes/landscape/bridges/bridge01.nif,f8289f6f0feda8a0
+11 Bridges/meshes/landscape/bridges/bridgelong01.nif,94b23404f9236282
+11 Bridges/meshes/landscape/bridges/bridgenarrow01.nif,e22f67eb0564ba72
+11 Bridges/meshes/landscape/bridges/bridgeshort01.nif,496ab236df714d66
+11 Bridges/textures/smim/landscape/bridges/bridge_pillar_top.dds,00a7bb1daf63664b
+11 Bridges/textures/smim/landscape/bridges/bridge_pillar_top_n.dds,12f14019a8be32f2
+11 Bridges/textures/smim/landscape/bridges/bridge_road_stone_tile.dds,c7de7318851cec00
+11 Bridges/textures/smim/landscape/bridges/bridge_road_stone_tile_n.dds,528b908fe4d56702
+11 Bridges/textures/smim/landscape/bridges/smim_bridge_dirt.dds,b1ce69993f7c8136
+11 Bridges/textures/smim/landscape/bridges/smim_bridge_dirt_n.dds,8ed62fe518091682
+11 Bridges Old Stonework/meshes/landscape/bridges/bridge01.nif,e234236ff4a37a80
+11 Bridges Old Stonework/meshes/landscape/bridges/bridgelong01.nif,62957e827d0866c0
+11 Bridges Old Stonework/meshes/landscape/bridges/bridgenarrow01.nif,169a5d8d65b2e29d
+11 Bridges Old Stonework/meshes/landscape/bridges/bridgeshort01.nif,a6efaae6255e6e89
+11 Bridges Old Stonework/textures/smim/landscape/bridges/bridge_pillar_top.dds,00a7bb1daf63664b
+11 Bridges Old Stonework/textures/smim/landscape/bridges/bridge_pillar_top_n.dds,12f14019a8be32f2
+11 Bridges Old Stonework/textures/smim/landscape/bridges/bridge_road_stone_tile.dds,5882a6d523b517d5
+11 Bridges Old Stonework/textures/smim/landscape/bridges/bridge_road_stone_tile_n.dds,5468af59d9377594
+11 Bridges Real Roads/meshes/architecture/solitude/sbridge01.nif,ee2d544780533f5c
+11 Bridges Real Roads/meshes/landscape/bridges/bridge01.nif,632c72927734956b
+11 Bridges Real Roads/meshes/landscape/bridges/bridgelong01.nif,8e1bd17f38fcae05
+11 Bridges Real Roads/meshes/landscape/bridges/bridgenarrow01.nif,21e72c950bf76eed
+11 Bridges Real Roads/meshes/landscape/bridges/bridgeshort01.nif,7c4e330b5cdcc5ae
+11 Bridges Real Roads/textures/smim/landscape/bridges/bridge_pillar_top.dds,00a7bb1daf63664b
+11 Bridges Real Roads/textures/smim/landscape/bridges/bridge_pillar_top_n.dds,12f14019a8be32f2
+11 Bridges Real Roads/textures/smim/landscape/bridges/bridge_road_stone_tile.dds,c7de7318851cec00
+11 Bridges Real Roads/textures/smim/landscape/bridges/bridge_road_stone_tile_n.dds,528b908fe4d56702
+11 Bridges Real Roads/textures/smim/landscape/bridges/smim_bridge_dirt.dds,b1ce69993f7c8136
+11 Bridges Real Roads/textures/smim/landscape/bridges/smim_bridge_dirt_n.dds,8ed62fe518091682
+12 Whiterun Doors/meshes/architecture/whiterun/wrcastledoor01.nif,f509f2f6c2484df6
+12 Whiterun Doors/meshes/architecture/whiterun/wrdoormaingate01.nif,f72ac8bce05ec867
+12 Whiterun Doors/meshes/architecture/whiterun/wrdragondoor01.nif,79b17611d4f03414
+12 Whiterun Doors/meshes/arthmoor/opencitiesskyrim/architecture/whiterun/ocswhiterunmaingatenew.nif,358cb098de07306c
+13 Lanterns/meshes/clutter/common/candlelantern01.nif,a0babd84540becea
+13 Lanterns/meshes/clutter/common/candlelanternwithcandle01.nif,b2dffbef45b6284c
+13 Lanterns/meshes/dlc02/loadscreenart/loadscreenadventure02.nif,9de052f2b62e3971
+13 Lanterns/meshes/loadscreenart/loadscreenadventure01.nif,89dce0f544656bb8
+13 Lanterns/meshes/loadscreenart/loadscreenshopsmagic01.nif,ebf6280041e899a7
+13 Lanterns/textures/effects/candleflame01.dds,312afe2c4c66e0a0
+13 Lanterns/textures/smim/candles/candles01.dds,36d9d5ead48714cc
+13 Lanterns/textures/smim/candles/candles01_g.dds,cfad1913638feeb6
+13 Lanterns/textures/smim/candles/candles01_n.dds,ea8228da6595e530
+13 Lanterns/textures/smim/clutter/common/smim_lantern.dds,d0f1b96ef1443af6
+13 Lanterns/textures/smim/clutter/common/smim_lantern_n.dds,95a22f90622874e0
+14 Stockade 3D Ropes/meshes/clutter/stockade/stockadescaffoldtoppost01.nif,727f3b09b705d9d7
+14 Stockade 3D Ropes/meshes/clutter/stockade/stockadescaffoldtoppost02.nif,2ff933d680818648
+14 Stockade 3D Ropes/meshes/clutter/stockade/stockadescaffoldtoppost03.nif,609bdbba1c85266a
+14 Stockade 3D Ropes/meshes/clutter/stockade/stockadescaffoldtoprope01.nif,95fb865885eede5d
+14 Stockade 3D Ropes/meshes/clutter/stockade/stockadescaffoldtoprope02.nif,c60a9a19fd5d9ee4
+14 Stockade 3D Ropes/meshes/clutter/stockade/stockadescaffoldtoprope03.nif,6d75608fa1614686
+14 Stockade 3D Ropes/textures/clutter/stockade/stockadewood01.dds,5e19fe0db8d1570a
+14 Stockade 3D Ropes/textures/clutter/stockade/stockadewood01snow.dds,e49b015b7e797019
+14 Stockade 3D Ropes/textures/clutter/stockade/stockadewood01_n.dds,deb4d7e6021a4eb9
+15 Clothing Fixes/meshes/armor/dragonscale/dragonscalecuirassgo.nif,18cc3fefd3c32aa8
+15 Clothing Fixes/meshes/armor/studded/male/body_go.nif,bd8aa41d0bea056d
+15 Clothing Fixes/meshes/clothes/farmclothes04/robem_0.nif,cc9e9a2d42d96367
+15 Clothing Fixes/meshes/clothes/farmclothes04/robem_1.nif,04dbdff67f540ff9
+15 Clothing Fixes/meshes/clothes/wench/wenchoutfitm_0.nif,ff2fa3c8ac443eb3
+15 Clothing Fixes/meshes/clothes/wench/wenchoutfitm_1.nif,ac37ac1e5113aee2
+15 Clothing Fixes/textures/clothes/wench/wenchoutfitm.dds,4b3c9b76abb5ecfc
+16 Tankard Bright Brushed Metal/meshes/animobjects/animobjectdrinkingtankard.nif,d0143111eb72189b
+16 Tankard Bright Brushed Metal/meshes/clutter/dining set/basictankard01.nif,49feec7d931f4772
+16 Tankard Bright Brushed Metal/meshes/dlc01/clutter/dlc01tankardblood.nif,17440a66f94fcacb
+16 Tankard Bright Brushed Metal/meshes/loadscreenart/loadscreenargonianbarkeep.nif,2e09bef0e6dc129d
+16 Tankard Bright Brushed Metal/textures/smim/clutter/diningset/smim_tankard.dds,211fffb202da6e9f
+16 Tankard Bright Brushed Metal/textures/smim/clutter/diningset/smim_tankard_em.dds,95c0a7ce6712eb95
+16 Tankard Bright Brushed Metal/textures/smim/clutter/diningset/smim_tankard_n.dds,c68bb8aadd4ef929
+16 Tankard Bright Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody.dds,77bf82370383bedf
+16 Tankard Bright Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_em.dds,345cae275eda52fe
+16 Tankard Bright Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_n.dds,65b5d3ca55a914e1
+16 Tankard Dark Brushed Metal/meshes/animobjects/animobjectdrinkingtankard.nif,d0143111eb72189b
+16 Tankard Dark Brushed Metal/meshes/clutter/dining set/basictankard01.nif,49feec7d931f4772
+16 Tankard Dark Brushed Metal/meshes/dlc01/clutter/dlc01tankardblood.nif,17440a66f94fcacb
+16 Tankard Dark Brushed Metal/meshes/loadscreenart/loadscreenargonianbarkeep.nif,2e09bef0e6dc129d
+16 Tankard Dark Brushed Metal/textures/smim/clutter/diningset/smim_tankard.dds,2e8ff748eda83518
+16 Tankard Dark Brushed Metal/textures/smim/clutter/diningset/smim_tankard_em.dds,9b69429fe990b4dc
+16 Tankard Dark Brushed Metal/textures/smim/clutter/diningset/smim_tankard_n.dds,7fbc7a49a6ee21d4
+16 Tankard Dark Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody.dds,acd8ad155b2344a6
+16 Tankard Dark Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_em.dds,305d2047c881b716
+16 Tankard Dark Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_n.dds,42674b0bc7580408
+16 Tankard Pewter Metal/meshes/animobjects/animobjectdrinkingtankard.nif,a72c4b470a9467f7
+16 Tankard Pewter Metal/meshes/clutter/dining set/basictankard01.nif,1ad741c33f746556
+16 Tankard Pewter Metal/meshes/dlc01/clutter/dlc01tankardblood.nif,fc62af9706df0de8
+16 Tankard Pewter Metal/meshes/loadscreenart/loadscreenargonianbarkeep.nif,51c2781fa2682be3
+16 Tankard Pewter Metal/textures/smim/clutter/diningset/smim_tankard.dds,adbd73fa2e7a4908
+16 Tankard Pewter Metal/textures/smim/clutter/diningset/smim_tankard_em.dds,2bf5f8894c3c97de
+16 Tankard Pewter Metal/textures/smim/clutter/diningset/smim_tankard_n.dds,7e9166a0bdb3c4cc
+16 Tankard Pewter Metal/textures/smim/dlc01/clutter/smim_tankard_bloody.dds,5cbe7efe60863e17
+16 Tankard Pewter Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_em.dds,b1697e6f3bcc2504
+16 Tankard Pewter Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_n.dds,bae3df70e3198776
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg1way01.nif,7c279a861334506b
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg1wayendcap01.nif,cbdadbbd196441a2
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg2way01.nif,d18999d5d041a41f
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg3way01.nif,b109dc23edde34c5
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm1way01.nif,894908cc45a362bd
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm1way02.nif,9cf50811f9628ac7
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm1way03.nif,bd1fc438c0066e4f
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm2way01.nif,efa314b5dc57bbe4
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm3way01.nif,bda1f3192d0ec578
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm3way02.nif,b8c81363ceecddb9
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm4way01.nif,e717c89473ec5cf9
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm4way02.nif,44f2e55ad28eba6f
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/temple/bghalls/nortmphallbg1waywall01.nif,d0081656af861e31
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/temple/bghalls/nortmphallbg1waywall02.nif,f24717a653c2424c
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/temple/bghalls/nortmphallbg1waywall03.nif,20d4da69c063a2e9
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/temple/bghalls/nortmphallbgcolumn01.nif,a990791129a6c121
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/temple/bghalls/nortmphallbgcolumn03.nif,bce2c998a61577cc
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/temple/bghalls/nortmphallbgcolumnsm01.nif,aec2fbc7a25dc2ca
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/temple/bghalls/nortmphallbgcolumnsm02.nif,a5f591cb1f6e842b
+17 Nordic Catacombs Skeletal Remains/textures/actors/skeleton/skeleton.dds,8c316d8ca8f2ea3e
+17 Nordic Catacombs Skeletal Remains/textures/actors/skeleton/skeleton_n.dds,2d2a0e827cc030fa
+17 Nordic Catacombs Skeletal Remains/textures/effects/candleflame01.dds,312afe2c4c66e0a0
+17 Nordic Catacombs Skeletal Remains/textures/smim/candles/candles01.dds,36d9d5ead48714cc
+17 Nordic Catacombs Skeletal Remains/textures/smim/candles/candles01_g.dds,cfad1913638feeb6
+17 Nordic Catacombs Skeletal Remains/textures/smim/candles/candles01_n.dds,ea8228da6595e530
+17 Nordic Catacombs Skeletal Remains/textures/smim/candles/candles02.dds,66aaba8688c65ccc
+17 Nordic Catacombs Skeletal Remains/textures/smim/candles/candles02_g.dds,f33f95b88753eefd
+17 Nordic Catacombs Skeletal Remains/textures/smim/candles/candles02_n.dds,dc06819ad91ac894
+17 Nordic Catacombs Skeletal Remains/textures/smim/dungeons/nordic/temple/smim_nordic_bonedirt.dds,eaed2c4dcee58f5f
+17 Nordic Catacombs Skeletal Remains/textures/smim/dungeons/nordic/temple/smim_nordic_bonedirt_n.dds,8caf3965af9e909f
+17 Nordic Catacombs Skeletal Remains/textures/smim/dungeons/nordic/temple/smim_nordic_skeleton.dds,90feb2e90dd25a07
+18 Farmhouse Woven Fence/meshes/architecture/farmhouse/fencewoven01.nif,1f28e804bc15b76c
+18 Farmhouse Woven Fence/meshes/architecture/farmhouse/fencewoven02.nif,56c4132959a6d0ad
+18 Farmhouse Woven Fence/meshes/_byoh/clutter/house crafting/inventory/invanimalpen01.nif,9cfadbc1bb16f17b
+18 Farmhouse Woven Fence/meshes/_byoh/clutter/house crafting/inventory/invgarden01.nif,52f530392d0a6e4b
+18 Farmhouse Woven Fence Dense/meshes/architecture/farmhouse/fencewoven01.nif,518554264dc69c85
+18 Farmhouse Woven Fence Dense/meshes/architecture/farmhouse/fencewoven02.nif,beb1b675e523b549
+18 Farmhouse Woven Fence Dense Gray/meshes/architecture/farmhouse/fencewoven01.nif,969b95d1a294484b
+18 Farmhouse Woven Fence Dense Gray/meshes/architecture/farmhouse/fencewoven02.nif,0714be2755f1a4af
+18 Farmhouse Woven Fence Less Flicker/meshes/architecture/farmhouse/fencewoven01.nif,e8dc441f6718be6b
+18 Farmhouse Woven Fence Less Flicker/meshes/architecture/farmhouse/fencewoven02.nif,85a54778cb01a193
+18 Farmhouse Woven Fence Less Flicker/meshes/_byoh/clutter/house crafting/inventory/invanimalpen01.nif,0c7adedc25f8d53a
+18 Farmhouse Woven Fence Less Flicker/meshes/_byoh/clutter/house crafting/inventory/invgarden01.nif,0a63830041d60ab6
+19 Smelter/meshes/furniture/smeltermarker.nif,6647ff38e1b80318
+19 Smelter/meshes/_byoh/clutter/house crafting/inventory/invsmelter01.nif,a1c5a9e1581b4a0d
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_dome.dds,85a6150fe5926fd4
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_dome_n.dds,22bd767c262fc3d8
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_door.dds,966dd7fae49edcce
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_door_n.dds,dbc6aa654fb87e55
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_metal.dds,eaff40bdee5e0546
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_metal_n.dds,aa1dd0ac5ba1d98d
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_spout.dds,b7f47e22180752b4
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_spout_n.dds,271d22c2c55436e2
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_stonework.dds,48bb184ae8254bea
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_stonework_n.dds,a22e4d0597629c53
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_stucco.dds,b75fc1491f1162a6
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_stucco_n.dds,57dfdfed7c24d76a
+20 Furniture Skyrim HD Appearance/meshes/clutter/common/commontablesquare01.nif,9517c1e62f7d1a4b
+20 Furniture Skyrim HD Appearance/meshes/clutter/common/dresser01.nif,aa5b41a1f8528cfd
+20 Furniture Skyrim HD Appearance/meshes/clutter/common/endtable01.nif,d6a8da261124424f
+20 Furniture Skyrim HD Appearance/meshes/clutter/common/wardrobe01.nif,ddc432c56546358b
+20 Furniture Skyrim HD Appearance/textures/clutter/common/dresser01.dds,879efd7f76ceb462
+20 Furniture Skyrim HD Appearance/textures/clutter/common/dresser01_n.dds,5fd4c847531e9b66
+20 Furniture Skyrim HD Appearance/textures/clutter/furniturewood01.dds,9d4e12fbbaeb97ba
+20 Furniture Skyrim HD Appearance/textures/clutter/furniturewood01_n.dds,63088b73fa522c5e
+20 Furniture Skyrim HD Appearance/textures/smim/clutter/common/dresser01.dds,36ab54d2262dea9b
+20 Furniture Skyrim HD Appearance/textures/smim/clutter/common/dresser01_n.dds,82e8b306166d141d
+20 Furniture Skyrim HD Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece.dds,9d0f205142393e88
+20 Furniture Skyrim HD Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece_n.dds,d57071a649379ec5
+20 Furniture Skyrim HD Weathered Appearance/meshes/clutter/common/commontablesquare01.nif,9517c1e62f7d1a4b
+20 Furniture Skyrim HD Weathered Appearance/meshes/clutter/common/dresser01.nif,aa5b41a1f8528cfd
+20 Furniture Skyrim HD Weathered Appearance/meshes/clutter/common/endtable01.nif,d6a8da261124424f
+20 Furniture Skyrim HD Weathered Appearance/meshes/clutter/common/wardrobe01.nif,ddc432c56546358b
+20 Furniture Skyrim HD Weathered Appearance/textures/clutter/common/dresser01.dds,5d4f2cc651ae4232
+20 Furniture Skyrim HD Weathered Appearance/textures/clutter/common/dresser01_n.dds,3afe67adde187b92
+20 Furniture Skyrim HD Weathered Appearance/textures/clutter/furniturewood01.dds,87416dc77b621e85
+20 Furniture Skyrim HD Weathered Appearance/textures/clutter/furniturewood01_n.dds,dabd609dba742a11
+20 Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/dresser01.dds,b015eb7f370ad240
+20 Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/dresser01_n.dds,0cec68363cdfc0ab
+20 Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece.dds,d3a504b4e5aa86a1
+20 Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece_n.dds,9d2f819869d43744
+21 Dwemer Animated Lifts SE/meshes/dlc02/dungeons/dwemer/door/dlc2dwefacadeliftleverloaddown01.nif,93afede1dfeb1141
+21 Dwemer Animated Lifts SE/meshes/dlc02/dungeons/dwemer/door/dlc2dwefacadeliftleverloaddown02.nif,e3150946e491fb5a
+21 Dwemer Animated Lifts SE/meshes/dlc02/dungeons/dwemer/door/dlc2dwefacadeliftleverloadup01.nif,b2e6b2062eb19438
+21 Dwemer Animated Lifts SE/meshes/dlc02/dungeons/dwemer/door/dlc2dwefacadeliftleverloadup02.nif,827c30d6c40f9c97
+21 Dwemer Animated Lifts SE/meshes/dungeons/dwemer/facades/dwefacadeliftleverloaddown01.nif,53b942c98c6d47d4
+21 Dwemer Animated Lifts SE/meshes/dungeons/dwemer/facades/dwefacadeliftleverloadup01.nif,248516dada30d74e
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockcolstr01.nif,e89b9dbcde4c501a
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockcolstr02.nif,f7c94b69d00e523e
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockcolstrsign01.nif,8f4b92dafb35d8f9
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockcolstrsignrope01.nif,0ddc5ca7e0c494d9
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockcorsol01.nif,7f681dafb15211ca
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockcorsol01uskp.nif,106be31aabba4f81
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockropestr01.nif,d13271a5cefe4bda
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockropestr02.nif,e244fed583d75e35
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstepsdown01.nif,0376ee91d0837c75
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstepsdown02.nif,ecd28d880581423c
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstepsdown02uskp.nif,3fc26ae3706239e9
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstepsdownend01.nif,141b90e558f11814
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstr4way01.nif,0b4eb2ca18929142
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrent01.nif,74acba98dab7ade6
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrent02.nif,6020d963909731e6
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrent02uskp.nif,d1729d98f8574678
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrent03.nif,39eae8d0789b932d
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrent03uskp.nif,5058d3393dd28d46
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrent04.nif,a34df9d8589484ca
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrsol01.nif,e76f5392a5331f34
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrsol01uskp.nif,6328a99be8e2466f
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrsol02.nif,9c21eb59afc98cf2
+22 Solitude Docks Ropes SE/meshes/architecture/solitude/clutter/slightpost01.nif,d1484e234c00467c
+22 Solitude Docks Ropes SE/meshes/architecture/solitude/seastempireco.nif,723d453d05a6e11b
+22 Solitude Docks Ropes SE/textures/smim/architecture/docks/smim_docks_ropes.dds,b9e611b5e3e4ef08
+22 Solitude Docks Ropes SE/textures/smim/architecture/docks/smim_docks_ropes_n.dds,2225c41aadf76b06
+22 Solitude Docks Ropes SE/SMIM-SE-SolitudeDocksFixes.esp,4e8951763bcbb278
+23 Tomato Pure Red without Blemish/textures/smim/clutter/ingredients/tomato_smim.dds,6e79367e74ea614f
+23 Tomato Pure Red without Blemish/textures/smim/clutter/ingredients/tomato_smim_n.dds,8811b6c66506f194
+25 Solitude Gate Doors/meshes/architecture/solitude/doors/sgatedoor.nif,b70356870393a939
+25 Solitude Gate Doors/meshes/architecture/solitude/doors/slgdoor01.nif,849238e2392843a4
+25 Solitude Gate Doors/meshes/arthmoor/opencitiesskyrim/architecture/solitude/ocssoldoorfrontgate.nif,dc068e98c071e378
+25 Solitude Gate Doors/textures/smim/architecture/solitude/smim_sdoorgate01.dds,97805e1ea6fc2c91
+25 Solitude Gate Doors/textures/smim/architecture/solitude/smim_sdoorgate01_n.dds,1f5d16e23fbbb177
+25 Solitude Gate Doors/textures/smim/architecture/solitude/smim_solitude_door_pattern.dds,20b51fc4b1ade476
+25 Solitude Gate Doors/textures/smim/architecture/solitude/smim_solitude_door_pattern_n.dds,4809bb53d4d4782e
+26 Human Skull Fixes/meshes/actors/draugr/character assets/draugrskeleton.nif,09d1ac600aae3620
+26 Human Skull Fixes/meshes/actors/skeleton/testskeleton.nif,3dd823ea7e9d080d
+26 Human Skull Fixes/meshes/clutter/bones/bloodyskull.nif,5a84e4e3fdb4911f
+26 Human Skull Fixes/meshes/clutter/bones/humanskull.nif,11fd62ecffdda2e3
+26 Human Skull Fixes/meshes/clutter/bones/humanskullfull.nif,311480c1dd8dd8ea
+26 Human Skull Fixes/meshes/clutter/bones/humanskullfullstatic.nif,2a69fcf889ab0d8f
+26 Human Skull Fixes/meshes/clutter/bones/humanskullstatic.nif,d5b8d39fbac687c5
+26 Human Skull Fixes/meshes/clutter/potema/potemasskull.nif,4696d7231adfd510
+26 Human Skull Fixes/meshes/landscape/rocks/cairns/rockcairnevil01.nif,ee138b41712407ab
+26 Human Skull Fixes/meshes/landscape/rocks/cairns/rockcairnevil02.nif,919759dcfeee9eb6
+26 Human Skull Fixes/meshes/landscape/rocks/cairns/rockcairnevil03.nif,7fb1b8e799cbe59a
+26 Human Skull Fixes/meshes/landscape/rocks/cairns/rockcairnevil04.nif,ec8534f1ce1e98a4
+26 Human Skull Fixes/meshes/loadscreenart/loadscreensinister01.nif,36e138d86f7f59cd
+26 Human Skull Fixes/meshes/loadscreenart/loadscreenskeleton.nif,0badf0a6352e5af6
+26 Human Skull Fixes/meshes/loadscreenart/loadscreentrollclean.nif,73dc9f6e17ac5478
+26 Human Skull Fixes/meshes/_byoh/architecture/byohhouse/trophy/byohhousetrophyskeleton01.nif,8085a96ea000b56c
+26 Human Skull Fixes/textures/actors/skeleton/skeleton.dds,8c316d8ca8f2ea3e
+26 Human Skull Fixes/textures/actors/skeleton/skeleton_n.dds,5cec730dadb3c56a
+26 Human Skull Fixes/textures/clutter/bones/bloodybones.dds,294c0898604db303
+26 Human Skull Fixes/textures/clutter/bones/bloodybones_n.dds,c13dbefaa5ab9489
+26 Human Skull Fixes/textures/smim/loadscreenart/smim_trollloadscreen_meat.dds,6d5e0d9363312cd7
+26 Human Skull Fixes/textures/smim/loadscreenart/smim_trollloadscreen_meat_n.dds,09fa8a9de8d085a8
+27 Hawk/meshes/critters/fchawk/fchawkgo.nif,21c263f34394f902
+27 Hawk/textures/effects/fxbird01.dds,a002a57dc431893a
+27 Hawk/textures/effects/fxbird01_n.dds,8248138f4bf5753d
+27 Hawk/textures/smim/critters/fchawk/smim_hawk.dds,2fb32c2c9c46379e
+27 Hawk/textures/smim/critters/fchawk/smim_hawk_b.dds,7f335c8d992d4358
+27 Hawk/textures/smim/critters/fchawk/smim_hawk_n.dds,7d02bf61b0f1af58
+27 Hawk/textures/smim/dlc02/critters/smim_tern.dds,45ff22892e7fd235
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_czech.DLSTRINGS,34c96acdcadb1bbb
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_czech.ILSTRINGS,34c96acdcadb1bbb
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_czech.STRINGS,2dc916b78dfd7ea4
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_English.DLSTRINGS,34c96acdcadb1bbb
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_English.ILSTRINGS,34c96acdcadb1bbb
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_English.STRINGS,1bdf42ec14490d28
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_french.DLSTRINGS,34c96acdcadb1bbb
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_french.ILSTRINGS,34c96acdcadb1bbb
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_french.STRINGS,1bdf42ec14490d28
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_german.DLSTRINGS,34c96acdcadb1bbb
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_german.ILSTRINGS,34c96acdcadb1bbb
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_german.STRINGS,583841aa43b62b88
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_italian.DLSTRINGS,34c96acdcadb1bbb
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_italian.ILSTRINGS,34c96acdcadb1bbb
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_italian.STRINGS,ec34f3c418eeb264
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_japanese.DLSTRINGS,34c96acdcadb1bbb
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_japanese.ILSTRINGS,34c96acdcadb1bbb
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_japanese.STRINGS,732774c1cd7e8112
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_polish.DLSTRINGS,34c96acdcadb1bbb
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_polish.ILSTRINGS,34c96acdcadb1bbb
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_polish.STRINGS,98132b34e81f6b80
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_russian.DLSTRINGS,34c96acdcadb1bbb
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_russian.ILSTRINGS,34c96acdcadb1bbb
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_russian.STRINGS,b38785282671eb92
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_spanish.DLSTRINGS,34c96acdcadb1bbb
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_spanish.ILSTRINGS,34c96acdcadb1bbb
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_spanish.STRINGS,20d9bb920ff1f8eb
+28 Hawk Dragonborn Fix/SMIM-DragonbornTernFix.esp,5e5f5511a30a0b0c
+28 Hawk Dragonborn Fix/SMIM-SE-DragonbornTernFix.esp,51776be736bb79bb
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdock01.nif,c657590c3467e3ae
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdock02.nif,f1ff86e21a7121ce
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockpier01.nif,82d4e625668d0d9c
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockpier01a.nif,77f22f3ada4bd868
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockpier02.nif,a5b158e6997c0044
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockstepsdownend01.nif,932b426d85ed711a
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockstr01.nif,811db82c3a83ef26
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockstr02.nif,8b5c7824f35f6abe
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockstr02a.nif,e2220dd9514edabf
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockstr3way01.nif,d5e541a9359c951c
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockstr4way01.nif,44d76a58f5a6a378
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/fences/dlc2rrbannerpost01.nif,0599b514556dd91b
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/fences/dlc2rrfence01.nif,c346faec2b056b17
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/fences/dlc2rrfence01a.nif,760f94849e3731a3
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/fences/dlc2rrfence01ramp.nif,2b1bb4700f3fe3b0
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/fences/dlc2rrfence05ramp.nif,4b7633876032ac91
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/fences/dlc2rrfencepost01.nif,ce6aa3e00dca815c
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/fences/dlc2rrlanternpost01.nif,1d638c8d2fa72d13
+29 Raven Rock 3D Ropes/textures/smim/architecture/riften/smim_riften_rope.dds,fe6c8c29d5a27b7e
+29 Raven Rock 3D Ropes/textures/smim/architecture/riften/smim_riften_rope_n.dds,7c72dbc596639122
+30 Rocks - Generic/meshes/dungeons/mines/rocks/minecboulderl02.nif,ec2c18e6baf31a74
+30 Rocks - Generic/meshes/landscape/rocks/rockl01.nif,0ff27921fcc6f6fb
+30 Rocks - Generic/meshes/landscape/rocks/rockl02.nif,15bce834dac9fcc5
+30 Rocks - Generic/meshes/landscape/rocks/rockl03.nif,3a8c243d7d94d2bd
+30 Rocks - Generic/meshes/landscape/rocks/rockl04.nif,59e8a4c3401b8645
+30 Rocks - Generic/meshes/landscape/rocks/rockl05.nif,5a6ff54459381e0e
+30 Rocks - Generic/meshes/landscape/rocks/rockm01.nif,a94b688b3505d33a
+30 Rocks - Generic/meshes/landscape/rocks/rockm02.nif,59d0987a6ed8e2d3
+30 Rocks - Generic/meshes/landscape/rocks/rockm03.nif,1bf99e4680339dbf
+30 Rocks - Generic/meshes/landscape/rocks/rockm04.nif,82cece4c1ee30012
+30 Rocks - Generic/meshes/landscape/rocks/rockpilel01.nif,d353bc0315ae68a2
+30 Rocks - Generic/meshes/landscape/rocks/rockpilem02.nif,c3fba0c885338754
+30 Rocks - Generic/meshes/landscape/rocks/rockpilem02tundra.nif,55623e9a2d3be25b
+30 Rocks - Generic/meshes/landscape/rocks/rockpiles01.nif,55ca1d546f7039e0
+30 Rocks - Generic/meshes/landscape/rocks/rockpiles02.nif,d559c82402389d5f
+30 Rocks - Generic/meshes/landscape/rocks/rockpiles03.nif,57f3ebb44ad3dd94
+30 Rocks - Generic/meshes/landscape/rocks/rockpiles04.nif,21857aa84284925e
+30 Rocks - Generic/meshes/landscape/rocks/rocks01.nif,85c7d00998aafd81
+30 Rocks - Generic/meshes/landscape/rocks/rocks02.nif,07a98012eb479964
+30 Rocks - Generic/meshes/landscape/rocks/rocks03.nif,2403477d499a5b78
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystall01.nif,43d9722ad837a502
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystall02.nif,53aba04cb790874c
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystall03.nif,9796d57712e722bd
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystall04.nif,c1fc7bef25c2b15e
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystall05.nif,6864bfe35febd32e
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystalm01.nif,e0e01ee5739cb8d7
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystalm02.nif,283012347e60a213
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystalm03.nif,6c793d4198fa2f33
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystalm04.nif,3f155a82bd0dc7fd
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystalpiles02.nif,30a58e6066e1be31
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystalpiles03.nif,cbe4330829c1f830
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystalpiles04.nif,3d6250131d1f2d7b
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystals02.nif,77b13af2a21b9417
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystals03.nif,5658c522d2ae7dd9
+32 Rocks - Mountains/meshes/landscape/mountains/mountaincliff02.nif,6c536fb95bddc4eb
+32 Rocks - Mountains/meshes/landscape/mountains/mountaincliff03.nif,a1df76224a8d7d3c
+32 Rocks - Mountains/meshes/landscape/mountains/mountaincliff04.nif,ec405c8a812ca830
+32 Rocks - Mountains/meshes/landscape/mountains/mountaincliffcrevasse.nif,f37a2822cb5ddbfd
+32 Rocks - Mountains/meshes/landscape/mountains/mountaincliffsm01.nif,8104d5f46ddac9d8
+32 Rocks - Mountains/meshes/landscape/mountains/mountainridge01.nif,d6e9e56109e629ef
+32 Rocks - Mountains/meshes/landscape/mountains/mountaintrim01.nif,1ba638430b27e3f1
+32 Rocks - Mountains/meshes/landscape/mountains/mountaintrim01wet.nif,0023f711036212fb
+32 Rocks - Mountains/meshes/landscape/mountains/mountaintrimslab.nif,9fd44c22c9e464e2
+33 Orc Longhouse/meshes/architecture/orclonghouse/orcawning01.nif,3dd749f2ee8875c6
+33 Orc Longhouse/meshes/architecture/orclonghouse/orcawningfull01.nif,645bb234d198d76c
+33 Orc Longhouse/meshes/architecture/orclonghouse/orcawninghalf01.nif,fe4e6e5ec38675e0
+33 Orc Longhouse/meshes/architecture/orclonghouse/orcawningpartitionexsm01.nif,054044be3e473272
+33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghouse01.nif,9feec3a8c2c6abe6
+33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghouseinterior01.nif,4c3c3eeb78b54200
+33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghouseinterioreastwing01.nif,b1c28dad50839b9e
+33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghouseinteriorwestwing01.nif,0bc61b94932b7c83
+33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghousepartitionbeam01.nif,b667f041f2d80a3e
+33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghousepartitionend01.nif,c33d6a6d4a77c0bd
+33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghousepartitionexsm01.nif,ec4d16cff9595d3f
+33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghousepartitionwall01.nif,8b30e7b0a19076bd
+33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood.dds,ffdbbac430223e2e
+33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood_n.dds,f6edc9094df933e9
+33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood_segments.dds,2052ff0b1d7d757e
+33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood_segments_doorway.dds,9c71277bc88c2cff
+33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood_segments_doorway_n.dds,395a238ca97e61de
+33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood_segments_house.dds,f171d19e177ca638
+33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood_segments_house2.dds,030c059dc95cc658
+33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood_segments_middle.dds,d1a6a9fb49703f96
+35 Shack Kit/meshes/architecture/shackkit/shackbrokepole01.nif,da4bfd365e42f6a0
+35 Shack Kit/meshes/architecture/shackkit/shackbrokepole02.nif,13db7218f1550ce1
+35 Shack Kit/meshes/architecture/shackkit/shackbrokepole03.nif,bb83a25d4ccb12ce
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood01.nif,0942521ada7098a6
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood02.nif,79047416189b7d7c
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood03.nif,de23e60b9a4c73cb
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood04.nif,0792de039c5418c7
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood05.nif,a2773172ddf30bb6
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood06.nif,b12051520c92eb3b
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood07.nif,351143e9a6ff56db
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood08.nif,4af020348710f899
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood09.nif,2e8d758de8a1930b
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood10.nif,b1072a12b1ed8322
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood11.nif,a686f2f714ac7423
+35 Shack Kit/meshes/architecture/shackkit/shackframebend01.nif,38d40238ad2dc0c3
+35 Shack Kit/meshes/architecture/shackkit/shackframelend01.nif,7e3f583049c0849b
+35 Shack Kit/meshes/architecture/shackkit/shackframelend02.nif,69f77bc1fe437693
+35 Shack Kit/meshes/architecture/shackkit/shackframelmid01.nif,7ae369459e066937
+35 Shack Kit/meshes/architecture/shackkit/shackframemend01.nif,ceafc7be566d67be
+35 Shack Kit/meshes/architecture/shackkit/shackframemend02.nif,23804dded86390dd
+35 Shack Kit/meshes/architecture/shackkit/shackframemmid01.nif,47993100cc8535d2
+35 Shack Kit/meshes/architecture/shackkit/shackframerend01.nif,356494f42c45d718
+35 Shack Kit/meshes/architecture/shackkit/shackframerend02.nif,bcfb943ed9cb787d
+35 Shack Kit/meshes/architecture/shackkit/shackframermid01.nif,44a9b121ab48bb73
+35 Shack Kit/meshes/architecture/shackkit/shackframeturncorner01.nif,46c7c49d2f965cc9
+35 Shack Kit/meshes/architecture/shackkit/shackframeturncorner01FIX.nif,7a5e94fbfb0d6684
+35 Shack Kit/meshes/architecture/shackkit/shackframeturncorner02.nif,42ee26df96a3763c
+35 Shack Kit/meshes/architecture/shackkit/shackframeturnmid01.nif,061f3d8435dcec2c
+35 Shack Kit/meshes/architecture/shackkit/shackroofcorner01.nif,21565952ffd5268f
+35 Shack Kit/meshes/architecture/shackkit/shackroofcorner02.nif,1f6a2a815c607463
+35 Shack Kit/meshes/architecture/shackkit/shackroofmid01.nif,6a67960765b5b9da
+35 Shack Kit/meshes/architecture/shackkit/shackroofmid02.nif,20769f5c99267de7
+35 Shack Kit/meshes/architecture/shackkit/shackroofmid03.nif,6756990ab30cb089
+35 Shack Kit/meshes/architecture/shackkit/shackroofmid04.nif,422886681f142fa7
+35 Shack Kit/meshes/architecture/shackkit/shackroofmid05.nif,abc10892b7804a50
+35 Shack Kit/meshes/architecture/shackkit/shackroofside01.nif,cf6b0b97f406abf8
+35 Shack Kit/meshes/architecture/shackkit/shackroofside01SMIMBoards.nif,6c49c5c01293c047
+35 Shack Kit/meshes/architecture/shackkit/shackroofside02.nif,2dd0fdd8a7a7c8e7
+35 Shack Kit/meshes/architecture/shackkit/shackroofside03.nif,3b787f32bc81719f
+35 Shack Kit/meshes/architecture/shackkit/shackroofside04.nif,22d98a9e188186ae
+35 Shack Kit/meshes/architecture/shackkit/shackwall01.nif,3423e8e4a11b9e74
+35 Shack Kit/meshes/architecture/shackkit/shackwall03.nif,328087509beec7ea
+35 Shack Kit/meshes/architecture/shackkit/shackwall04.nif,e8ff707664771443
+35 Shack Kit/meshes/architecture/shackkit/shackwalldoor01.nif,6ca37e7893603295
+35 Shack Kit/meshes/architecture/shackkit/shackwalll01.nif,2d1dada44e7260d6
+35 Shack Kit/meshes/architecture/shackkit/shackwalll02.nif,5baa303d8b463104
+35 Shack Kit/meshes/architecture/shackkit/shackwallr01.nif,f069af1daad3f5b3
+35 Shack Kit/meshes/architecture/shackkit/shackwallr02.nif,0d00022cfbe348c5
+35 Shack Kit/meshes/architecture/shackkit/shackwalltop01.nif,5a162a9f5e525308
+35 Shack Kit/meshes/architecture/shackkit/shackwalltopwindow01.nif,5d4dc0b50dd32d5f
+35 Shack Kit/meshes/architecture/shackkit/shackwallwindow01.nif,7ae77f45c4f59655
+35 Shack Kit/meshes/architecture/shackkit/shackwallwindow02.nif,08658cd3aafa4402
+35 Shack Kit/meshes/betterdynamicsnow/shader/snowshader.nif,20508f83cc27e1ad
+35 Shack Kit/textures/smim/architecture/shackkit/smim_shack_roof.dds,d56b35a1973d048f
+35 Shack Kit/textures/smim/architecture/shackkit/smim_shack_roof_n.dds,9e2dc29f504cefce
+35 Shack Kit/SMIM-SE-ShackRoofFixes.esp,084b9f970ab6f9a0
+35 Shack Kit/SMIM-ShackRoofFixes.esp,7ffa8b4b92ea1140
+36 Shack Kit Dragonborn/SMIM-SE-ShackRoofFixesDragonborn.esp,553d6132e9969f66
+36 Shack Kit Dragonborn/SMIM-ShackRoofFixesDragonborn.esp,814a12dd2d03b85e
+37 Riften 3D Ropes/meshes/architecture/riften/docks/dockmooring01.nif,593fc61f57d28d44
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbld3waydwn01.nif,225ea3f8f870a95a
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldcor01.nif,f4634f924034cd01
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldcorin01.nif,6b29db789766d9d5
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldcorpier01.nif,7dbaa2a49559c447
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldcorpier02.nif,42bb439b11203f30
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldcorramp01.nif,320ca1563f88cb28
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldcortostairs01.nif,f25b7901ce9eb7ff
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldstr01.nif,5cf5e0d3499152a7
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldstrbridge01.nif,f117dc1825ad7527
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldstrdbl01.nif,d73d18c7b519f283
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldstrdbl02.nif,7657903177053aca
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldstrstairst01.nif,8f2e9bfea74e717b
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldtallstairs01.nif,8c0ff5a00f9d64fc
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockpier01.nif,cc553f3efae43d3c
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockpier02.nif,80cf42399b3e89f8
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockpier03.nif,3a99cbbf493fff95
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockpier03SMIM.nif,74f6e833364c9019
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockstairsturn01.nif,4d568f0aeb4f8f3c
+37 Riften 3D Ropes/meshes/architecture/riften/rtcanallock01.nif,9ca878d845eaf915
+37 Riften 3D Ropes/meshes/architecture/riften/rtcanalsdeck01.nif,fa2541a9d42fb6d1
+37 Riften 3D Ropes/meshes/architecture/riften/rtcanalsdeck02.nif,d4787f25125ca624
+37 Riften 3D Ropes/meshes/architecture/riften/rtlamppost01.nif,215d47fa88f640fe
+37 Riften 3D Ropes/meshes/architecture/riften/rtplayerhousedeck01.nif,ba2106349ef782a8
+37 Riften 3D Ropes/textures/smim/architecture/riften/smim_riften_rope.dds,fe6c8c29d5a27b7e
+37 Riften 3D Ropes/textures/smim/architecture/riften/smim_riften_rope_n.dds,7c72dbc596639122
+37 Riften 3D Ropes/SMIM-RiftenDocksRopesObjectFix.esp,9142c5043d3614fd
+37 Riften 3D Ropes/SMIM-SE-RiftenDocksRopesObjectFix.esp,68328aac96350268
+38 Riften 3D Ropes Better Ropes Texture/textures/smim/architecture/riften/smim_riften_rope.dds,94953c9161f48d6f
+38 Riften 3D Ropes Better Ropes Texture/textures/smim/architecture/riften/smim_riften_rope_n.dds,2a241f0b38993531
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldbaseropediv01.nif,712f0e48c5772681
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldbridge01.nif,0eb297532a861f74
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldbridge02.nif,4ac2e99784819d9b
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldbridge03.nif,d5926ad136f7c50c
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldbridge04.nif,abb5d990155760f1
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreerope01.nif,c4181823075852a6
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreerope02.nif,0076850ed707734a
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreerope03.nif,ff686a487b37f997
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreerope04.nif,7f7fc3dabcb60c4e
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreerope05.nif,3d7ffcc0250ba987
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreerope06.nif,7df8464756f67bcf
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreeropeend01.nif,352bca3bd26ca4b6
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreeropeend02.nif,df25ffd6aa39b156
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldrope01.nif,a5e6a7dcd162c920
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldrope02.nif,3b2a5d88845be381
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldrope03.nif,3efadbf8fbb8e8bd
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldrope04.nif,8ae593a195696bcc
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldrope05.nif,16e49973621d79e7
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldrope06.nif,83bfd73f5ac86b6e
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldropelong01.nif,642d735e1d43b9be
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldropelong02.nif,cb1e0411c5da5d66
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldropelong03.nif,69341f552e1038ac
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldropelong04.nif,baa8a353d595d935
+39 Dungeons 3D Ropes/textures/smim/dungeons/mines/smim_mines_rope.dds,ae24467508e61b5a
+39 Dungeons 3D Ropes/textures/smim/dungeons/mines/smim_mines_rope_n.dds,a7ecc2f2c8dd0e87
+39 Dungeons 3D Ropes/textures/smim/dungeons/mines/smim_wood_mine_smalltile.dds,e15de2e1eed43ef4
+39 Dungeons 3D Ropes/textures/smim/dungeons/mines/smim_wood_mine_smalltile_n.dds,0e9b44db013145a3
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/genericwell01.nif,0c6f5b10f93b7acf
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodbeam01.nif,20160094aa515b51
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodbeam02.nif,8d9926843d0cadce
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodbeam03.nif,70dd030d0814b29b
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodbeamshort01.nif,4fa927d1590f16ed
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodbeamshort02.nif,de97457f948148ed
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodplanks01.nif,269e57087040e925
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodplanks02.nif,71ac6a66852d8bf9
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodplanks03.nif,b47604d7b753fb18
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodplanks04.nif,5c84997af3e52e0a
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way01.nif,096e8d82c72193f7
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way128d01.nif,1732f317a0c53b8f
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way128l01.nif,18b947b0e60e0b21
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way128r01.nif,2237c5de48884edd
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way128short01.nif,8550b21f86e1c126
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way128u01.nif,a45fc4faaf44721f
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way256short01.nif,8f393a815bd8b7bb
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way64d01.nif,6e94c33412c92b6a
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way64l01.nif,bcaff9ca1e25a0e9
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way64r01.nif,5f56ddddfb6c7183
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way64short01.nif,9ae2a6d8fa96978d
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way64u01.nif,fbfc9dac3546513c
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall2way01.nif,d7623fd9fcffa742
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall2way02.nif,cc34f4c3394557c6
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall3way01.nif,94d09250ed03920d
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall3way02.nif,393974c346d94ab4
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall4way01.nif,01ab9f98c66d560a
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhallcrossover01.nif,139ea9992a1d30cc
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhalldeadend01.nif,d0c62d15a90b56d2
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhalldeadend02.nif,87b7c28f5718d818
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhalldetwist01.nif,e1a8f4fe5303a438
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhalldetwist02.nif,c06163fe463f9171
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhallentrance01.nif,6cb477f3009f62fb
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhallentrance02.nif,5a67979d61ebbc43
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhallramp01.nif,5d25c84b325976b2
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhallramp02.nif,254017aa54980022
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minerailramp01.nif,2d2e7a50288bf2be
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minerailtop1sided01.nif,e657e027b72e423f
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minerailtop2sided01.nif,547e21b048da380a
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minerailtop2sided02.nif,dc3f95f6bbf7a68d
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minerailtop3sided01.nif,83ceb05515ac4851
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minerailtop4sided01.nif,2732a1398b2c5da6
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbase0sided01.nif,7588c9831b94e261
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbase1sided01.nif,5d2af5416c1e31a4
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbase2sided01.nif,1bc2eebe37602fc7
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbase2sided02.nif,45d16ca0d0c9b24e
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbase3sided01.nif,16ee840b28384256
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbase4sided01.nif,006cb55998027e8f
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbaseropediv01.nif,712f0e48c5772681
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbasesupport01.nif,019d19971f23971e
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbasesupportw01.nif,99c993eadcd04803
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbridge01.nif,149ae7d45e59a9ef
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbridge02.nif,ae776040733a2171
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbridge03.nif,654a9ebe8d39636e
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbridge04.nif,8ae989f711fd88b1
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreerope01.nif,c4181823075852a6
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreerope02.nif,0076850ed707734a
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreerope03.nif,ff686a487b37f997
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreerope04.nif,7f7fc3dabcb60c4e
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreerope05.nif,3d7ffcc0250ba987
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreerope06.nif,7df8464756f67bcf
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreeropeend01.nif,352bca3bd26ca4b6
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreeropeend02.nif,df25ffd6aa39b156
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldramp01.nif,edf4ed0f4363408c
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldrope01.nif,a5e6a7dcd162c920
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldrope02.nif,3b2a5d88845be381
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldrope03.nif,3efadbf8fbb8e8bd
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldrope04.nif,8ae593a195696bcc
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldrope05.nif,16e49973621d79e7
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldrope06.nif,83bfd73f5ac86b6e
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldropelong01.nif,642d735e1d43b9be
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldropelong02.nif,cb1e0411c5da5d66
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldropelong03.nif,69341f552e1038ac
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldropelong04.nif,baa8a353d595d935
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldsupport01.nif,b0c49660a77c7ade
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldtop0sided01.nif,5e59554f4a25e83e
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldtop1sided01.nif,aad43a56800be03c
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldtop2sided01.nif,5a7cb9a355dcaa36
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldtop2sided02.nif,b331280a15709d99
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldtop3sided01.nif,b287ffa5db6997f8
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldtop4sided01.nif,feaf5e33da69ff93
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldtopcross01.nif,b33c2b8416ecd2ac
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/dungeons/imperial/impwood01.dds,a2dbbd44628ea198
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/dungeons/imperial/impwood01_n.dds,ee7a6843b8d8ba02
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/dungeons/mines/minewood01.dds,a2dbbd44628ea198
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/dungeons/mines/minewood01_n.dds,ee7a6843b8d8ba02
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_mines_rope.dds,ae24467508e61b5a
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_mines_rope_n.dds,a7ecc2f2c8dd0e87
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_beamsupport_thirdstile.dds,835460d5cc2dc092
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_beamsupport_thirdstile_n.dds,059d710be2a33ee9
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_beams_1k_support_corners.dds,421827927a16c7cc
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_beams_1k_support_corners_n.dds,035bed5c625dbd31
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_beams_x4_seamless.dds,dfd82564fa928043
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_beams_x4_seamless_n.dds,4a8f4084cadcd22f
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_planks.dds,26579f49d1af0b7d
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_planks_n.dds,68212fd78937326b
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_smalltile.dds,e15de2e1eed43ef4
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_smalltile_n.dds,0e9b44db013145a3
+40 Furniture Chests/meshes/clutter/containers/chest01/chest01.nif,0b2b90b00e1a640d
+40 Furniture Chests/meshes/clutter/containers/chestopen01.nif,e3620d88eb5b2a31
+40 Furniture Chests/meshes/clutter/upperclass/upperchest01.nif,c6b622b738c306dc
+40 Furniture Chests/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceupperchest01.nif,b78dbd0f3a95b129
+40 Furniture Chests/textures/smim/clutter/upperclass/smim_upperchest.dds,23120579f6fb76aa
+40 Furniture Chests/textures/smim/clutter/upperclass/smim_upperchest_n.dds,0ab62549d8e377dd
+40 Furniture Chests/textures/smim/clutter/upperclass/smim_upperchest_weathered.dds,487d6162a8d073fd
+40 Furniture Chests/textures/smim/clutter/upperclass/smim_upperchest_weathered_snow.dds,6c0998845bd6aba7
+40 Furniture Chests/SMIM-FurnitureChestSnowFix.esp,1596b36722855df8
+40 Furniture Chests/SMIM-SE-FurnitureChestSnowFix.esp,171c2a9f0df9c73e
+41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugr01.nif,a4c8361a4b7f4261
+41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugr02.nif,9cd0fa6b406b6628
+41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugr03.nif,1d228abdc55b741a
+41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugr04.nif,6182456d732d8b7d
+41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugr05.nif,f0f35021e0de28e1
+41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugr06.nif,94bc63352b34835d
+41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugrwrapped01.nif,d148d056600f69c8
+41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugrwrapped02.nif,11a94358f063b611
+42 Furniture Noble/meshes/furniture/noble/noblechair01.nif,e42d429399739756
+42 Furniture Noble/meshes/furniture/noble/noblechair02.nif,a5e7f4db072378ed
+42 Furniture Noble/meshes/_byoh/architecture/byohhouse/interface/byohinterfacenoblechair01.nif,89248ac9b24d9092
+42 Furniture Noble/meshes/_byoh/architecture/byohhouse/interface/byohinterfacenoblechair02.nif,fdb6030608c8fd8e
+42 Furniture Noble/meshes/_byoh/architecture/byohhouse/interface/byohinterfacenobletablelong01.nif,c5fd6caae8af16bd
+42 Furniture Noble/textures/smim/furniture/noble/SMIMNobleChair.dds,0a3d55419893c918
+42 Furniture Noble/textures/smim/furniture/noble/SMIMNobleChair_n.dds,edcec610e48c094c
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01.nif,1278ec2f17314f80
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01midendnubs.nif,4b53e672dccf7034
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar02.nif,112bc5efcd02850b
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorinltrans01.nif,8696c57d8f284660
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorinrtrans01.nif,afc8f40302d0824c
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorl01.nif,e3dc6f8a58de0a91
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorr01.nif,32346a07b34a5e8a
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam02nub.nif,d48d248908cb6562
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam02nubdouble.nif,22b51b5e049d11d8
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam03.nif,121fa52f96a80aaa
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestr01.nif,b6418b11e3d12de8
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestrdouble01.nif,f14bd636f3b447bf
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestrdouble01ext.nif,d10817065052cae0
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallcor01.nif,97ebac410c96ffab
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallcor01doorl.nif,ff5228a4eb6d65c8
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstr01.nif,f3b199db10c4e027
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstr01double.nif,2b3c05e9b33ad6a8
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrchimney01.nif,91a37c2b9515fc4d
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrmaindoor01.nif,8a36811e62cf1c95
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrtrans512.nif,c8341a88b30a92fc
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrtrans512r.nif,f39476fd58ecd94e
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewalltallfreestr01top.nif,eb7a11e7f1aeda7d
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrtemple/wrtempintpromarch02.nif,62fd3b810da5ad62
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrtemple/wrtempintpromarchnub01.nif,d2121a62162d59f4
+43 Whiterun Castle Wood Carvings Celtic/meshes/uskp/architecture/whiterun/wrintcastlefreepillar01uskp.nif,db95ba36768a5f64
+43 Whiterun Castle Wood Carvings Celtic/textures/smim/architecture/whiterun/wrcastlecarvings.dds,9834a23042553b88
+43 Whiterun Castle Wood Carvings Celtic/textures/smim/architecture/whiterun/wrcastlecarvings_n.dds,e04135b55740c14d
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01.nif,1278ec2f17314f80
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01midendnubs.nif,1c1b96fe703de75d
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar02.nif,112bc5efcd02850b
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorinltrans01.nif,6fa903ca030410f4
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorinrtrans01.nif,f2e7ac0c97f86184
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorl01.nif,756ca3938a31b4f4
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorr01.nif,7554466f8b2d9296
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam02nub.nif,88e828e1c43f39bd
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam02nubdouble.nif,cd22e4cdb40afd72
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam03.nif,7441fa0bcbe71a29
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestr01.nif,cf1aa272d6d1a27a
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestrdouble01.nif,399f9b5e94aa8b5a
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestrdouble01ext.nif,bc03ab786923c5f2
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallcor01.nif,a4186340dab3fc4a
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallcor01doorl.nif,2fc8598ee62ae331
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstr01.nif,06d54b482cf85a1b
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstr01double.nif,ef53d9b5ea645e4e
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrchimney01.nif,91a37c2b9515fc4d
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrmaindoor01.nif,ddf9affb751aabad
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrtrans512.nif,9e706f1f4a24c4c3
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrtrans512r.nif,30017c032e18c0e1
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewalltallfreestr01top.nif,96afdd4d72494d41
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrtemple/wrtempintpromarch02.nif,62fd3b810da5ad62
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrtemple/wrtempintpromarchnub01.nif,d2121a62162d59f4
+43 Whiterun Castle Wood Carvings Moroccan/meshes/uskp/architecture/whiterun/wrintcastlefreepillar01uskp.nif,db95ba36768a5f64
+43 Whiterun Castle Wood Carvings Moroccan/textures/smim/architecture/whiterun/wrcastlecarvings.dds,8647863771dd8062
+43 Whiterun Castle Wood Carvings Moroccan/textures/smim/architecture/whiterun/wrcastlecarvings_n.dds,5b6e202a6ed3d20b
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01.nif,1278ec2f17314f80
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01midendnubs.nif,1c1b96fe703de75d
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar02.nif,112bc5efcd02850b
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorinltrans01.nif,c13f313e0c133423
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorinrtrans01.nif,87e780eddb22f98e
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorl01.nif,02b2525625dbfaf6
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorr01.nif,c1707cd5fd9aef4c
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam02nub.nif,88e828e1c43f39bd
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam02nubdouble.nif,cd22e4cdb40afd72
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam03.nif,7441fa0bcbe71a29
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestr01.nif,51c4fc327e3f5efd
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestrdouble01.nif,fd6e328a78b0cbe2
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestrdouble01ext.nif,fd7a202777089e6e
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallcor01.nif,3f1150bf5d950a78
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallcor01doorl.nif,4955d3ab8f2a3881
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstr01.nif,5dbd8ec44e448788
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstr01double.nif,c96f39689211ef62
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrchimney01.nif,ecd87594503bf5cb
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrmaindoor01.nif,a855c517b70747b9
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrtrans512.nif,7185b2b7a67ba57c
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrtrans512r.nif,eeefa6e49b43a66c
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewalltallfreestr01top.nif,782babc7b76139f0
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrtemple/wrtempintpromarch02.nif,31ab434dc4dceedb
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrtemple/wrtempintpromarchnub01.nif,26793cec286ed2bf
+43 Whiterun Castle Wood Carvings Vanilla/meshes/uskp/architecture/whiterun/wrintcastlefreepillar01uskp.nif,db95ba36768a5f64
+43 Whiterun Castle Wood Carvings Vanilla/textures/smim/architecture/whiterun/wrcastlecarvings.dds,0365b2a3e3fe456f
+43 Whiterun Castle Wood Carvings Vanilla/textures/smim/architecture/whiterun/wrcastlecarvings_n.dds,c1f8d33e87590436
+44 Poor Coffin Custom Texture/meshes/furniture/noble/scoffinpoor.nif,4286c7a19b372745
+44 Poor Coffin Custom Texture/textures/smim/furniture/noble/smim_poor_coffin.dds,49da056d19147aa6
+44 Poor Coffin Custom Texture/textures/smim/furniture/noble/smim_poor_coffin_n.dds,95dee84186689b94
+45 Hanging Rings/meshes/clutter/deadanimals/hanginganimals01.nif,7c9ebeddafce3e11
+45 Hanging Rings/meshes/clutter/deadanimals/hanginganimals02.nif,1a6546232f287c87
+45 Hanging Rings/meshes/clutter/deadanimals/hanginganimals03.nif,a821de4087b0ec2a
+45 Hanging Rings/meshes/clutter/deadanimals/hanginganimalsring01.nif,b592be212485fe6b
+45 Hanging Rings/meshes/clutter/deadanimals/hanginganimalsring02.nif,6b97c9b5132d23ba
+45 Hanging Rings/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceanimalring01.nif,5e4ce46dbec166a9
+45 Hanging Rings/meshes/_byoh/clutter/dead animals/hanginganimalsring03.nif,68bce0ae07626323
+45 Hanging Rings/textures/smim/clutter/deadanimals/smim_metalhanger_deadanimals.dds,9fc093155afaf545
+45 Hanging Rings/textures/smim/clutter/deadanimals/smim_metalhanger_deadanimals_n.dds,817f56fd827a4aeb
+46 Carriage Seats and Fixes/meshes/Actors/horse/character assets/harness.nif,fc7e9f70ba7d82ca
+46 Carriage Seats and Fixes/meshes/clutter/common/wagonwheel01.nif,61f69f7aaf49c756
+46 Carriage Seats and Fixes/meshes/clutter/helgen/burntrubblecart01.nif,6fb89ba855d3eb08
+46 Carriage Seats and Fixes/meshes/furniture/cart/cartfurndriver01.nif,c580e2939f1b6f4b
+46 Carriage Seats and Fixes/meshes/furniture/cart/cartfurnpassanger01.nif,1b3e3ee15019a0ce
+46 Carriage Seats and Fixes/meshes/furniture/cart/cartfurnstatic01.nif,90c2becffc684d8f
+46 Carriage Seats and Fixes/meshes/furniture/prisonercarriage/prisonercarriage01.nif,8819bf04fd86f16e
+46 Carriage Seats and Fixes/meshes/furniture/prisonercarriage/prisonercarriage01static.nif,d3aef423899a84fd
+46 Carriage Seats and Fixes/meshes/furniture/prisonercarriage/prisonercarriagefurniture01.nif,bfca3b24a8f85e50
+46 Carriage Seats and Fixes/textures/smim/furniture/prisonercarriage/smim_carriage_metal.dds,f1bbaccf4c2071f1
+46 Carriage Seats and Fixes/textures/smim/furniture/prisonercarriage/smim_carriage_metal_n.dds,0a1c11ea84467067
+46 Carriage Seats and Fixes/textures/smim/furniture/prisonercarriage/smim_carriage_seat.dds,4bda1dc014d43733
+46 Carriage Seats and Fixes/textures/smim/furniture/prisonercarriage/smim_carriage_seat_n.dds,0b3b714230ee0f2b
+47 Juniper Tree/meshes/plants/florajuniper01.nif,f1bf343ec94401b9
+47 Juniper Tree/textures/smim/plants/smim_juniper_tree.dds,c9a8a05903fcc17f
+47 Juniper Tree/textures/smim/plants/smim_juniper_tree_n.dds,78c37ff1144fd718
+48 Juniper Tree Excessive Polycount Version/meshes/plants/florajuniper01.nif,caedd638aab75b94
+49 Tundra Tree/meshes/landscape/trees/tundradriftwood01.nif,97d1af8457aeb8ec
+49 Tundra Tree/textures/smim/landscape/trees/smim_tundra_tree.dds,ef9ed9291c1a17e8
+49 Tundra Tree/textures/smim/landscape/trees/smim_tundra_tree_n.dds,c731ee68e03b36a9
+50 Dawnguard Soulcairn Bone Piles/meshes/dlc01/soulcairn/sc_bonepile01.nif,c524169f240a7832
+50 Dawnguard Soulcairn Bone Piles/meshes/dlc01/soulcairn/sc_bonepile02.nif,69e5951788f8404e
+50 Dawnguard Soulcairn Bone Piles/meshes/dlc01/soulcairn/sc_bonepile03.nif,c38185c3181c9c70
+50 Dawnguard Soulcairn Bone Piles/meshes/dlc01/soulcairn/sc_bonepile04.nif,0d3a0d534617d12f
+50 Dawnguard Soulcairn Bone Piles/meshes/dlc01/soulcairn/sc_bonepile05.nif,cb9eb479e4ebc9b0
+50 Dawnguard Soulcairn Bone Piles/meshes/dlc01/soulcairn/sc_bonepile06.nif,5f73ee3fba03c5f7
+50 Dawnguard Soulcairn Bone Piles/textures/dlc01/landscape/soulcairnbones01.dds,8d0e9bf6e51040f9
+50 Dawnguard Soulcairn Bone Piles/textures/dlc01/landscape/soulcairnbones01_n.dds,a89c0a65614b8653
+50 Dawnguard Soulcairn Bone Piles/textures/dlc01/soulcairn/scbonetile.dds,99abfa4dc1309413
+50 Dawnguard Soulcairn Bone Piles/textures/dlc01/soulcairn/scbonetile_n.dds,45bcc69178c4a010
+50 Dawnguard Soulcairn Bone Piles/textures/smim/dlc01/soulcairn/smim_soulcairn_bone.dds,c0148154214e61d7
+50 Dawnguard Soulcairn Bone Piles/textures/smim/dlc01/soulcairn/smim_soulcairn_bone_n.dds,86c12012b66cd2d6
+50 Dawnguard Soulcairn Bone Piles/textures/smim/dlc01/soulcairn/smim_soulcairn_skeleton.dds,a281c06b22763f05
+50 Dawnguard Soulcairn Bone Piles/textures/smim/dlc01/soulcairn/smim_soulcairn_skeleton_n.dds,5cec730dadb3c56a
+51 Dawnguard Soulcairn Bone Piles (More Bones)/meshes/dlc01/soulcairn/sc_bonepile01.nif,74dc5fd390ab8ef2
+51 Dawnguard Soulcairn Bone Piles (More Bones)/meshes/dlc01/soulcairn/sc_bonepile02.nif,e323da082f45a8c1
+51 Dawnguard Soulcairn Bone Piles (More Bones)/meshes/dlc01/soulcairn/sc_bonepile03.nif,cd0a5e98c5073adc
+51 Dawnguard Soulcairn Bone Piles (More Bones)/meshes/dlc01/soulcairn/sc_bonepile04.nif,5ae45704d356fbfa
+51 Dawnguard Soulcairn Bone Piles (More Bones)/meshes/dlc01/soulcairn/sc_bonepile05.nif,71fa0c7d109d7d34
+51 Dawnguard Soulcairn Bone Piles (More Bones)/meshes/dlc01/soulcairn/sc_bonepile06.nif,2b98ca70e027f55c
+52 Dawnguard Soulcairn Bone Piles (White Bones)/textures/dlc01/landscape/soulcairnbones01.dds,61986aeabe168d02
+52 Dawnguard Soulcairn Bone Piles (White Bones)/textures/dlc01/soulcairn/scbonetile.dds,290de04b4eb4d8b9
+52 Dawnguard Soulcairn Bone Piles (White Bones)/textures/smim/dlc01/soulcairn/smim_soulcairn_bone.dds,5e3dbc794b4e6fa0
+52 Dawnguard Soulcairn Bone Piles (White Bones)/textures/smim/dlc01/soulcairn/smim_soulcairn_skeleton.dds,ff6ffff06e80a17c
+53 Imperial Jail/meshes/dungeons/imperial/jail/impjaildoor01.nif,151d98afa912b54b
+53 Imperial Jail/meshes/dungeons/imperial/jail/impjaildoor02.nif,8faeb72e750f8dfa
+53 Imperial Jail/meshes/dungeons/imperial/jail/impjaildoorframe01.nif,4fe61c31916a3227
+53 Imperial Jail/meshes/dungeons/imperial/jail/impjailpole01.nif,ad4fea4c343aefff
+53 Imperial Jail/meshes/dungeons/imperial/jail/impjailtop01.nif,3144c4e752ecd26a
+53 Imperial Jail/meshes/dungeons/imperial/jail/impjailwall01.nif,027269114d053c91
+53 Imperial Jail/meshes/dungeons/imperial/jail/impjailwall02.nif,d7d03c77032fd561
+53 Imperial Jail/meshes/dungeons/imperial/jail/impjailwall03.nif,de7b36c71041893a
+53 Imperial Jail/textures/smim/dungeons/imperial/smim_imp_gate_pole.dds,e01b640c97dbf5c7
+53 Imperial Jail/textures/smim/dungeons/imperial/smim_imp_gate_pole_n.dds,cb039cea7080f72b
+54 Imperial Jail Brighter Metal/textures/smim/dungeons/imperial/smim_imp_gate_pole.dds,b3f57344b45c98ed
+55 Windmills Base Vanilla Version/meshes/architecture/farmhouse/farmhousewindmill/farmhousewindmillfan.nif,758e10a13f754c2c
+55 Windmills Base Vanilla Version/meshes/architecture/solitude/swindmill.nif,39682ed62cf305e3
+55 Windmills Base Vanilla Version/textures/smim/architecture/farmhouse/smim_windmill_fan.dds,fc1c69b53434bbad
+55 Windmills Base Vanilla Version/textures/smim/architecture/farmhouse/smim_windmill_fan_n.dds,f06a9d8ca1a70e54
+55 Windmills Base Vanilla Version Sails/meshes/architecture/farmhouse/farmhousewindmill/farmhousewindmillfan.nif,051075e4e970a0b9
+55 Windmills Base Vanilla Version Sails/meshes/architecture/solitude/swindmill.nif,c65180d771888b66
+55 Windmills Base Vanilla Version Sails/textures/smim/architecture/farmhouse/smim_windmill_fan.dds,fc1c69b53434bbad
+55 Windmills Base Vanilla Version Sails/textures/smim/architecture/farmhouse/smim_windmill_fan_n.dds,f06a9d8ca1a70e54
+55 Windmills Base Vanilla Version Sails/textures/smim/architecture/farmhouse/smim_windmill_sail.dds,e2a487c6d8666060
+55 Windmills Base Vanilla Version Sails/textures/smim/architecture/farmhouse/smim_windmill_sail_n.dds,32a9bde5ad76d277
+55 Windmills Base Vanilla Version Sails/textures/smim/architecture/farmhouse/smim_windmill_sail_solitude.dds,3a6848780301f804
+56 Windmills SkyMills Compatibility/meshes/architecture/farmhouse/farmhousewindmill/farmhousewindmillfan02.nif,bf64a470ba7e365b
+56 Windmills SkyMills Compatibility/meshes/architecture/farmhouse/farmhousewindmill/smfarmhousewindmillfan.nif,2e21e7310da22334
+56 Windmills SkyMills Compatibility/meshes/architecture/solitude/swindmillrotor.nif,aa908f85b8380ca8
+56 Windmills SkyMills Compatibility Sails/meshes/architecture/farmhouse/farmhousewindmill/farmhousewindmillfan02.nif,a08771e0a8066461
+56 Windmills SkyMills Compatibility Sails/meshes/architecture/farmhouse/farmhousewindmill/smfarmhousewindmillfan.nif,5f0304e8d62fd9c5
+56 Windmills SkyMills Compatibility Sails/meshes/architecture/solitude/swindmillrotor.nif,2f6728aec8901e78
+57 Ruins Sarcophagus/meshes/clutter/ruins/sarcophaguslid/norsarcophagustopanim01.nif,ac893f87b9655743
+57 Ruins Sarcophagus/meshes/clutter/ruins/sarcophaguslidvert/sarcophagus_topvert01.nif,59cd74d2ec43a4c5
+57 Ruins Sarcophagus/meshes/clutter/ruins/ruinsfurniturerubble01.nif,ae3abb0b998c8e23
+57 Ruins Sarcophagus/meshes/clutter/ruins/ruinsfurniturerubble02.nif,e5a4973f93bdb687
+57 Ruins Sarcophagus/meshes/clutter/ruins/ruinssarcophagusvert01.nif,0fee203e10803a06
+57 Ruins Sarcophagus/meshes/clutter/ruins/ruinssarcophagusvert02.nif,110f6b002e70e3bb
+57 Ruins Sarcophagus/meshes/clutter/ruins/ruinssarcophagusvert03.nif,3cd1d6124d8a1514
+57 Ruins Sarcophagus/meshes/clutter/ruins/ruinssarcophagusverthole.nif,d41648fc7ff8b830
+57 Ruins Sarcophagus/meshes/clutter/ruins/ruinssarcophagus_bottom01.nif,df831b0eeea3b83a
+57 Ruins Sarcophagus/meshes/clutter/ruins/ruinssarcophagus_top01.nif,30cfe5dc741752f5
+57 Ruins Sarcophagus/textures/smim/clutter/ruins/smim_ruins_sarcophagus_parts.dds,c77cac3d15f3e2d7
+57 Ruins Sarcophagus/textures/smim/clutter/ruins/smim_ruins_sarcophagus_parts_n.dds,6a035bb842ab3114
+57 Ruins Sarcophagus/textures/smim/clutter/ruins/smim_ruins_sarcophagus_tub.dds,41f0d2ec8c4c5342
+57 Ruins Sarcophagus/textures/smim/clutter/ruins/smim_ruins_sarcophagus_tub_n.dds,379bd85074d2a52b
+58 Jewelry Rings/meshes/armor/amuletsandrings/goldringdiamondgo.nif,cff346e90e6f6b4e
+58 Jewelry Rings/meshes/armor/amuletsandrings/goldringdiamond_1.nif,2ca60faa4bc36288
+58 Jewelry Rings/meshes/armor/amuletsandrings/goldringemeraldgo.nif,e691d66a62bd5a13
+58 Jewelry Rings/meshes/armor/amuletsandrings/goldringemerald_1.nif,8c721ca7a1f71433
+58 Jewelry Rings/meshes/armor/amuletsandrings/goldringgo.nif,8f176e050421e089
+58 Jewelry Rings/meshes/armor/amuletsandrings/goldringsapphirego.nif,4826bbc74ef00800
+58 Jewelry Rings/meshes/armor/amuletsandrings/goldringsapphire_1.nif,28ba7b6a563d66d7
+58 Jewelry Rings/meshes/armor/amuletsandrings/goldring_1.nif,6f0463642e8b020e
+58 Jewelry Rings/meshes/armor/amuletsandrings/silverringamethystgo.nif,c7b2c0ffb7a39225
+58 Jewelry Rings/meshes/armor/amuletsandrings/silverringamethyst_1.nif,9917b5ed30275575
+58 Jewelry Rings/meshes/armor/amuletsandrings/silverringgarnetgo.nif,6520008466e9592b
+58 Jewelry Rings/meshes/armor/amuletsandrings/silverringgarnet_1.nif,67188253873b7420
+58 Jewelry Rings/meshes/armor/amuletsandrings/silverringgo.nif,80de76243493db4e
+58 Jewelry Rings/meshes/armor/amuletsandrings/silverringrubygo.nif,c4067321557bf2af
+58 Jewelry Rings/meshes/armor/amuletsandrings/silverringruby_1.nif,7c98ffab0b26414f
+58 Jewelry Rings/meshes/armor/amuletsandrings/silverring_1.nif,c1efd83c141fa953
+58 Jewelry Rings/textures/smim/armor/amuletsandrings/smim_my_precious.dds,b2685d0966576f86
+58 Jewelry Rings/textures/smim/armor/amuletsandrings/smim_my_precious_n.dds,f67d6574bcb8d25e
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingAmethystGo.nif,dcdf95e46f85496f
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingAmethyst_1.nif,cef6d35df264af16
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingDiamondGo.nif,9a397544a8af891a
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingDiamond_1.nif,b70a811f0b7a18f7
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingEmeraldGo.nif,18b0d1f74a910688
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingEmerald_1.nif,0d3045200c6e410f
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingGarnetGo.nif,a57debc4c2eb7140
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingGarnet_1.nif,e9945a5358c9d13c
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingGo.nif,27f407410aeaf67f
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingOnyxGo.nif,1ae23bbc28cafc35
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingOnyx_1.nif,562b8601e89a27e7
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingRubyGo.nif,685337b1634d9e30
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingRuby_1.nif,7a43504f8618987f
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingSapphireGo.nif,1977f7f39acd8ede
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingSapphire_1.nif,472d0f8e81a0a029
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingTopazGo.nif,b75b9460e816c64d
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingTopaz_1.nif,483341b3f033553e
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRing_1.nif,d549e886509e6828
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingAmethystGo.nif,3d44714eff2bc9d8
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingAmethyst_1.nif,d35d2c99c7837c6f
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingGarnetGo.nif,0162b13cce9d26ed
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingGarnet_1.nif,e3224e4d3cdc76af
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingOnyxGo.nif,a93e7d08e72360e4
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingOnyx_1.nif,5f4a1ad7243f90c8
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingRubyGo.nif,e5fdaedbb41b165c
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingRuby_1.nif,300e943ac075336d
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingTopazGo.nif,faebf4e7c93a8b50
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingTopaz_1.nif,186915e321caaf37
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingAmethystGo.nif,f9ddef4952db3e50
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingAmethyst_1.nif,81d978ae2db56ebe
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingDiamondGo.nif,19f220371e1782db
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingDiamond_1.nif,7491984dc0694fe4
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingEmeraldGo.nif,730c85495c6f2adf
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingEmerald_1.nif,1a3add64e4b071aa
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingGarnetGo.nif,b94fda1c7ac1486b
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingGarnet_1.nif,276a256a97ba6f51
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingGo.nif,e881187c8724c9f9
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingOnyxGo.nif,2a5a08dd8efaff7d
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingOnyx_1.nif,31dd077fac10baac
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingRubyGo.nif,14acc6c201f604e5
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingRuby_1.nif,405d8114d5b3878c
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingSapphireGo.nif,22fb7d283cd22a76
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingSapphire_1.nif,b37989311aa9c744
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingTopazGo.nif,fc245f90e61d4211
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingTopaz_1.nif,b37989311aa9c744
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRing_1.nif,ad9e097f1a4b447a
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingDiamondGo.nif,84039bef08f0b40a
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingDiamond_1.nif,c0a2726bf7562f37
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingEmeraldGo.nif,a07b886840560ba4
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingEmerald_1.nif,be938be6449af8bc
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingOnyxGo.nif,3f004530cc0ab893
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingOnyx_1.nif,8a16cc846f67c54f
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingSapphireGo.nif,b1dbbeb4aacdc6e0
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingSapphire_1.nif,2a6303788a48441a
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingTopazGo.nif,b8fd9f89cb73c9cd
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingTopaz_1.nif,ea14d8da80f98e53
+60 Hearthfires Stuff/meshes/_byoh/architecture/byohhouse/interface/byohinterfacearcherytarget01.nif,0138af29fcb1ab82
+60 Hearthfires Stuff/meshes/_byoh/architecture/byohhouse/interface/byohinterfacebasement01.nif,3b87c25c2a0d880c
+60 Hearthfires Stuff/meshes/_byoh/architecture/byohhouse/interface/byohinterfacenobletablelong01.nif,c5fd6caae8af16bd
+60 Hearthfires Stuff/meshes/_byoh/clutter/house crafting/lock01.nif,5788344cb13e1bba
+60 Hearthfires Stuff/meshes/_byoh/loadsscreens/loadscreenadoptionboy01.nif,577d56fe2724e929
+60 Hearthfires Stuff/meshes/_byoh/loadsscreens/loadscreenadoptiongirl01.nif,3cbd17936477e29d
+60 Hearthfires Stuff/textures/smim/actors/character/malechild/upperbodymale.dds,4dd4df3aecb37656
+60 Hearthfires Stuff/textures/smim/actors/character/malechild/upperbodymale_n.dds,160b182cdfbf0673
+60 Hearthfires Stuff/textures/smim/actors/character/malechild/upperbodymale_sk.dds,f22976d0cb36ec38
+61 Bowl Ingredients/meshes/clutter/ingredients/bonemeal01.nif,887c47f486e63f00
+61 Bowl Ingredients/meshes/clutter/ingredients/ectoplasm.nif,51e98feebd63434c
+61 Bowl Ingredients/meshes/clutter/ingredients/glowdust01.nif,8732105a681592dd
+61 Bowl Ingredients/meshes/clutter/ingredients/mammothcheesebowl.nif,0db53b8e842ba8ba
+61 Bowl Ingredients/meshes/clutter/ingredients/moonsugar01.nif,2e9c7b62fc0aa249
+61 Bowl Ingredients/meshes/clutter/ingredients/powderedmammothtusk.nif,e2c4b86875796836
+61 Bowl Ingredients/meshes/clutter/ingredients/saltpile.nif,526753d782047d9a
+61 Bowl Ingredients/meshes/clutter/ingredients/sap.nif,054fa60662516bc5
+61 Bowl Ingredients/meshes/clutter/ingredients/stew.nif,30acc4ddd790889e
+61 Bowl Ingredients/meshes/clutter/ingredients/trollfat01.nif,04662e79a5486e9d
+61 Bowl Ingredients/meshes/clutter/ingredients/vampiredust.nif,216ecf053f4ced6b
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_bonemeal.dds,82d29725f9f8a14c
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_bonemeal_n.dds,88c5aa2700b296e3
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_ectoplasm.dds,3d0bf5ef7e1fc4d6
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_ectoplasm_g.dds,5799ae06b888a4f5
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_ectoplasm_n.dds,b7109fe07f29a813
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_ingredient_bowl.dds,7cc6788629112805
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_ingredient_bowl_n.dds,673fb73261834871
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_ingredient_bowl_spriggansap.dds,f2dbb9fd45349bc2
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_ingredient_bowl_vampire.dds,9f6ea4907d5b5905
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_moonsugar_bowl.dds,ce5a2de3b60a9a79
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_moonsugar_bowl_n.dds,744a8b27c388f598
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_saltglow.dds,a0965f37d32dc671
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_saltpile.dds,dd22069ec69b4d2a
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_saltpile_n.dds,59343460c67f3b3d
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_stew_bowl.dds,5fdf09ce597c3077
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_stew_bowl_n.dds,7dfc4b5248574b96
+70 Rabbit/meshes/actors/ambient/hare/character assets/rabbit.nif,7a71a03650fe3fdd
+70 Rabbit/meshes/clutter/deadanimals/hangingrabbit01.nif,65e65545568b9acb
+70 Rabbit/meshes/clutter/deadanimals/hangingrabbit02.nif,cfe41024e3a698f7
+70 Rabbit/textures/smim/actors/hare/smim_rabbit.dds,238de76c5218e6b5
+70 Rabbit/textures/smim/actors/hare/smim_rabbit_blood.dds,2140648e0af54248
+70 Rabbit/textures/smim/actors/hare/smim_rabbit_n.dds,837ad775ec451136
+71 Candelabras Sconces Walltorches/meshes/clutter/common/torchpermanent01.nif,6a4607b06106af67
+71 Candelabras Sconces Walltorches/meshes/clutter/common/torchpermanentoff.nif,f82a6235d6136777
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impbrazier01.nif,a6c947bbd7339836
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impcandelabracandle01.nif,a87421662e4c29df
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impcandelabracandle02.nif,848ad65bf0b3ff06
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impcandelabracandleoff01.nif,e5fe4a9ff8501b17
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impcandelabranocandle.nif,c46abc27d930339b
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impcandle01.nif,c91c2ae731076069
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/imperialwallshackle01.nif,d7273dbc2bb31d77
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impwallsconce02candleoff01.nif,e8dc2a2b7768d660
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impwallsconce02candleon01.nif,51182370ab4300c4
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impwallsconce02nocandle01.nif,47762237bf064be4
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impwallsconcecandle01.nif,87b64f8f02064d3b
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impwallsconcecandle02.nif,69eeb5fc9361202b
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impwallsconcecandleoff01.nif,d9ab7a3ea0742bb1
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impwallsconcenocandle01.nif,1bd0f9035fbc81f2
+71 Candelabras Sconces Walltorches/meshes/traps/pressureplatemetal/trappressureplatemetal01.nif,303b53ff6a7c63b9
+71 Candelabras Sconces Walltorches/textures/effects/candleflame01.dds,312afe2c4c66e0a0
+71 Candelabras Sconces Walltorches/textures/smim/candles/candles01.dds,36d9d5ead48714cc
+71 Candelabras Sconces Walltorches/textures/smim/candles/candles01_g.dds,cfad1913638feeb6
+71 Candelabras Sconces Walltorches/textures/smim/candles/candles01_n.dds,ea8228da6595e530
+71 Candelabras Sconces Walltorches/textures/smim/clutter/common/smim_imperial_torch.dds,3b43fbb039b26ad3
+71 Candelabras Sconces Walltorches/textures/smim/clutter/common/smim_imperial_torch_n.dds,2ccfad18a41cd3e4
+71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_candelabra.dds,aec7ef3e25ea0e25
+71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_candelabra_gray.dds,5e5e6ea629f4933b
+71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_candelabra_n.dds,c8559cb0a970eefd
+71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_imperial_brazier.dds,b8e3a5b90d9ff09b
+71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_imperial_brazier_n.dds,dc27bb16e9f8e6e8
+71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_imperial_sconce.dds,ca12b1c69710fc01
+71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_imperial_sconce_n.dds,994d4d4c0b8740b8
+71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_trap_pressure_plate.dds,d9fd9cf76c8bd3e9
+71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_trap_pressure_plate_n.dds,65a3f2eb9c859ed9
+72 Chandeliers/meshes/clutter/imperial/impchandelliercandle01.nif,5ec8bc5895d4fc37
+72 Chandeliers/meshes/clutter/imperial/impchandelliercandle02.nif,abf9b19341e9e2b5
+72 Chandeliers/meshes/clutter/imperial/impchandelliercandle03.nif,48d7cb5bfd174b38
+72 Chandeliers/meshes/clutter/imperial/impchandelliercandleoff.nif,824d0b8b39f4b75e
+72 Chandeliers/meshes/clutter/imperial/impchandellierextension.nif,5c1ba1733d106b7e
+72 Chandeliers/meshes/clutter/imperial/impchandelliernocandle01.nif,c65e9b9fe7b09d36
+72 Chandeliers/meshes/uskp/clutter/chandellier/impchandelliercandle01uskp.nif,3a3594674d18bc13
+72 Chandeliers/meshes/uskp/clutter/chandellier/impchandellierextensionmeduskp.nif,ef887a92051db6cd
+72 Chandeliers/meshes/uskp/clutter/chandellier/impchandellierextensionshortuskp.nif,3a0ddf4f9a1ad49d
+72 Chandeliers/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceimpchandelier01.nif,08c52178bec08c8b
+72 Chandeliers/textures/effects/candleflame01.dds,312afe2c4c66e0a0
+72 Chandeliers/textures/smim/candles/candles01.dds,36d9d5ead48714cc
+72 Chandeliers/textures/smim/candles/candles01_g.dds,cfad1913638feeb6
+72 Chandeliers/textures/smim/candles/candles01_n.dds,ea8228da6595e530
+72 Chandeliers/textures/smim/clutter/imperial/smim_candelabra.dds,aec7ef3e25ea0e25
+72 Chandeliers/textures/smim/clutter/imperial/smim_candelabra_gray.dds,5e5e6ea629f4933b
+72 Chandeliers/textures/smim/clutter/imperial/smim_candelabra_n.dds,c8559cb0a970eefd
+72 Chandeliers/textures/smim/clutter/imperial/smim_imperial_chains.dds,bcfda412a954cea5
+72 Chandeliers/textures/smim/clutter/imperial/smim_imperial_chains_gray.dds,99518b7b543c4c32
+72 Chandeliers/textures/smim/clutter/imperial/smim_imperial_chains_n.dds,0db39c8bc609da89
+72 Chandeliers/textures/smim/clutter/imperial/smim_imperial_sconce_gray.dds,8f2bf03e40947112
+72 Chandeliers/textures/smim/clutter/imperial/smim_imperial_sconce_n.dds,994d4d4c0b8740b8
+73 Chandeliers No 3D Chains Addon/meshes/clutter/imperial/impchandelliercandle01.nif,f951792791b78314
+73 Chandeliers No 3D Chains Addon/meshes/clutter/imperial/impchandelliercandle02.nif,7eeea262a8327a16
+73 Chandeliers No 3D Chains Addon/meshes/clutter/imperial/impchandelliercandle03.nif,0671f01ab46a07bc
+73 Chandeliers No 3D Chains Addon/meshes/clutter/imperial/impchandelliercandleoff.nif,382637d7f54a80fa
+73 Chandeliers No 3D Chains Addon/meshes/clutter/imperial/impchandellierextension.nif,b3576986b3ff0674
+73 Chandeliers No 3D Chains Addon/meshes/clutter/imperial/impchandelliernocandle01.nif,724d6956e6e6acaf
+73 Chandeliers No 3D Chains Addon/meshes/uskp/clutter/chandellier/impchandelliercandle01uskp.nif,59b5d7940cd81f2b
+73 Chandeliers No 3D Chains Addon/meshes/uskp/clutter/chandellier/impchandellierextensionmeduskp.nif,38f973790c19698c
+73 Chandeliers No 3D Chains Addon/meshes/uskp/clutter/chandellier/impchandellierextensionshortuskp.nif,29f02306c8caaf2a
+73 Chandeliers No 3D Chains Addon/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceimpchandelier01.nif,846dbef1d4ceb03a
+75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffs01-SMIMICE.nif,f1329adc5cb1bcac
+75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffs02-SMIMICE.nif,e8cbbb2e6962a7a7
+75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffs03-SMIMICE.nif,adf0a6bf08687a5b
+75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffs03ns-SMIMICE.nif,896af8cf827fc454
+75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffscornerin01-SMIMICE.nif,0ade5a051b800b0f
+75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffscornerin01ns-SMIMICE.nif,ee5901a02bce8dd5
+75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffscornerout01-SMIMICE.nif,5d858c7b95cd2dce
+75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffscornerout01ns-SMIMICE.nif,e486c7f61c964774
+75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffsisland01-SMIMICE.nif,e75c8fa5516853c9
+75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffsisland01ns-SMIMICE.nif,2918a3f53bbecdf7
+75 Dungeons Cliffs Snow Skirts/textures/smim/dungeons/caves/green/smim_caveg_dirtcliffsroots_snow.dds,7af48cb079d4fea9
+75 Dungeons Cliffs Snow Skirts/SMIM-DungeonsCliffsIceSkirts.esp,ec1baaf462c2c80d
+75 Dungeons Cliffs Snow Skirts/SMIM-SE-DungeonsCliffsIceSkirts.esp,186aaf0a2bf39fb3
+80 Half-Sized Textures/textures/actors/skeleton/skeleton.dds,2d4298367ea29491
+80 Half-Sized Textures/textures/actors/skeleton/skeleton_n.dds,2e5c434a5d0f93dc
+80 Half-Sized Textures/textures/clutter/common/dresser01.dds,f0d54e0f86812faf
+80 Half-Sized Textures/textures/clutter/common/dresser01_n.dds,d7faa797cc70197e
+80 Half-Sized Textures/textures/clutter/deadanimals/rabbitmeatcooked.dds,9d34603a4651fde5
+80 Half-Sized Textures/textures/clutter/ruins/ruinschest01snow.dds,91cdbd64cd40972f
+80 Half-Sized Textures/textures/clutter/ruins/smim_ruins_sarcophagus_parts.dds,98fbcad49910b4ab
+80 Half-Sized Textures/textures/clutter/ruins/smim_ruins_sarcophagus_parts_n.dds,af49d9bb5afeaffc
+80 Half-Sized Textures/textures/clutter/ruins/smim_ruins_sarcophagus_tub.dds,915a7b00571f6a52
+80 Half-Sized Textures/textures/clutter/ruins/smim_ruins_sarcophagus_tub_n.dds,2f04152abb354528
+80 Half-Sized Textures/textures/clutter/stockade/stockadewood01.dds,fb6563027064fe68
+80 Half-Sized Textures/textures/clutter/stockade/stockadewood01snow.dds,8b587b6c8c2ae3b6
+80 Half-Sized Textures/textures/clutter/stockade/stockadewood01_n.dds,f83580c34898bed5
+80 Half-Sized Textures/textures/clutter/furniturewood01.dds,613640807230cfbf
+80 Half-Sized Textures/textures/clutter/furniturewood01_n.dds,edb1cdec54d8e740
+80 Half-Sized Textures/textures/dungeons/imperial/impwood01.dds,3032b4970c9c5504
+80 Half-Sized Textures/textures/dungeons/imperial/impwood01_n.dds,ceb7ed796a23deea
+80 Half-Sized Textures/textures/dungeons/mines/minewood01.dds,3032b4970c9c5504
+80 Half-Sized Textures/textures/dungeons/mines/minewood01_n.dds,ceb7ed796a23deea
+80 Half-Sized Textures/textures/effects/fxbird01.dds,75bfe6d43bc56c8e
+80 Half-Sized Textures/textures/effects/fxbird01_n.dds,761d1edde3c0f410
+80 Half-Sized Textures/textures/smim/architecture/docks/smim_docks_ropes.dds,a6e72b86092358c8
+80 Half-Sized Textures/textures/smim/architecture/docks/smim_docks_ropes_n.dds,7347422001a0c652
+80 Half-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_fan.dds,f94061a2cdac03fe
+80 Half-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_fan_n.dds,a781ee19fe3ee8fc
+80 Half-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_sail.dds,432f267b8b8c58f6
+80 Half-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_sail_n.dds,6e91b6aa5ed4323c
+80 Half-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_sail_solitude.dds,5d7fba278f841994
+80 Half-Sized Textures/textures/smim/architecture/riften/smim_RiftenDoor01.dds,46fa7da51b53ba2f
+80 Half-Sized Textures/textures/smim/architecture/riften/smim_RiftenDoor01_n.dds,0672a2c6c97af875
+80 Half-Sized Textures/textures/smim/architecture/shackkit/smim_shack_roof.dds,71f6708fee6cb4bd
+80 Half-Sized Textures/textures/smim/architecture/shackkit/smim_shack_roof_n.dds,81e30757aa7e7d9f
+80 Half-Sized Textures/textures/smim/architecture/solitude/smim_solitude_door_pattern.dds,a2e6ea4f7f785089
+80 Half-Sized Textures/textures/smim/architecture/solitude/smim_solitude_door_pattern_n.dds,48f1fd3c573a0645
+80 Half-Sized Textures/textures/smim/architecture/whiterun/smim_wr_bench.dds,70c567bdfbb1c261
+80 Half-Sized Textures/textures/smim/architecture/whiterun/smim_wr_bench_n.dds,3dd0dc1a9051888a
+80 Half-Sized Textures/textures/smim/armor/amuletsandrings/smim_my_precious.dds,3c12050a0d03cea4
+80 Half-Sized Textures/textures/smim/armor/amuletsandrings/smim_my_precious_n.dds,27c4ed90bb3a08c3
+80 Half-Sized Textures/textures/smim/clutter/common/dresser01.dds,7e15d594debc12aa
+80 Half-Sized Textures/textures/smim/clutter/common/dresser01_n.dds,4b19ad8165185a58
+80 Half-Sized Textures/textures/smim/clutter/common/smim_imperial_torch.dds,9cf6c276f5647fd5
+80 Half-Sized Textures/textures/smim/clutter/common/smim_imperial_torch_n.dds,dd03972cf86f860f
+80 Half-Sized Textures/textures/smim/clutter/common/smim_lantern.dds,b01d47ca5ecaf0b1
+80 Half-Sized Textures/textures/smim/clutter/common/smim_lantern_n.dds,14cfaeb63533ed3a
+80 Half-Sized Textures/textures/smim/clutter/common/smim_quill.dds,c1ef0b939c29c3f4
+80 Half-Sized Textures/textures/smim/clutter/common/smim_quill_n.dds,e22f7a89a8c19de3
+80 Half-Sized Textures/textures/smim/clutter/common/Stump_Bottom_for_Furniture.dds,ff48eb31ab4e14bf
+80 Half-Sized Textures/textures/smim/clutter/common/Stump_Bottom_for_Furniture_n.dds,e723258fdfedbe77
+80 Half-Sized Textures/textures/smim/clutter/common/Table_Leg_Bark.dds,17e1004979f33140
+80 Half-Sized Textures/textures/smim/clutter/common/Table_Leg_Bark_n.dds,f36391ad49850122
+80 Half-Sized Textures/textures/smim/clutter/common/Table_Leg_Bark_Seamless.dds,bb46513138670a16
+80 Half-Sized Textures/textures/smim/clutter/common/Table_Leg_Bark_Seamless_n.dds,fb4978f9804f364c
+80 Half-Sized Textures/textures/smim/clutter/common/Table_Leg_Bark_Thin.dds,8ed2131440eff2c2
+80 Half-Sized Textures/textures/smim/clutter/common/Table_Leg_Bark_Thin_n.dds,8f8a40c3649c16a3
+80 Half-Sized Textures/textures/smim/clutter/common/Table_Wood_SinglePiece.dds,c1312afe19adc2b2
+80 Half-Sized Textures/textures/smim/clutter/common/Table_Wood_SinglePiece_n.dds,df39549e883dcd1c
+80 Half-Sized Textures/textures/smim/clutter/deadanimals/smim_metalhanger_deadanimals.dds,c9cc4c8073aead21
+80 Half-Sized Textures/textures/smim/clutter/deadanimals/smim_metalhanger_deadanimals_n.dds,204d32ccc7defe13
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_centurion_core.dds,41e6b1a38d4d6c6c
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_centurion_core_g.dds,c240b06baa294ca5
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_centurion_core_m.dds,b85bec2747c4740a
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_centurion_core_n.dds,02d241bf9bc55e76
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_clutter_bowl.dds,fb0de7bde74639ce
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_clutter_bowl_n.dds,9c410c574749df9c
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_clutter_cup.dds,0113e26859fce2eb
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_clutter_cup_n.dds,17b3ff039d436eda
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_gyro.dds,d0cc627e5df50600
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_gyro_m.dds,026ee0fde5017fb3
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_gyro_n.dds,4810b0192c984263
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_scrap3.dds,a65bebf49bc1bd50
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_scrap3_m.dds,83ad606dccdeed75
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_scrap3_n.dds,7d661ac63dec50f3
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_scrap4.dds,43edf1d0813ae706
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_scrap4_m.dds,71f3e2cca79d20a0
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_scrap4_n.dds,570c1ead305df5c3
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_cog01.dds,4150938599ac1d82
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_cog01_m.dds,310c4cea18c12fd2
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_cog01_n.dds,c773775c6fe453b5
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_gear.dds,a963de60ea9a50c6
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_gear_m.dds,2ae5a676a85451db
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_gear_n.dds,2950557864ee2cc9
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_scrap1_sides.dds,72289ef379aacf4e
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_scrap1_sides_m.dds,013c751501422aff
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_scrap1_sides_n.dds,6ac8b5bc91fc3c89
+80 Half-Sized Textures/textures/smim/clutter/food/apple01_semi-circle-UV.dds,9679ed3dcdcba653
+80 Half-Sized Textures/textures/smim/clutter/food/apple01_semi-circle-UV_n.dds,95e4793caef776b4
+80 Half-Sized Textures/textures/smim/clutter/food/apple02_semi-circle-UV.dds,32b3a327af902605
+80 Half-Sized Textures/textures/smim/clutter/food/apple02_semi-circle-UV_n.dds,95e4793caef776b4
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_candelabra.dds,fc891dcfc0d39412
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_candelabra_gray.dds,7c4dd4ad2b4f6e02
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_candelabra_n.dds,d0bd96fa1499fc53
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_brazier.dds,8c91fc8500dbe2b0
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_brazier_n.dds,397e05094844e17c
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_chains.dds,89abb6fef00e82ed
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_chains_gray.dds,8da2fbfd5c269e45
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_chains_n.dds,7c99beea52d48a89
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_sconce.dds,e1a3dca9abe750ba
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_sconce_gray.dds,1b0d2baac18015d1
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_sconce_n.dds,7b6ee5129bad27aa
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_trap_pressure_plate.dds,93781d18719ff71f
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_trap_pressure_plate_n.dds,225b6506cd9c43a4
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_bonemeal.dds,47bbeb65f5efe470
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_bonemeal_n.dds,5add524fdb297b11
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_dwarven_oil.dds,be8b528dc9abd995
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_dwarven_oilspill.dds,fc39a42d7d01d3a0
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_dwarven_oilspill_n.dds,e981012ec23d737f
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_dwarven_oil_m.dds,7567f85c559dbf6f
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_dwarven_oil_n.dds,b5bbfbe933cdd406
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_ectoplasm.dds,ef33bc7a357adc3e
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_ectoplasm_g.dds,5b7ea8751d130f28
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_ectoplasm_n.dds,715d313e5278ac6e
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_hagclaw.dds,a2c3eab2e0076d89
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_hagclaw_n.dds,2bed1fb5becd07d4
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_ingredient_bowl.dds,7cc6788629112805
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_ingredient_bowl_n.dds,673fb73261834871
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_ingredient_bowl_spriggansap.dds,9fdf16ba2a4b6652
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_ingredient_bowl_vampire.dds,c5ea870ec78498fa
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_moonsugar_bowl.dds,e6e5b7e8d444b227
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_moonsugar_bowl_n.dds,7675548ab49afec1
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_sabrecat_tooth.dds,47dbf59ac2eb524d
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_sabrecat_tooth_n.dds,53f1c51941dab01a
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_saltglow.dds,3d2fe16981dfa894
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_saltpile.dds,23462fe15a32be8c
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_saltpile_n.dds,39fcd447aa7285d9
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_stew_bowl.dds,efeed27c50aef712
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_stew_bowl_n.dds,f6d6ded49f226427
+80 Half-Sized Textures/textures/smim/clutter/quest/smim_giant_mortar.dds,cccd562668d40d81
+80 Half-Sized Textures/textures/smim/clutter/quest/smim_giant_mortar_n.dds,b7d5865622124711
+80 Half-Sized Textures/textures/smim/clutter/ruins/ruinschest.dds,e04a2a46d187a3b5
+80 Half-Sized Textures/textures/smim/clutter/ruins/ruinschestsmall.dds,9e9646b60a8c86e9
+80 Half-Sized Textures/textures/smim/clutter/ruins/ruinschestsmall_n.dds,97143e18715505f0
+80 Half-Sized Textures/textures/smim/clutter/ruins/ruinschest_n.dds,a5c7d6c0864be40c
+80 Half-Sized Textures/textures/smim/clutter/ruins/smim_ruinspot01.dds,9b2548b668fbdc47
+80 Half-Sized Textures/textures/smim/clutter/ruins/smim_ruinspot01_n.dds,7574dab7088267f5
+80 Half-Sized Textures/textures/smim/clutter/ruins/smim_ruins_sarcophagus_parts.dds,98fbcad49910b4ab
+80 Half-Sized Textures/textures/smim/clutter/ruins/smim_ruins_sarcophagus_parts_n.dds,af49d9bb5afeaffc
+80 Half-Sized Textures/textures/smim/clutter/ruins/smim_ruins_sarcophagus_tub.dds,915a7b00571f6a52
+80 Half-Sized Textures/textures/smim/clutter/ruins/smim_ruins_sarcophagus_tub_n.dds,2f04152abb354528
+80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest.dds,dba253ea87e1200e
+80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest_n.dds,624843675387c246
+80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest_weathered.dds,3b1c21e1daa20894
+80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest_weathered_snow.dds,133000b536dba1a3
+80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upper_bedpost.dds,cb23656dd27f1579
+80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upper_bedpost_n.dds,ab28f90f0c0dbb87
+80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upper_bench_legs.dds,f3b8eab46c804ab2
+80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upper_bench_legs_n.dds,b6c80474d121a3ad
+80 Half-Sized Textures/textures/smim/clutter/upperclass/Table_Leg_Bark_Thin.dds,50fface2ffcd02e4
+80 Half-Sized Textures/textures/smim/clutter/upperclass/Table_Leg_Bark_Thin_n.dds,996e53e715bcfda7
+80 Half-Sized Textures/textures/smim/clutter/upperclass/Table_Wood_SinglePiece.dds,b01e75e25406d9c6
+80 Half-Sized Textures/textures/smim/clutter/upperclass/Table_Wood_SinglePiece_n.dds,df39549e883dcd1c
+80 Half-Sized Textures/textures/smim/clutter/woodfires/smim_campfire_rocks.dds,9e1986a09f5da0a5
+80 Half-Sized Textures/textures/smim/clutter/woodfires/smim_campfire_rocks_n.dds,d1d5746772ac9e39
+80 Half-Sized Textures/textures/smim/clutter/barrel02.dds,8c64761ab7251690
+80 Half-Sized Textures/textures/smim/clutter/barrel02_n.dds,8f03b07019d4c42b
+80 Half-Sized Textures/textures/smim/clutter/barrel_smim_metal.dds,09b880e5ecca83de
+80 Half-Sized Textures/textures/smim/clutter/barrel_smim_metal_n.dds,062a8f59d93467ca
+80 Half-Sized Textures/textures/smim/clutter/barrel_smim_wood.dds,607b701947964dee
+80 Half-Sized Textures/textures/smim/clutter/barrel_smim_wood_n.dds,6242bb64669261f8
+80 Half-Sized Textures/textures/smim/clutter/furniturewood01.dds,aad234f4147870e1
+80 Half-Sized Textures/textures/smim/clutter/furniturewood01_n.dds,dbdc0bf8162d9953
+80 Half-Sized Textures/textures/smim/critters/fchawk/smim_hawk.dds,0e26e3a3cc56c508
+80 Half-Sized Textures/textures/smim/critters/fchawk/smim_hawk_b.dds,a428b727825aa0b2
+80 Half-Sized Textures/textures/smim/critters/fchawk/smim_hawk_n.dds,2ac59a3df921503b
+80 Half-Sized Textures/textures/smim/dlc02/clutter/ingredients/smim_tern_ingredient.dds,cc86ff7b906c1b07
+80 Half-Sized Textures/textures/smim/dlc02/critters/smim_tern.dds,bf9a1086aa02326a
+80 Half-Sized Textures/textures/smim/dungeons/dwemer/smim_dwemer_focus_rock.dds,19c770b640344638
+80 Half-Sized Textures/textures/smim/dungeons/dwemer/smim_dwemer_focus_rock_n.dds,8674d37b2a0ce976
+80 Half-Sized Textures/textures/smim/dungeons/mines/smim_wood_mine_beams_x4_seamless.dds,cb342f5895e8cd3d
+80 Half-Sized Textures/textures/smim/dungeons/mines/smim_wood_mine_beams_x4_seamless_n.dds,d3d4256206fbc473
+80 Half-Sized Textures/textures/smim/dungeons/mines/smim_wood_mine_planks.dds,7f7c0752772e4f0f
+80 Half-Sized Textures/textures/smim/dungeons/mines/smim_wood_mine_planks_n.dds,1e4c9eb2ed336d65
+80 Half-Sized Textures/textures/smim/dungeons/mines/smim_wood_mine_smalltile.dds,e15de2e1eed43ef4
+80 Half-Sized Textures/textures/smim/dungeons/mines/smim_wood_mine_smalltile_n.dds,0e9b44db013145a3
+80 Half-Sized Textures/textures/smim/dungeons/nordic/temple/smim_nordic_bonedirt.dds,66c405f452c0cea8
+80 Half-Sized Textures/textures/smim/dungeons/nordic/temple/smim_nordic_bonedirt_n.dds,7fed9e4f6539ba7a
+80 Half-Sized Textures/textures/smim/dungeons/nordic/temple/smim_nordic_skeleton.dds,302654ce501c93c4
+80 Half-Sized Textures/textures/smim/furniture/noble/smim_poor_coffin.dds,7a0a8b87d05d71ab
+80 Half-Sized Textures/textures/smim/furniture/noble/smim_poor_coffin_n.dds,86d13ac1e63a0fa7
+80 Half-Sized Textures/textures/smim/furniture/nordic/ruinstable_smim_vanillamix.dds,1e5f8e718305e6f8
+80 Half-Sized Textures/textures/smim/furniture/nordic/ruinstable_smim_vanillamix_n.dds,0a1e497d6a265efa
+80 Half-Sized Textures/textures/smim/furniture/prisonercarriage/smim_carriage_metal.dds,ee88aedcb774b9da
+80 Half-Sized Textures/textures/smim/furniture/prisonercarriage/smim_carriage_metal_n.dds,c58bfcc52b1b35e4
+80 Half-Sized Textures/textures/smim/furniture/prisonercarriage/smim_carriage_seat.dds,e466b0f72a230b61
+80 Half-Sized Textures/textures/smim/furniture/prisonercarriage/smim_carriage_seat_n.dds,0f0bce043e223ec0
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_dome.dds,9f3fe782ebe940e6
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_dome_n.dds,274ceaaf4d5b00a6
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_door.dds,648f819c6ea53acb
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_door_n.dds,d4c6858296b2c6fd
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_metal.dds,8370f3c0789d9132
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_metal_n.dds,61ad8adb827a95e5
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_spout.dds,d58f066e91ab71e9
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_spout_n.dds,17612db1888ddb5b
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stonework.dds,a592362f2d0ed117
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stonework_n.dds,c0e1828c684bbfa0
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stucco.dds,35b095e23d57d0a6
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stucco_n.dds,b1c6dd30c2ea5323
+80 Half-Sized Textures/textures/smim/furniture/smim_wooden_chair.dds,2b298c5c6e663078
+80 Half-Sized Textures/textures/smim/furniture/smim_wooden_chair_n.dds,1514776aba565281
+80 Half-Sized Textures/textures/smim/landscape/bridges/bridge_pillar_top.dds,d8f0d330190bebf7
+80 Half-Sized Textures/textures/smim/landscape/bridges/bridge_pillar_top_n.dds,8fd67d13f90bd768
+80 Half-Sized Textures/textures/smim/landscape/bridges/bridge_road_stone_tile.dds,dcfacde8b51f9551
+80 Half-Sized Textures/textures/smim/landscape/bridges/bridge_road_stone_tile_n.dds,8496f4af42b11410
+80 Half-Sized Textures/textures/smim/landscape/bridges/smim_bridge_dirt.dds,58eaf4c8e7a77c66
+80 Half-Sized Textures/textures/smim/landscape/bridges/smim_bridge_dirt_n.dds,2460ce3121c73933
+80 Half-Sized Textures/textures/smim/landscape/trees/smim_tundra_tree.dds,fbb18a4e0c90fdfa
+80 Half-Sized Textures/textures/smim/landscape/trees/smim_tundra_tree_n.dds,445202abcd4ac489
+80 Half-Sized Textures/textures/smim/loadscreenart/smim_trollloadscreen_meat.dds,5ffad8fb30e509f7
+80 Half-Sized Textures/textures/smim/loadscreenart/smim_trollloadscreen_meat_n.dds,c7651f136675bc01
+80 Half-Sized Textures/textures/smim/plants/potato01_properUVmap.dds,e393e2d39e44e60b
+80 Half-Sized Textures/textures/smim/plants/potato01_properUVmap_n.dds,9dbb1f5e4a72b840
+80 Half-Sized Textures/textures/smim/plants/smim_juniper_tree.dds,9e124af5716fe27e
+80 Half-Sized Textures/textures/smim/plants/smim_juniper_tree_n.dds,c715b45a3a5f5b45
+80 Half-Sized Textures/textures/smim/traps/smim_trap_deadbolt.dds,4f9fc43def65148c
+80 Half-Sized Textures/textures/smim/traps/smim_trap_deadbolt_n.dds,3170b3e58d0fae25
+81 Half-Sized Furniture Skyrim HD Appearance/textures/clutter/common/dresser01.dds,9fdecfe8aa94d687
+81 Half-Sized Furniture Skyrim HD Appearance/textures/clutter/common/dresser01_n.dds,aa0c4ad3dee5c171
+81 Half-Sized Furniture Skyrim HD Appearance/textures/clutter/furniturewood01.dds,4c653e3c708efa8d
+81 Half-Sized Furniture Skyrim HD Appearance/textures/clutter/furniturewood01_n.dds,5b44194c2e6386fa
+81 Half-Sized Furniture Skyrim HD Appearance/textures/smim/clutter/common/dresser01.dds,4370c241934045ec
+81 Half-Sized Furniture Skyrim HD Appearance/textures/smim/clutter/common/dresser01_n.dds,e8abb307d4a1bd3b
+81 Half-Sized Furniture Skyrim HD Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece.dds,a7f4417ffdf8270d
+81 Half-Sized Furniture Skyrim HD Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece_n.dds,5c1f529a2639b68a
+81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/clutter/common/dresser01.dds,4904e15c65643314
+81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/clutter/common/dresser01_n.dds,c791950501c8249e
+81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/clutter/furniturewood01.dds,dbb0160368e467d4
+81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/clutter/furniturewood01_n.dds,19824d6044c7c673
+81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/dresser01.dds,2a88c06ad81b53ad
+81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/dresser01_n.dds,e2500a3b1ec47d3d
+81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece.dds,ab6b20e93aeca20c
+81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece_n.dds,ce40022af9e1a044
+84 Half-Sized Textures Tankard Bright Brushed Metal/textures/smim/clutter/diningset/smim_tankard.dds,50dde6cb9e45f31d
+84 Half-Sized Textures Tankard Bright Brushed Metal/textures/smim/clutter/diningset/smim_tankard_em.dds,3b89de1d4c18a4cc
+84 Half-Sized Textures Tankard Bright Brushed Metal/textures/smim/clutter/diningset/smim_tankard_n.dds,24e39d0700fa9d9d
+84 Half-Sized Textures Tankard Bright Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody.dds,1021fdb95267fee4
+84 Half-Sized Textures Tankard Bright Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_em.dds,384301ed314ca93d
+84 Half-Sized Textures Tankard Bright Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_n.dds,2c276fdeb261964d
+84 Half-Sized Textures Tankard Dark Brushed Metal/textures/smim/clutter/diningset/smim_tankard.dds,d035f280a1f7afe2
+84 Half-Sized Textures Tankard Dark Brushed Metal/textures/smim/clutter/diningset/smim_tankard_em.dds,1429e76db5f1c905
+84 Half-Sized Textures Tankard Dark Brushed Metal/textures/smim/clutter/diningset/smim_tankard_n.dds,1756a29429f33439
+84 Half-Sized Textures Tankard Dark Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody.dds,f5cac14ea674d7e3
+84 Half-Sized Textures Tankard Dark Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_em.dds,057ab7b3beafe8c1
+84 Half-Sized Textures Tankard Dark Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_n.dds,262fe896a35688bf
+84 Half-Sized Textures Tankard Pewter Metal/textures/smim/clutter/diningset/smim_tankard.dds,c7f8f4199f9effa1
+84 Half-Sized Textures Tankard Pewter Metal/textures/smim/clutter/diningset/smim_tankard_em.dds,d6d5495a1d3a4908
+84 Half-Sized Textures Tankard Pewter Metal/textures/smim/clutter/diningset/smim_tankard_n.dds,b1c2cb2db81c7686
+84 Half-Sized Textures Tankard Pewter Metal/textures/smim/dlc01/clutter/smim_tankard_bloody.dds,56a48f1682d90fca
+84 Half-Sized Textures Tankard Pewter Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_em.dds,381a32af383154e2
+84 Half-Sized Textures Tankard Pewter Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_n.dds,00f5a120a9b0b3fa
+90 Ultra-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_fan.dds,9caa4f8200011a4e
+90 Ultra-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_fan_n.dds,5103c44ee98ea744
+90 Ultra-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_sail.dds,b19d96a3ae118e50
+90 Ultra-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_sail_n.dds,3b8a7f246039c68f
+90 Ultra-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_sail_solitude.dds,49c70759477c97b4
+90 Ultra-Sized Textures/textures/smim/architecture/shackkit/smim_shack_roof.dds,4b90946c4fa1831c
+90 Ultra-Sized Textures/textures/smim/architecture/shackkit/smim_shack_roof_n.dds,21d21f306fc88b23
+90 Ultra-Sized Textures/textures/smim/architecture/whiterun/smim_wr_bench.dds,796eb6565c7b2612
+90 Ultra-Sized Textures/textures/smim/architecture/whiterun/smim_wr_bench_n.dds,b3dbfc1f7e01f4db
+90 Ultra-Sized Textures/textures/smim/clutter/common/smim_lantern.dds,bef46910fbffd60b
+90 Ultra-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest.dds,5b4602448c274fee
+90 Ultra-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest_n.dds,ac601766fc50945b
+90 Ultra-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest_weathered.dds,928edebc8479fbcd
+90 Ultra-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest_weathered_snow.dds,486f2c7d5c10ca1e
+90 Ultra-Sized Textures/textures/smim/clutter/woodfires/smim_campfire_rocks.dds,591d8fc74e5ee038
+90 Ultra-Sized Textures/textures/smim/clutter/woodfires/smim_campfire_rocks_n.dds,b2b8bda39b4795ab
+90 Ultra-Sized Textures/textures/smim/critters/fchawk/smim_hawk.dds,1e4f59105916da48
+90 Ultra-Sized Textures/textures/smim/critters/fchawk/smim_hawk_b.dds,2d7a85877428419f
+90 Ultra-Sized Textures/textures/smim/critters/fchawk/smim_hawk_n.dds,fef0843f90c17c90
+90 Ultra-Sized Textures/textures/smim/furniture/prisonercarriage/smim_carriage_metal.dds,d9f12237faf4d7b6
+90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_door.dds,1545b5b7a1af1546
+90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_door_n.dds,3ffc41b3d92ffd8f
+90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_metal.dds,4621c3df34e5cafd
+90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_metal_n.dds,fe98d6aabbf1656d
+90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_spout.dds,b7f47e22180752b4
+90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_spout_n.dds,271d22c2c55436e2
+90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stonework.dds,b49ec7e157174296
+90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stonework_n.dds,e60ffdc355b44e51
+90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stucco.dds,99e6deba49283e84
+90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stucco_n.dds,1042c0b252ddd969
+90 Ultra-Sized Textures/textures/smim/furniture/smim_wooden_chair.dds,ac7b9246b7a1a8f5
+90 Ultra-Sized Textures/textures/smim/furniture/smim_wooden_chair_n.dds,0d20834c3b33773f
+90 Ultra-Sized Textures/textures/smim/loadscreenart/smim_trollloadscreen_meat.dds,ace0f7ef6153a2a4
+90 Ultra-Sized Textures/textures/smim/loadscreenart/smim_trollloadscreen_meat_n.dds,b5a4e0fc725e31e0
+90 Ultra-Sized Textures/textures/smim/plants/smim_juniper_tree.dds,abab4c342a75365f
+90 Ultra-Sized Textures/textures/smim/plants/smim_juniper_tree_n.dds,4319ae5359e9c1b7
+95 Merged ESP SE All/SMIM-SE-Merged-All.esp,3991aeaffa7987e2
+95 Merged ESP SE No Riften Ropes/SMIM-SE-Merged-NoRiftenRopes.esp,00925a8c4dd0e451
+95 Merged ESP SE No Riften Ropes No Solitude Ropes/SMIM-SE-Merged-NoRiftenRopes-NoSolitudeRopes.esp,8b19d68d40f43c91
+95 Merged ESP SE No Solitude Ropes/SMIM-SE-Merged-NoSolitudeRopes.esp,ce39c71017244812
+FOMod/info.xml,35b62c81083ea6ce
+FOMod/ModuleConfig.xml,300275e81142a952

--- a/NexusMods.Archives.Nx.Tests/Assets/SMIM SE 2-08-659-2-08-Hashes.txt
+++ b/NexusMods.Archives.Nx.Tests/Assets/SMIM SE 2-08-659-2-08-Hashes.txt
@@ -1,0 +1,2223 @@
+--- Screenshots ---/3D Chains Misc.jpg,823FAA976FFFA5A7
+--- Screenshots ---/3D Chains Pull Levers.jpg,531C1D59BDBB5BC
+--- Screenshots ---/3D Chains Signs.jpg,1B8BAEE8FE4793D2
+--- Screenshots ---/3D Chains Whiterun.jpg,BE5A218AEE811065
+--- Screenshots ---/3DDungeonRopes.jpg,C87C16E91E7928D1
+--- Screenshots ---/barrels.jpg,D4374F386D555C2B
+--- Screenshots ---/Barrels_NewTextures.jpg,DA5CF5A08BB97BEE
+--- Screenshots ---/Barrels_NewTexturesAnimate.jpg,3016E45DC86F94F9
+--- Screenshots ---/Barrels_Rustic.jpg,9A0F9D7497693511
+--- Screenshots ---/Barrels_VanillaTextures.jpg,7264B7AFF1B8F20B
+--- Screenshots ---/Barrels_VanillaTexturesAnimate.jpg,BD68CFFB065EE737
+--- Screenshots ---/Blurry.jpg,626D3A4D61716945
+--- Screenshots ---/Bonemeal.jpg,F299A646E185D524
+--- Screenshots ---/BridgeSMIMComp.jpg,66E0F1621105883A
+--- Screenshots ---/BridgesRealRoads.jpg,111846E6CAE49ED2
+--- Screenshots ---/Bridges_Stonework_Comp.jpg,36AFCE964AAB2CBF
+--- Screenshots ---/Candelabras.jpg,8B8668A7444770E3
+--- Screenshots ---/CarriageSeat.jpg,954193044FD8A81D
+--- Screenshots ---/Chandeliers.jpg,223A449F0318F0C7
+--- Screenshots ---/Clothing _Fix.jpg,C27A1759505A2DF7
+--- Screenshots ---/Custom.jpg,A7EA6C53E1DE0A16
+--- Screenshots ---/CustomOS.jpg,7901FA5DEDF318CC
+--- Screenshots ---/CustomSE.jpg,51CABA4F4056E89C
+--- Screenshots ---/DraugrCorpses-Comp.jpg,A635C81F598CCE19
+--- Screenshots ---/Dwemer Clutter Comp.jpg,D3E91981B8A917D7
+--- Screenshots ---/DwemerAnimatedLifts.jpg,251C3088243A19FF
+--- Screenshots ---/Empty.jpg,C6BE01A0A6B86518
+--- Screenshots ---/Everything.jpg,7AA6E3BA7ED50F16
+--- Screenshots ---/EverythingNoDragonborn.jpg,6B7CF3B1B6ADAC83
+--- Screenshots ---/EverythingSE.jpg,D3CA67F825E473E2
+--- Screenshots ---/EverythingWithDragonborn.jpg,5155795A895AFAA6
+--- Screenshots ---/farmhouse.jpg,EBC6C9DB787A1973
+--- Screenshots ---/FarmhouseWoodPost_Comp.jpg,8381705CCB259556
+--- Screenshots ---/FarmhouseWovenFenceComp.jpg,54E19CD051680A03
+--- Screenshots ---/FarmhouseWovenFenceGray.jpg,D06C59A36559CC49
+--- Screenshots ---/FarmhouseWovenFenceLessFlicker.jpg,68B424A9B4639DD2
+--- Screenshots ---/Farmhouse_3D_Ropes.jpg,CF1B48B89E85DF3E
+--- Screenshots ---/food.jpg,7531B0682FBE8323
+--- Screenshots ---/Food_SMIM.jpg,A79A093DC9D44B5F
+--- Screenshots ---/Furniture_Chest_SMIM.jpg,5C576A34346B2FAD
+--- Screenshots ---/Furniture_SMIM.jpg,E46B147AC95E080C
+--- Screenshots ---/Hanging_Rings.jpg,727B072963DB4F24
+--- Screenshots ---/Hawk.jpg,63827444AD072A6A
+--- Screenshots ---/Hearthfire-Lock.jpg,B644B8E53DAF3AC9
+--- Screenshots ---/Imperial_Jail.jpg,1FC5402428C3FE39
+--- Screenshots ---/Imperial_Jail_Brighter.jpg,8F2B541C04B2B7F3
+--- Screenshots ---/JuniperComp.jpg,CE59A31BB20771DE
+--- Screenshots ---/Lantern-Comp.jpg,FDA0635626B18ECF
+--- Screenshots ---/LiteNoDragonborn.jpg,A396B455A3EC56D1
+--- Screenshots ---/LiteSE.jpg,7B0635358F71F8B4
+--- Screenshots ---/LiteWithDragonborn.jpg,CEEF3B087AF7CF8E
+--- Screenshots ---/MergedPlugin.jpg,9DCC9007175E0AE1
+--- Screenshots ---/MinesRopesAndScaffolding.jpg,F96DA23B75D18EFD
+--- Screenshots ---/NobleChairComp.jpg,F9C79C7263ADC1CF
+--- Screenshots ---/Nordic_Marble_Comp.jpg,2ADD9A45A16795F4
+--- Screenshots ---/OrcBeams.jpg,B74CBC114EC1A13
+--- Screenshots ---/PoorCoffin.jpg,860039E4AC93F36F
+--- Screenshots ---/PullLever_Full.jpg,2BC93913AA1045AC
+--- Screenshots ---/PullLever_Full_Smaller_Chain.jpg,D29C109CEFC4B274
+--- Screenshots ---/PullLever_Lite.jpg,1BCE8AFC618042D3
+--- Screenshots ---/RabbitComp.jpg,15BBFE69862EE082
+--- Screenshots ---/Raven_Rock_Ropes.jpg,91C23454B4DA80AE
+--- Screenshots ---/RiftenRopes.jpg,13B2034932FFFBBF
+--- Screenshots ---/RiftenRopesTextureComp.jpg,627EF15AF2AB7007
+--- Screenshots ---/Rings.jpg,ED7E27E4AEC455D6
+--- Screenshots ---/Rocks_Blackreach_Comp.jpg,DB4E94E262C4F445
+--- Screenshots ---/Rocks_Render_Comp.jpg,146810D78C65894C
+--- Screenshots ---/Sarcophagus.jpg,F6262D5DBF77F880
+--- Screenshots ---/ShackRoof.jpg,451E4E69A7B765DE
+--- Screenshots ---/Signs_SMIM.jpg,234E2F0088B88477
+--- Screenshots ---/Skeleton-Comp.jpg,959861D4C6D42166
+--- Screenshots ---/SkullFixComp.jpg,CDEAE9A314F5C807
+--- Screenshots ---/Smelter-Full.jpg,6C52D3B212F96938
+--- Screenshots ---/SMIM_CoverImage_Bnet-XBoxLite.jpg,4E8D954123286829
+--- Screenshots ---/SnowSkirtFix.jpg,82AB313CE50C361D
+--- Screenshots ---/SolitudeDocksRopes.jpg,1D1FC99CC59CEDE4
+--- Screenshots ---/SolitudeGate.jpg,E1BFEA712176B8CC
+--- Screenshots ---/Soulcairn_Comparison.jpg,8D17B4A96C110530
+--- Screenshots ---/StockadePosts-Comp.jpg,42CD3D20C4AF5359
+--- Screenshots ---/Table_SkyrimHD.jpg,9662948B53AE2285
+--- Screenshots ---/Table_SkyrimHD_Weathered.jpg,58FD0810C42797E4
+--- Screenshots ---/Table_SMIM_Default.jpg,13C7AE67A7168AFA
+--- Screenshots ---/Tankard_Comp-4Way.jpg,F2CD3DDF3471A82
+--- Screenshots ---/Tomato_Comparison.jpg,77B8D364E6EB3452
+--- Screenshots ---/TundraTree.jpg,285C4AD97A9F8942
+--- Screenshots ---/Whiterun_Wood_Carvings_Options.jpg,F35AD445E7377DD1
+--- Screenshots ---/Windmills.jpg,95B0D9379ED41882
+--- Screenshots ---/Windmill_Sails.jpg,BCE93A7590980369
+--- Screenshots ---/WRDrawbridge_SMIM.jpg,F29FB6516D82689C
+--- Screenshots ---/WR_Door_Comp.jpg,7A045C5AD1F2D78A
+00 Core/SMIM Readme.txt,8F34C1376BE4B69A
+00 Core/SMIM-FarmhouseFlickeringFix.esp,FFAF8DC7555D3FF3
+00 Core/SMIM-SE-FarmhouseFlickeringFix.esp,17B246D2153A68D4
+22 Solitude Docks Ropes SE/SMIM-SE-SolitudeDocksFixes.esp,4E8951763BCBB278
+28 Hawk Dragonborn Fix/SMIM-DragonbornTernFix.esp,5E5F5511A30A0B0C
+28 Hawk Dragonborn Fix/SMIM-SE-DragonbornTernFix.esp,51776BE736BB79BB
+35 Shack Kit/SMIM-SE-ShackRoofFixes.esp,84B9F970AB6F9A0
+35 Shack Kit/SMIM-ShackRoofFixes.esp,7FFA8B4B92EA1140
+36 Shack Kit Dragonborn/SMIM-SE-ShackRoofFixesDragonborn.esp,553D6132E9969F66
+36 Shack Kit Dragonborn/SMIM-ShackRoofFixesDragonborn.esp,814A12DD2D03B85E
+37 Riften 3D Ropes/SMIM-RiftenDocksRopesObjectFix.esp,9142C5043D3614FD
+37 Riften 3D Ropes/SMIM-SE-RiftenDocksRopesObjectFix.esp,68328AAC96350268
+40 Furniture Chests/SMIM-FurnitureChestSnowFix.esp,1596B36722855DF8
+40 Furniture Chests/SMIM-SE-FurnitureChestSnowFix.esp,171C2A9F0DF9C73E
+75 Dungeons Cliffs Snow Skirts/SMIM-DungeonsCliffsIceSkirts.esp,EC1BAAF462C2C80D
+75 Dungeons Cliffs Snow Skirts/SMIM-SE-DungeonsCliffsIceSkirts.esp,186AAF0A2BF39FB3
+95 Merged ESP SE All/SMIM-SE-Merged-All.esp,3991AEAFFA7987E2
+95 Merged ESP SE No Riften Ropes/SMIM-SE-Merged-NoRiftenRopes.esp,925A8C4DD0E451
+95 Merged ESP SE No Riften Ropes No Solitude Ropes/SMIM-SE-Merged-NoRiftenRopes-NoSolitudeRopes.esp,8B19D68D40F43C91
+95 Merged ESP SE No Solitude Ropes/SMIM-SE-Merged-NoSolitudeRopes.esp,CE39C71017244812
+FOMod/info.xml,35B62C81083EA6CE
+FOMod/ModuleConfig.xml,300275E81142A952
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_czech.DLSTRINGS,34C96ACDCADB1BBB
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_czech.ILSTRINGS,34C96ACDCADB1BBB
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_czech.STRINGS,2DC916B78DFD7EA4
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_English.DLSTRINGS,34C96ACDCADB1BBB
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_English.ILSTRINGS,34C96ACDCADB1BBB
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_English.STRINGS,1BDF42EC14490D28
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_french.DLSTRINGS,34C96ACDCADB1BBB
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_french.ILSTRINGS,34C96ACDCADB1BBB
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_french.STRINGS,1BDF42EC14490D28
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_german.DLSTRINGS,34C96ACDCADB1BBB
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_german.ILSTRINGS,34C96ACDCADB1BBB
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_german.STRINGS,583841AA43B62B88
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_italian.DLSTRINGS,34C96ACDCADB1BBB
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_italian.ILSTRINGS,34C96ACDCADB1BBB
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_italian.STRINGS,EC34F3C418EEB264
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_japanese.DLSTRINGS,34C96ACDCADB1BBB
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_japanese.ILSTRINGS,34C96ACDCADB1BBB
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_japanese.STRINGS,732774C1CD7E8112
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_polish.DLSTRINGS,34C96ACDCADB1BBB
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_polish.ILSTRINGS,34C96ACDCADB1BBB
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_polish.STRINGS,98132B34E81F6B80
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_russian.DLSTRINGS,34C96ACDCADB1BBB
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_russian.ILSTRINGS,34C96ACDCADB1BBB
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_russian.STRINGS,B38785282671EB92
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_spanish.DLSTRINGS,34C96ACDCADB1BBB
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_spanish.ILSTRINGS,34C96ACDCADB1BBB
+28 Hawk Dragonborn Fix/Strings/SMIM-DragonbornTernFix_spanish.STRINGS,20D9BB920FF1F8EB
+00 Core/meshes/animobjects/animobjectquill.nif,BE4440B2E235F5E5
+00 Core/meshes/clutter/brewerycasklargeclosed01.nif,FA891AD876AC93DA
+00 Core/meshes/clutter/brewerycasklargeclosed02.nif,E35809A16719F80
+00 Core/meshes/clutter/brewerycasklargeopen01.nif,DA93A6E8A3575120
+00 Core/meshes/clutter/cookingstone01.nif,8B4A66F0CAD81AD1
+00 Core/meshes/clutter/wallbasket02.nif,AB36ED26512A7747
+00 Core/meshes/clutter/wallbaskethex02.nif,DCA488156B9D3DC0
+00 Core/meshes/clutter/wallbaskethex03.nif,D5EBFD6B738FA619
+00 Core/meshes/clutter/wallbasketlarge01.nif,CEC8FA81C85C43BB
+00 Core/meshes/clutter/wallbasketlarge02.nif,1A001FE35AECAEB1
+00 Core/meshes/effects/fxcreekflatlong01.nif,2A8754ADD3C65796
+00 Core/meshes/furniture/blacksmithforgemarker.nif,D7905383221F7ABE
+00 Core/meshes/furniture/blacksmithforgemarkerwr.nif,4799F21A2E729A48
+00 Core/meshes/furniture/smeltermarker.nif,FB056A0A0541DA0F
+00 Core/meshes/loadscreenart/loadscreenadventure01.nif,84D478BBE1459BF8
+00 Core/meshes/loadscreenart/loadscreendragonpriest.nif,5120DAE821E1A056
+00 Core/meshes/loadscreenart/loadscreenhagraven01.nif,80B82F720CD87855
+00 Core/meshes/loadscreenart/loadscreenhagraven02.nif,9BADD8140536F3D2
+00 Core/meshes/loadscreenart/loadscreenmoney01.nif,4FF967B8A18BE713
+00 Core/meshes/loadscreenart/loadscreenpotions01.nif,94E5C6EF0D391AE6
+00 Core/meshes/loadscreenart/loadscreenreagent01.nif,5A12076D82DB8A72
+00 Core/meshes/loadscreenart/loadscreenshopsmagic01.nif,FAF4A2A1C6E4E13E
+00 Core/meshes/loadscreenart/loadscreenwrtempletree02.nif,1C796723B2D5AE5
+00 Core/meshes/plants/coinbaglarge.nif,35D91F8D507CE64F
+00 Core/meshes/plants/coinbagmed.nif,8802E164D563C503
+00 Core/meshes/plants/coinbagsmall.nif,E3598BF524424E8E
+00 Core/textures/dungeons/candles01.dds,AD5E42F32C9805AD
+00 Core/textures/dungeons/candles01_g.dds,4F7B7AA1F717EED4
+00 Core/textures/dungeons/candles01_n.dds,7F772E51A499DEE4
+01 Furniture/meshes/clutter/table01.nif,EF3A3F1B6757480A
+01 Furniture/meshes/furniture/commontableonebench.nif,589986D5B798AEB0
+01 Furniture/meshes/furniture/commontabletwobenches.nif,87774F6F4B8F994F
+01 Furniture/meshes/furniture/woodenchair01.nif,59FC51023FDEAF30
+01 Furniture/meshes/furniture/woodenchair01static.nif,FF960C7E8233F62D
+01 Furniture/textures/clutter/furniturewood01.dds,149BC3EE8F72ACE6
+01 Furniture/textures/clutter/furniturewood01_n.dds,94905A18D662740
+02 SMIM Barrel Textures Animations/meshes/clutter/barrel01.nif,E2A652958AADDC4
+02 SMIM Barrel Textures Animations/meshes/clutter/barrel02.nif,FEF06BEFFEDE5461
+02 SMIM Barrel Textures Animations/meshes/clutter/tgbarrel01.nif,690A842B09A38662
+02 SMIM Barrel Textures Animations Original Movement/meshes/clutter/barrel01.nif,8A658062CB5D0C1B
+02 SMIM Barrel Textures Animations Original Movement/meshes/clutter/barrel02.nif,FEF06BEFFEDE5461
+02 SMIM Barrel Textures Animations Original Movement/meshes/clutter/tgbarrel01.nif,51F1B76C277E5980
+02 SMIM Barrel Textures No Animations/meshes/clutter/barrel01.nif,44BDE7F95DFB31A8
+02 SMIM Barrel Textures No Animations/meshes/clutter/barrel02.nif,FEF06BEFFEDE5461
+02 SMIM Barrel Textures No Animations/meshes/clutter/tgbarrel01.nif,D1EBAA1A84DC7B21
+02 SMIM Rustic Barrel Textures Animations/meshes/clutter/barrel01.nif,E2A652958AADDC4
+02 SMIM Rustic Barrel Textures Animations/meshes/clutter/barrel02.nif,FEF06BEFFEDE5461
+02 SMIM Rustic Barrel Textures Animations/meshes/clutter/tgbarrel01.nif,690A842B09A38662
+02 SMIM Rustic Barrel Textures No Animations/meshes/clutter/barrel01.nif,44BDE7F95DFB31A8
+02 SMIM Rustic Barrel Textures No Animations/meshes/clutter/barrel02.nif,FEF06BEFFEDE5461
+02 SMIM Rustic Barrel Textures No Animations/meshes/clutter/tgbarrel01.nif,D1EBAA1A84DC7B21
+02 Vanilla Barrel Textures Animations/meshes/clutter/barrel01.nif,7388B387DA86B40E
+02 Vanilla Barrel Textures Animations/meshes/clutter/barrel02.nif,42ECAEC346B4E936
+02 Vanilla Barrel Textures Animations/meshes/clutter/tgbarrel01.nif,E6EA8C23176389DF
+02 Vanilla Barrel Textures No Animations/meshes/clutter/barrel01.nif,B29EA75F8EBC0212
+02 Vanilla Barrel Textures No Animations/meshes/clutter/barrel02.nif,42ECAEC346B4E936
+02 Vanilla Barrel Textures No Animations/meshes/clutter/tgbarrel01.nif,FA857FC2224A42A7
+03 Food/meshes/animobjects/animobjectbread.nif,64DCF9D31AC12C5
+03 Food/meshes/loadscreenart/loadscreenmarket01.nif,76A8893ECFCB5B82
+03 Food/meshes/plants/cabbage01.nif,36AED65AB194724A
+03 Food/meshes/plants/potato01.nif,5CCE73F93B2A01CB
+05 Chains 3D - Misc/meshes/loadscreenart/loadscreenmetalcage.nif,CF9E10F621B48EEA
+06 Chains 3D - Signs/meshes/loadscreenart/loadscreenblackbriar01.nif,DA6FDCF9E957748
+13 Lanterns/meshes/loadscreenart/loadscreenadventure01.nif,89DCE0F544656BB8
+13 Lanterns/meshes/loadscreenart/loadscreenshopsmagic01.nif,EBF6280041E899A7
+13 Lanterns/textures/effects/candleflame01.dds,312AFE2C4C66E0A0
+16 Tankard Bright Brushed Metal/meshes/animobjects/animobjectdrinkingtankard.nif,D0143111EB72189B
+16 Tankard Bright Brushed Metal/meshes/loadscreenart/loadscreenargonianbarkeep.nif,2E09BEF0E6DC129D
+16 Tankard Dark Brushed Metal/meshes/animobjects/animobjectdrinkingtankard.nif,D0143111EB72189B
+16 Tankard Dark Brushed Metal/meshes/loadscreenart/loadscreenargonianbarkeep.nif,2E09BEF0E6DC129D
+16 Tankard Pewter Metal/meshes/animobjects/animobjectdrinkingtankard.nif,A72C4B470A9467F7
+16 Tankard Pewter Metal/meshes/loadscreenart/loadscreenargonianbarkeep.nif,51C2781FA2682BE3
+17 Nordic Catacombs Skeletal Remains/textures/effects/candleflame01.dds,312AFE2C4C66E0A0
+19 Smelter/meshes/furniture/smeltermarker.nif,6647FF38E1B80318
+20 Furniture Skyrim HD Appearance/textures/clutter/furniturewood01.dds,9D4E12FBBAEB97BA
+20 Furniture Skyrim HD Appearance/textures/clutter/furniturewood01_n.dds,63088B73FA522C5E
+20 Furniture Skyrim HD Weathered Appearance/textures/clutter/furniturewood01.dds,87416DC77B621E85
+20 Furniture Skyrim HD Weathered Appearance/textures/clutter/furniturewood01_n.dds,DABD609DBA742A11
+26 Human Skull Fixes/meshes/loadscreenart/loadscreensinister01.nif,36E138D86F7F59CD
+26 Human Skull Fixes/meshes/loadscreenart/loadscreenskeleton.nif,BADF0A6352E5AF6
+26 Human Skull Fixes/meshes/loadscreenart/loadscreentrollclean.nif,73DC9F6E17AC5478
+27 Hawk/textures/effects/fxbird01.dds,A002A57DC431893A
+27 Hawk/textures/effects/fxbird01_n.dds,8248138F4BF5753D
+47 Juniper Tree/meshes/plants/florajuniper01.nif,F1BF343EC94401B9
+48 Juniper Tree Excessive Polycount Version/meshes/plants/florajuniper01.nif,CAEDD638AAB75B94
+71 Candelabras Sconces Walltorches/textures/effects/candleflame01.dds,312AFE2C4C66E0A0
+72 Chandeliers/textures/effects/candleflame01.dds,312AFE2C4C66E0A0
+80 Half-Sized Textures/textures/clutter/furniturewood01.dds,613640807230CFBF
+80 Half-Sized Textures/textures/clutter/furniturewood01_n.dds,EDB1CDEC54D8E740
+80 Half-Sized Textures/textures/effects/fxbird01.dds,75BFE6D43BC56C8E
+80 Half-Sized Textures/textures/effects/fxbird01_n.dds,761D1EDDE3C0F410
+81 Half-Sized Furniture Skyrim HD Appearance/textures/clutter/furniturewood01.dds,4C653E3C708EFA8D
+81 Half-Sized Furniture Skyrim HD Appearance/textures/clutter/furniturewood01_n.dds,5B44194C2E6386FA
+81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/clutter/furniturewood01.dds,DBB0160368E467D4
+81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/clutter/furniturewood01_n.dds,19824D6044C7C673
+00 Core/meshes/architecture/farmhouse/farmbannerpost01.nif,AA56A68884EEFF3D
+00 Core/meshes/architecture/farmhouse/farmhouse01.nif,7B21A396B3E8E5B1
+00 Core/meshes/architecture/farmhouse/farmhouse01walkway.nif,6D44CBEF75BBA9EF
+00 Core/meshes/architecture/farmhouse/farmhouse02.nif,7BD8516E44D2ED81
+00 Core/meshes/architecture/farmhouse/farmhouse02walkway.nif,351371B0B61CB847
+00 Core/meshes/architecture/farmhouse/farmhouse03.nif,BF6BCD1C50D3BDBD
+00 Core/meshes/architecture/farmhouse/farmhouse03walkway.nif,6C31F3CC2752337F
+00 Core/meshes/architecture/farmhouse/farmhouse04.nif,4B0EFAF3FD85FF49
+00 Core/meshes/architecture/farmhouse/farmhouse04walkway.nif,1DEE9DE7FB505C17
+00 Core/meshes/architecture/farmhouse/farmhouse05.nif,F8BD11651A084F4E
+00 Core/meshes/architecture/farmhouse/farmhouse05destroyed01.nif,92406ECDE5A485D4
+00 Core/meshes/architecture/farmhouse/farmhouse05destroyed02.nif,AAB82ABBE213EA34
+00 Core/meshes/architecture/farmhouse/farmhouse06.nif,EF052F5A04BFD31D
+00 Core/meshes/architecture/farmhouse/farmhouse06destroyed01.nif,32A48CBFE9CBF3A4
+00 Core/meshes/architecture/farmhouse/farmhouse06destroyed02.nif,6A991B17E23DAFD8
+00 Core/meshes/architecture/farmhouse/farmlonghouse01.nif,BA18ACA872189447
+00 Core/meshes/architecture/farmhouse/farmwell01.nif,A0886C1E7F290F6A
+00 Core/meshes/architecture/farmhouse/inn01.nif,F759AD05898435B9
+00 Core/meshes/architecture/farmhouse/inndestroyed01.nif,DCD6D877991331B8
+00 Core/meshes/architecture/farmhouse/inndestroyed02.nif,4D7407E9450AD203
+00 Core/meshes/architecture/farmhouse/lumbermill01.nif,E4BCB62767BCF115
+00 Core/meshes/architecture/farmhouse/lumbermill01waterwheel01.nif,C7A7A59E6879C612
+00 Core/meshes/architecture/farmhouse/lumbermill01waterwheel02.nif,3CD096743CBD1AAE
+00 Core/meshes/architecture/farmhouse/smith01.nif,BCA491A04AC0EA70
+00 Core/meshes/architecture/highhrothgar/mqetchedshrine.nif,AE8F91990F99F08
+00 Core/meshes/architecture/markarth/mrkmillroof01.nif,F8AC5745564EA8F6
+00 Core/meshes/architecture/markarth/mrksilverfishinnpart01.nif,538D3459473E8C9B
+00 Core/meshes/architecture/riften/riftenkeepdoor01.nif,1C657EE1AC629AEB
+00 Core/meshes/architecture/shackkit/shackwalll01.nif,7FF20B273F05F55
+00 Core/meshes/architecture/shackkit/shackwalll02.nif,E2A830E30F08D192
+00 Core/meshes/architecture/shackkit/shackwallr01.nif,F069AF1DAAD3F5B3
+00 Core/meshes/architecture/shackkit/shackwallr02.nif,D00022CFBE348C5
+00 Core/meshes/architecture/shackkit/shackwalltop01.nif,5A162A9F5E525308
+00 Core/meshes/architecture/shackkit/shackwalltopwindow01.nif,3E8CDA35C6524633
+00 Core/meshes/architecture/solitude/sblacksmith.nif,ABE0FAD8AA1D8BFB
+00 Core/meshes/architecture/solitude/sbridge01.nif,6375AEA41FC38514
+00 Core/meshes/architecture/solitude/seastempireco.nif,2A2492E8F659B641
+00 Core/meshes/architecture/solitude/spatiowallentrance.nif,87DBCAF56585866C
+00 Core/meshes/architecture/solitude/sthalmorembassy.nif,37CF2367E6D21F33
+00 Core/meshes/architecture/tents/largeimperialtent01.nif,B89BA1908CDBFA79
+00 Core/meshes/architecture/windhelm/whwallwulfharth.nif,411693C0CF9C4F0C
+00 Core/meshes/betterdynamicsnow/shader/snowshader.nif,20508F83CC27E1AD
+00 Core/meshes/clutter/blackreach/blackreachcrystall01.nif,DD9D87FD87973D84
+00 Core/meshes/clutter/blackreach/blackreachcrystall02.nif,C1D5894B9D0F20A0
+00 Core/meshes/clutter/blackreach/blackreachcrystall04.nif,771050B0D2801848
+00 Core/meshes/clutter/blackreach/blackreachcrystalm02.nif,BAC7119B8BCA568C
+00 Core/meshes/clutter/blackreach/blackreachcrystalm03.nif,9C100271938E08BF
+00 Core/meshes/clutter/blackreach/blackreachcrystalpiles02.nif,18DB8DC2010A3D75
+00 Core/meshes/clutter/blackreach/blackreachcrystalpiles04.nif,5BE85680D40E0F55
+00 Core/meshes/clutter/blackreach/blackreachcrystals02.nif,D089472C7672F9E2
+00 Core/meshes/clutter/blackreach/blackreachcrystals03.nif,205B7E75E4661073
+00 Core/meshes/clutter/blackreach/blackreachtinymushroom01.nif,2C0654953AB4B337
+00 Core/meshes/clutter/blackreach/blackreachtinymushroom02.nif,211C0C68438615D
+00 Core/meshes/clutter/caves/cave_lamp01.nif,AF80B172660B812A
+00 Core/meshes/clutter/caves/cave_lamp02.nif,91D8BE1182DF9316
+00 Core/meshes/clutter/common/archerytarget01.nif,4540292B1BF7619E
+00 Core/meshes/clutter/common/archerytargettripod01.nif,A981C5417529430C
+00 Core/meshes/clutter/common/cratesmall01.nif,90B6C67B9B9E2059
+00 Core/meshes/clutter/common/cratesmall01eeco.nif,63ED76D680822581
+00 Core/meshes/clutter/common/cratesmall02.nif,348B39C6EF590E74
+00 Core/meshes/clutter/common/cratesmalllong01.nif,8CF0F1E71A011662
+00 Core/meshes/clutter/common/cratesmalllong01eeco.nif,99EBAA1E6B7714C3
+00 Core/meshes/clutter/common/cratesmalllong02.nif,D73918841D900E63
+00 Core/meshes/clutter/common/lockpick.nif,113AD2E17E1EC6B
+00 Core/meshes/clutter/common/quill01.nif,FECF24BBFEE38C12
+00 Core/meshes/clutter/deadanimals/rabbitmeat01.nif,28EDF4519EEB20D5
+00 Core/meshes/clutter/deadanimals/rabbitmeatcooked01.nif,45388F050283A125
+00 Core/meshes/clutter/dwemer/dwarvenscraplarge1.nif,E702E43C6854896F
+00 Core/meshes/clutter/giant/giantobelisk01.nif,32DE27A1687CF67F
+00 Core/meshes/clutter/giant/giantobeliskblue01.nif,9BC7AF9041964291
+00 Core/meshes/clutter/giant/giantskewer01.nif,56C581F83850B260
+00 Core/meshes/clutter/giant/giantsmokestack01.nif,1C1B676ED37494A0
+00 Core/meshes/clutter/giant/giantspit01.nif,DF42B745B3D87DA7
+00 Core/meshes/clutter/ingredients/dwarvenoil.nif,1CF81C7BF31BFCB1
+00 Core/meshes/clutter/ingredients/hagclaw.nif,C46CA921BC3ACEDD
+00 Core/meshes/clutter/ingredients/hawkfeather01.nif,C4132BB8940C9216
+00 Core/meshes/clutter/ingredients/sabrecattooth.nif,8A59D53A76ED8DDE
+00 Core/meshes/clutter/quest/giantmortar.nif,684A5A867F267B3C
+00 Core/meshes/clutter/ruins/ruinsfurniturerubble01.nif,D2BE4E399E71CCEB
+00 Core/meshes/clutter/ruins/ruinsfurniturerubble02.nif,2181D6AE7F806F7B
+00 Core/meshes/clutter/ruins/ruinsfurniturerubble12.nif,DDF5C87592A8CB4
+00 Core/meshes/clutter/ruins/ruinsfurniturerubble13.nif,5A785CA2AE617A3D
+00 Core/meshes/clutter/ruins/ruinspot01.nif,9BDD5D6BF289152C
+00 Core/meshes/clutter/ruins/ruinspot02.nif,2DBDAFD6AA64EAAA
+00 Core/meshes/clutter/ruins/ruinspot03.nif,9E55B9618F0B356B
+00 Core/meshes/clutter/ruins/ruinspot03static.nif,3B289BE0648F36FC
+00 Core/meshes/clutter/ruins/ruinspot04.nif,E81F2530B3B22436
+00 Core/meshes/clutter/ruins/ruinspot05.nif,E5BD884FA271E7E3
+00 Core/meshes/clutter/ruins/ruinspot06.nif,FE641210E04E401
+00 Core/meshes/clutter/ruins/ruinssarcophagusverthole.nif,8FB6009BD3766B0B
+00 Core/meshes/clutter/ruins/ruinssarcophagus_bottom01.nif,3793DB7B803014EC
+00 Core/meshes/clutter/ruins/ruins_largechest.nif,CEBA219FC89AE146
+00 Core/meshes/clutter/ruins/ruins_smallchest.nif,EA527454BB3D847C
+00 Core/meshes/clutter/statues/statuenamira.nif,170FD4E37E072BF
+00 Core/meshes/clutter/woodfires/campfire01burning.nif,3EE7B0022A5618F5
+00 Core/meshes/clutter/woodfires/campfire01landburning.nif,3126A557CA24E2E1
+00 Core/meshes/clutter/woodfires/campfire01landoff.nif,6E8BCA68714D4AEE
+00 Core/meshes/clutter/woodfires/campfire01off.nif,2B521CDE741080D8
+00 Core/meshes/furniture/cart/cartfurnstatic01.nif,B2D9A4C59477CE1
+00 Core/meshes/furniture/clutter/leveranimating.nif,684DCB550E7325A5
+00 Core/meshes/furniture/clutter/milllogpile.nif,1ED80E030B458DC8
+00 Core/meshes/furniture/noble/noblechair01.nif,77D4A5F8B2373A1E
+00 Core/meshes/furniture/noble/noblechair02.nif,B835747FE8CF7F54
+00 Core/meshes/furniture/noble/scoffinpoor.nif,8C16C5E779FDD7B9
+00 Core/meshes/furniture/nordic/ruins_chair01.nif,1381D10B261A7516
+00 Core/meshes/furniture/nordic/ruins_chairshadow01.nif,AF1338F01847B22C
+00 Core/meshes/furniture/prisonercarriage/prisonercarriage01.nif,3F57273A98DB1D42
+00 Core/meshes/furniture/prisonercarriage/prisonercarriage01static.nif,2BD6D5CAD6E76C33
+00 Core/meshes/furniture/prisonercarriage/prisonercarriagefurniture01.nif,30A1D8EC0B61AD33
+00 Core/meshes/landscape/dirtcliffs/dirtcliffs01moss.nif,6FEB1FD8F6417A5
+00 Core/meshes/landscape/dirtcliffs/dirtcliffs02moss.nif,11C5A18DD6A2C685
+00 Core/meshes/landscape/dirtcliffs/dirtcliffs03moss.nif,978FCCAC123C5907
+00 Core/meshes/landscape/dirtcliffs/dirtcliffs04moss.nif,9E92D3EA36FB71AB
+00 Core/meshes/landscape/dirtcliffs/dirtcliffs05moss.nif,1DD65959CD8EE146
+00 Core/meshes/landscape/mountains/mountaincliff02.nif,2B69FCBFACB704DB
+00 Core/meshes/landscape/mountains/mountaincliffsm01.nif,D45DB4BF0812BEE5
+00 Core/meshes/landscape/rocks/rockanimalden01.nif,D611DC310C8054F2
+00 Core/meshes/landscape/rocks/rockl01.nif,B49CD689D23C760E
+00 Core/meshes/landscape/rocks/rockl02.nif,9EBBA7EE5F1D33B
+00 Core/meshes/landscape/rocks/rockl04.nif,BB6BE12A8286E63A
+00 Core/meshes/landscape/rocks/rockm03.nif,D0DC5EE84E5FF6E6
+00 Core/meshes/landscape/rocks/rockpilel01.nif,6F57A9AA99EB3B35
+00 Core/meshes/landscape/rocks/rockpilem02.nif,21C561ACBB0AB3EB
+00 Core/meshes/landscape/rocks/rockpilem02tundra.nif,A81E131659A264FF
+00 Core/meshes/landscape/rocks/rockpiles02.nif,6B9076C41CA4580A
+00 Core/meshes/landscape/rocks/rockpiles04.nif,CCA0AD26F756C462
+00 Core/meshes/landscape/trees/coastdriftwood01.nif,AAB9EADDB91118A8
+00 Core/meshes/landscape/trees/coastdriftwood02.nif,466591844B5FC11B
+00 Core/meshes/landscape/trees/coastdriftwood03.nif,BF653A7BEDC0C8AE
+00 Core/meshes/traps/doordeadbolt/doordeadbolt01.nif,452681404CADEA04
+00 Core/meshes/traps/doordeadboltdbl/doordeadboltdbl01.nif,617830255AD0836C
+00 Core/textures/architecture/farmhouse/woodpost02.dds,AFEF4D6A0B8C244E
+00 Core/textures/architecture/farmhouse/woodpost02_n.dds,49AC117D42EC48B1
+00 Core/textures/architecture/whiterun/wrslate02.dds,1B7EF5CC8368C80D
+00 Core/textures/architecture/whiterun/wrslate02_n.dds,D7E7ECCEDA0763D6
+00 Core/textures/architecture/whiterun/wrwoodbeam01.dds,A475E49576504E01
+00 Core/textures/architecture/whiterun/wrwoodbeam01_n.dds,D09BB42D776D8654
+00 Core/textures/clutter/caves/caves_lamp01.dds,D49DF9FC7EB49AF3
+00 Core/textures/clutter/caves/caves_lamp01_n.dds,AC5108644F6D5DFB
+00 Core/textures/clutter/deadanimals/rabbitmeatcooked.dds,F126EF3408C8D9C5
+00 Core/textures/clutter/ingredients/hagfeathers.dds,816AD08DEBB0EBEE
+00 Core/textures/clutter/ruins/ruinschest01snow.dds,FDDB0382EE50009D
+00 Core/textures/dungeons/azurasstar/azuracrystal01.dds,2F2000C320B2AA92
+00 Core/textures/dungeons/azurasstar/azuracrystal01_n.dds,F2C98E8703D8FBBD
+00 Core/textures/dungeons/caves/CaveRocks01_n.dds,A65C028F09EB7486
+00 Core/textures/dungeons/mines/mineroots01.dds,38D5124C46E90572
+00 Core/textures/smim/chains/metalwork01_brown.dds,EC6D1D0DEB249E38
+00 Core/textures/smim/chains/metalwork01_brown_n.dds,D7732E6E282E1D36
+00 Core/textures/smim/chains/metalwork01_gray.dds,CCDFBED05C08CF08
+00 Core/textures/smim/chains/metalwork01_gray_n.dds,553FCF5E0628A21A
+00 Core/textures/smim/clutter/barrel02.dds,AA89AFADF99FBA33
+00 Core/textures/smim/clutter/barrel02_n.dds,87E2B710D2B532F
+00 Core/textures/smim/clutter/barrel_smim_metal.dds,89E7C9F747C18B96
+00 Core/textures/smim/clutter/barrel_smim_metal_n.dds,96E6A701490A9E32
+00 Core/textures/smim/clutter/barrel_smim_wood.dds,45BA154BA4D89AC
+00 Core/textures/smim/clutter/barrel_smim_wood_n.dds,EE038180EA601238
+00 Core/textures/smim/clutter/smim_ingotdwemer.dds,DA161F73549CB8BF
+00 Core/textures/smim/clutter/smim_ingotdwemer_n.dds,3B4BEE947C4AF6F3
+00 Core/textures/smim/traps/smim_trap_deadbolt.dds,8BDEEB2B12A29710
+00 Core/textures/smim/traps/smim_trap_deadbolt_n.dds,6A41FAD94C006443
+01 Furniture/meshes/_byoh/furniture/byohupperendtable02.nif,7916B38B6DF30AD3
+01 Furniture/meshes/clutter/common/commonchair02.nif,E252797C3FEF89D0
+01 Furniture/meshes/clutter/common/commonchair02static.nif,8B674C828B203AE6
+01 Furniture/meshes/clutter/common/commoncrate01.nif,8399E59417B9C31B
+01 Furniture/meshes/clutter/common/commoncrate02.nif,BE046339A377DDCC
+01 Furniture/meshes/clutter/common/commonshelf01.nif,417E76E4C52FAB28
+01 Furniture/meshes/clutter/common/commonshelf03.nif,33D2523688139A42
+01 Furniture/meshes/clutter/common/commonshelf04.nif,B8D8AB715EEC4775
+01 Furniture/meshes/clutter/common/commonshelf04open.nif,489746F39A7D0578
+01 Furniture/meshes/clutter/common/commonshelf05.nif,33FE02CFA3558BF5
+01 Furniture/meshes/clutter/common/commontable01.nif,F2D656C1AA648A4F
+01 Furniture/meshes/clutter/common/commontable02.nif,F38B36B2DACEF945
+01 Furniture/meshes/clutter/common/commontablelow01.nif,25AE63205601CB16
+01 Furniture/meshes/clutter/common/commontablelow02.nif,A8D7BC9293AD4BD6
+01 Furniture/meshes/clutter/common/commontableround01.nif,798083A21F76C455
+01 Furniture/meshes/clutter/common/commontablesquare01.nif,AEF20499AF731EE8
+01 Furniture/meshes/clutter/common/commontablethin01.nif,F7102E6866762FB4
+01 Furniture/meshes/clutter/common/cupboard01.nif,992DD2747714A1F7
+01 Furniture/meshes/clutter/common/dresser01.nif,A342D5F6E6501CA2
+01 Furniture/meshes/clutter/common/endtable01.nif,3FEF591CDA3513B6
+01 Furniture/meshes/clutter/common/wardrobe01.nif,7D666FCD553D7128
+01 Furniture/meshes/clutter/upperclass/upperbeddouble01.nif,BE768B64C4085028
+01 Furniture/meshes/clutter/upperclass/upperbedsingle01.nif,C3C8751E4554422A
+01 Furniture/meshes/clutter/upperclass/upperbench01.nif,5E51FCA85B2986E7
+01 Furniture/meshes/clutter/upperclass/upperbench02.nif,43598F6D7AFD8F5B
+01 Furniture/meshes/clutter/upperclass/upperbench03.nif,EDA3475790C89127
+01 Furniture/meshes/clutter/upperclass/upperchair01.nif,33D19598C05088D9
+01 Furniture/meshes/clutter/upperclass/uppercupboard01.nif,971B17BDAB2B2A29
+01 Furniture/meshes/clutter/upperclass/upperdresser01.nif,96201A651A3AD79
+01 Furniture/meshes/clutter/upperclass/upperendtable01.nif,E14A5B09E5FA1179
+01 Furniture/meshes/clutter/upperclass/upperendtable02.nif,F2A5E2A8A5453273
+01 Furniture/meshes/clutter/upperclass/uppernightstand01.nif,99FD9B6600661FAA
+01 Furniture/meshes/clutter/upperclass/uppershelf01.nif,BB0BECE4B700F8D3
+01 Furniture/meshes/clutter/upperclass/uppershelf02.nif,67D01750F2EAE509
+01 Furniture/meshes/clutter/upperclass/uppertable01.nif,EF4972F65F1AFC0C
+01 Furniture/meshes/clutter/upperclass/uppertable01custom01.nif,A33FF5BA3A4F9D81
+01 Furniture/meshes/clutter/upperclass/uppertable01custom01cloth01.nif,5984C13A86196D13
+01 Furniture/meshes/clutter/upperclass/uppertablebench01.nif,C1BAFE6510CEBC57
+01 Furniture/meshes/clutter/upperclass/uppertablebench02.nif,A0FD9BA3C93C306F
+01 Furniture/meshes/clutter/upperclass/uppertableround01.nif,1DD70EDA50F679BE
+01 Furniture/meshes/clutter/upperclass/uppertablesquare01.nif,BC2D8ABD0658D4C6
+01 Furniture/meshes/clutter/upperclass/upperwardrobe01.nif,26440697DF4A2C4B
+01 Furniture/meshes/furniture/common/commonbench01.nif,4BDB12BDE5421A45
+01 Furniture/meshes/furniture/common/commonchair01.nif,625A7FD172C199E7
+01 Furniture/meshes/furniture/farm/farmbench01.nif,CCA62FB399C4C48B
+01 Furniture/meshes/furniture/farm/farmtable01.nif,EF3A3F1B6757480A
+01 Furniture/meshes/furniture/farm/farmtablebench01.nif,238056FF5F83C7BA
+01 Furniture/meshes/furniture/farm/farmtablebench02.nif,A1415DA1D80A30BF
+01 Furniture/textures/clutter/common/dresser01.dds,E1AC4C65A127F3F4
+01 Furniture/textures/clutter/common/dresser01_n.dds,5BEA1ADF32BCA51B
+01 Furniture/textures/smim/clutter/furniturewood01.dds,5FFAE78BD5600579
+01 Furniture/textures/smim/clutter/furniturewood01_n.dds,31DFD2D87198F2CF
+01 Furniture/textures/smim/furniture/smim_wooden_chair.dds,C5DE24915AE25EDA
+01 Furniture/textures/smim/furniture/smim_wooden_chair_n.dds,F655882EDE099D16
+02 SMIM Rustic Barrel Textures Animations/textures/smim/clutter/barrel_smim_wood.dds,E9F17B41386B7DA7
+02 SMIM Rustic Barrel Textures Animations/textures/smim/clutter/barrel_smim_wood_n.dds,94EF176EA22DB6BB
+02 SMIM Rustic Barrel Textures No Animations/textures/smim/clutter/barrel_smim_wood.dds,E9F17B41386B7DA7
+02 SMIM Rustic Barrel Textures No Animations/textures/smim/clutter/barrel_smim_wood_n.dds,94EF176EA22DB6BB
+03 Food/meshes/clutter/food/apple01.nif,8800A499BBDDDFE7
+03 Food/meshes/clutter/food/apple02.nif,85DBBA7D1EFF6B0F
+03 Food/meshes/clutter/food/bread01a.nif,ADEE99EAFCC0B5A1
+03 Food/meshes/clutter/food/bread01b.nif,AAB8EEBD63874C00
+03 Food/meshes/clutter/food/grilledpotatoes01.nif,5E379395F022BC27
+03 Food/meshes/clutter/ingredients/tomato.nif,8BA8BB9926BF49EB
+03 Food/textures/smim/plants/potato01_properUVmap.dds,E393E2D39E44E60B
+03 Food/textures/smim/plants/potato01_properUVmap_n.dds,9DBB1F5E4A72B840
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmbannerpost01.nif,C631ACCAF8924D44
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse01walkway.nif,45D07C38940A6DB9
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse02.nif,853C7CFAA33EE352
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse02walkway.nif,CE648483ADDABE55
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse03.nif,DE114EEA33593CA3
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse03walkway.nif,4FAC71C91408D426
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse04.nif,90643D567205AA1D
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse04walkway.nif,F0B55D66DEE91A88
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmhouse06.nif,B694F7C7E90390A8
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/farmwell01.nif,3B0CD6188FB67A69
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/inn01.nif,EAA89663303ADC7E
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/lumbermill01.nif,DB1D30E035E39017
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmbannerpost01.nif,C631ACCAF8924D44
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse01walkway.nif,2D602701AFEDD20B
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse02.nif,BA49A9D19CEF88D
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse02walkway.nif,9AD3D66D74C648AA
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse03.nif,4A82033407D4AB9D
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse03walkway.nif,AABBEB3119F518EC
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse04.nif,5172474EFB3E67DE
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse04walkway.nif,B57E39DF0FF9DA5D
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmhouse06.nif,B694F7C7E90390A8
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/farmwell01.nif,3B0CD6188FB67A69
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/inn01.nif,EAA89663303ADC7E
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/lumbermill01.nif,A8897C6B94EE6D75
+05 Chains 3D - Misc/meshes/architecture/markarth/mrkapoth01.nif,BD3B010D1218127D
+05 Chains 3D - Misc/meshes/architecture/markarth/mrkbrazierhanging01.nif,FFBF45EDB49B133F
+05 Chains 3D - Misc/meshes/architecture/markarth/mrkbrazierhanging02.nif,6133635B1ABCBC2C
+05 Chains 3D - Misc/meshes/architecture/markarth/mrksilverfishinnpart03.nif,CF195DE06B6FD630
+05 Chains 3D - Misc/meshes/architecture/markarth/mrksilverfishinnpart05.nif,BC9845739BF52AAA
+05 Chains 3D - Misc/meshes/architecture/markarth/mrktempledoorl01.nif,DE1AAEABAB411BC1
+05 Chains 3D - Misc/meshes/architecture/markarth/mrktempledoorr01.nif,217853E77CE7AE80
+05 Chains 3D - Misc/meshes/architecture/riften/riftendoor01.nif,2DA97F50EB41AB96
+05 Chains 3D - Misc/meshes/architecture/riften/riftendoor02.nif,F27C8CEA1EC52DA5
+05 Chains 3D - Misc/meshes/clutter/common/metalcage01.nif,67180E32079A87A2
+05 Chains 3D - Misc/meshes/clutter/common/torturerack01.nif,8DCB88DCFF66FCA1
+06 Chains 3D - Signs/meshes/architecture/markarth/mrksigngeneralgoods01.nif,85AC77936A924F06
+06 Chains 3D - Signs/meshes/architecture/markarth/mrksignmrksilverbloodinnsign01.nif,BAB3AF258D371971
+06 Chains 3D - Signs/meshes/clutter/signage/signtg03blackbriarmeadery.nif,38CB0C7B91B3F922
+07 Chains 3D - Whiterun/meshes/architecture/whiterun/wrdrawbridge01.nif,7AB8050AC9D68B63
+07 Chains 3D - Whiterun/meshes/traps/whiterundragontrap/whiterundragontrap01.nif,E617CED45FCA427E
+09 Dwemer Clutter/meshes/clutter/dwemer/armscrap.nif,8595D43E99B74AF3
+09 Dwemer Clutter/meshes/clutter/dwemer/centuriondynamocore01.nif,63C5CF37EFF5D911
+09 Dwemer Clutter/meshes/clutter/dwemer/dwarvengear.nif,A18DD997482CA82E
+09 Dwemer Clutter/meshes/clutter/dwemer/dwarvengyro.nif,1CE3A942D1F0608A
+09 Dwemer Clutter/meshes/clutter/dwemer/dwarvenplate.nif,3BFB85E4BDDEF65F
+09 Dwemer Clutter/meshes/clutter/dwemer/dwarvenscrap1.nif,F6BDCB8622E5EA8D
+09 Dwemer Clutter/meshes/clutter/dwemer/dwarvenscrap2.nif,FBEB74C960896E27
+09 Dwemer Clutter/meshes/clutter/dwemer/dwarvenscrap3.nif,6A087B530EC4DD06
+09 Dwemer Clutter/meshes/clutter/dwemer/dwarvenscrap4.nif,F4E97AA4CA4C6BD7
+09 Dwemer Clutter/meshes/clutter/dwemer/dwarvenscraplarge1.nif,2248EEEC739C50F0
+09 Dwemer Clutter/meshes/clutter/dwemer/dwarvenscraplarge2.nif,DEA5C420D0B5FC55
+09 Dwemer Clutter/meshes/clutter/dwemer/dwebowl01.nif,DA1F680E4243E7D
+09 Dwemer Clutter/meshes/clutter/dwemer/dwebowl02.nif,F330079BF0ECB0A2
+09 Dwemer Clutter/meshes/clutter/dwemer/dwecog01.nif,CBAE2720B74DFEC3
+09 Dwemer Clutter/meshes/clutter/dwemer/dwecup01.nif,98B789A3280B14D2
+09 Dwemer Clutter/meshes/clutter/dwemer/dwecup02.nif,6AD6FB7F6158F59C
+09 Dwemer Clutter/meshes/clutter/dwemer/dwecup03.nif,943970700F68F1F2
+09 Dwemer Clutter/meshes/clutter/dwemer/dwefork.nif,2A169F52A1BEFDF6
+09 Dwemer Clutter/meshes/clutter/dwemer/dweknife.nif,7E63AAF2D8E2249D
+09 Dwemer Clutter/meshes/clutter/dwemer/dweplate01.nif,41DACA469B1141D1
+09 Dwemer Clutter/meshes/clutter/dwemer/dwepot01.nif,E473A437BBB12997
+09 Dwemer Clutter/meshes/clutter/dwemer/dwespoon.nif,1FA15F9E09CC5C45
+10 Nordic Tables and Benches/meshes/clutter/ruins/ruinsfurniturerubble03.nif,BD1B5BC375D894AC
+10 Nordic Tables and Benches/meshes/clutter/ruins/ruinsfurniturerubble04.nif,15D3F9141DF16FE1
+10 Nordic Tables and Benches/meshes/clutter/ruins/ruinsfurniturerubble09.nif,A82D35B177B33B72
+10 Nordic Tables and Benches/meshes/clutter/ruins/ruinsfurniturerubble10.nif,34064AAFFAE6D172
+10 Nordic Tables and Benches/meshes/clutter/ruins/ruinsfurniturerubble11.nif,3127E3256B95605D
+10 Nordic Tables and Benches/meshes/clutter/ruins/ruinsfurniturerubble15.nif,D5D3EAAF5B83B522
+10 Nordic Tables and Benches/meshes/clutter/ruins/ruinslongtable01.nif,E9F373A78A3CD61C
+10 Nordic Tables and Benches/meshes/clutter/ruins/ruinstable01.nif,FE7C2FE82CC14226
+10 Nordic Tables and Benches/meshes/clutter/ruins/ruins_altar01.nif,7E2C8D8D5645A7A7
+10 Nordic Tables and Benches/meshes/furniture/nordic/ruinsbenchtable1sided.nif,9474DE23D04AA485
+10 Nordic Tables and Benches/meshes/furniture/nordic/ruinsbenchtable2sided.nif,D05140596001432D
+10 Nordic Tables and Benches/meshes/furniture/nordic/ruinsbookpedestal.nif,F328533B5CF15807
+10 Nordic Tables and Benches/meshes/furniture/nordic/ruinsbookpedestalshadow.nif,7082A8F3F2FFE4B
+10 Nordic Tables and Benches/meshes/furniture/nordic/ruins_bench01.nif,101686F1270CE507
+10 Nordic Tables and Benches/meshes/furniture/nordic/ruins_benchshadow01.nif,EBF3DE61DAF404D6
+11 Bridges/meshes/landscape/bridges/bridge01.nif,F8289F6F0FEDA8A0
+11 Bridges/meshes/landscape/bridges/bridgelong01.nif,94B23404F9236282
+11 Bridges/meshes/landscape/bridges/bridgenarrow01.nif,E22F67EB0564BA72
+11 Bridges/meshes/landscape/bridges/bridgeshort01.nif,496AB236DF714D66
+11 Bridges Old Stonework/meshes/landscape/bridges/bridge01.nif,E234236FF4A37A80
+11 Bridges Old Stonework/meshes/landscape/bridges/bridgelong01.nif,62957E827D0866C0
+11 Bridges Old Stonework/meshes/landscape/bridges/bridgenarrow01.nif,169A5D8D65B2E29D
+11 Bridges Old Stonework/meshes/landscape/bridges/bridgeshort01.nif,A6EFAAE6255E6E89
+11 Bridges Real Roads/meshes/architecture/solitude/sbridge01.nif,EE2D544780533F5C
+11 Bridges Real Roads/meshes/landscape/bridges/bridge01.nif,632C72927734956B
+11 Bridges Real Roads/meshes/landscape/bridges/bridgelong01.nif,8E1BD17F38FCAE05
+11 Bridges Real Roads/meshes/landscape/bridges/bridgenarrow01.nif,21E72C950BF76EED
+11 Bridges Real Roads/meshes/landscape/bridges/bridgeshort01.nif,7C4E330B5CDCC5AE
+12 Whiterun Doors/meshes/architecture/whiterun/wrcastledoor01.nif,F509F2F6C2484DF6
+12 Whiterun Doors/meshes/architecture/whiterun/wrdoormaingate01.nif,F72AC8BCE05EC867
+12 Whiterun Doors/meshes/architecture/whiterun/wrdragondoor01.nif,79B17611D4F03414
+13 Lanterns/meshes/clutter/common/candlelantern01.nif,A0BABD84540BECEA
+13 Lanterns/meshes/clutter/common/candlelanternwithcandle01.nif,B2DFFBEF45B6284C
+13 Lanterns/meshes/dlc02/loadscreenart/loadscreenadventure02.nif,9DE052F2B62E3971
+13 Lanterns/textures/smim/candles/candles01.dds,36D9D5EAD48714CC
+13 Lanterns/textures/smim/candles/candles01_g.dds,CFAD1913638FEEB6
+13 Lanterns/textures/smim/candles/candles01_n.dds,EA8228DA6595E530
+14 Stockade 3D Ropes/meshes/clutter/stockade/stockadescaffoldtoppost01.nif,727F3B09B705D9D7
+14 Stockade 3D Ropes/meshes/clutter/stockade/stockadescaffoldtoppost02.nif,2FF933D680818648
+14 Stockade 3D Ropes/meshes/clutter/stockade/stockadescaffoldtoppost03.nif,609BDBBA1C85266A
+14 Stockade 3D Ropes/meshes/clutter/stockade/stockadescaffoldtoprope01.nif,95FB865885EEDE5D
+14 Stockade 3D Ropes/meshes/clutter/stockade/stockadescaffoldtoprope02.nif,C60A9A19FD5D9EE4
+14 Stockade 3D Ropes/meshes/clutter/stockade/stockadescaffoldtoprope03.nif,6D75608FA1614686
+14 Stockade 3D Ropes/textures/clutter/stockade/stockadewood01.dds,5E19FE0DB8D1570A
+14 Stockade 3D Ropes/textures/clutter/stockade/stockadewood01snow.dds,E49B015B7E797019
+14 Stockade 3D Ropes/textures/clutter/stockade/stockadewood01_n.dds,DEB4D7E6021A4EB9
+15 Clothing Fixes/meshes/armor/dragonscale/dragonscalecuirassgo.nif,18CC3FEFD3C32AA8
+15 Clothing Fixes/meshes/clothes/farmclothes04/robem_0.nif,CC9E9A2D42D96367
+15 Clothing Fixes/meshes/clothes/farmclothes04/robem_1.nif,4DBDFF67F540FF9
+15 Clothing Fixes/meshes/clothes/wench/wenchoutfitm_0.nif,FF2FA3C8AC443EB3
+15 Clothing Fixes/meshes/clothes/wench/wenchoutfitm_1.nif,AC37AC1E5113AEE2
+15 Clothing Fixes/textures/clothes/wench/wenchoutfitm.dds,4B3C9B76ABB5ECFC
+16 Tankard Bright Brushed Metal/meshes/clutter/dining set/basictankard01.nif,49FEEC7D931F4772
+16 Tankard Bright Brushed Metal/meshes/dlc01/clutter/dlc01tankardblood.nif,17440A66F94FCACB
+16 Tankard Dark Brushed Metal/meshes/clutter/dining set/basictankard01.nif,49FEEC7D931F4772
+16 Tankard Dark Brushed Metal/meshes/dlc01/clutter/dlc01tankardblood.nif,17440A66F94FCACB
+16 Tankard Pewter Metal/meshes/clutter/dining set/basictankard01.nif,1AD741C33F746556
+16 Tankard Pewter Metal/meshes/dlc01/clutter/dlc01tankardblood.nif,FC62AF9706DF0DE8
+17 Nordic Catacombs Skeletal Remains/textures/actors/skeleton/skeleton.dds,8C316D8CA8F2EA3E
+17 Nordic Catacombs Skeletal Remains/textures/actors/skeleton/skeleton_n.dds,2D2A0E827CC030FA
+17 Nordic Catacombs Skeletal Remains/textures/smim/candles/candles01.dds,36D9D5EAD48714CC
+17 Nordic Catacombs Skeletal Remains/textures/smim/candles/candles01_g.dds,CFAD1913638FEEB6
+17 Nordic Catacombs Skeletal Remains/textures/smim/candles/candles01_n.dds,EA8228DA6595E530
+17 Nordic Catacombs Skeletal Remains/textures/smim/candles/candles02.dds,66AABA8688C65CCC
+17 Nordic Catacombs Skeletal Remains/textures/smim/candles/candles02_g.dds,F33F95B88753EEFD
+17 Nordic Catacombs Skeletal Remains/textures/smim/candles/candles02_n.dds,DC06819AD91AC894
+18 Farmhouse Woven Fence/meshes/architecture/farmhouse/fencewoven01.nif,1F28E804BC15B76C
+18 Farmhouse Woven Fence/meshes/architecture/farmhouse/fencewoven02.nif,56C4132959A6D0AD
+18 Farmhouse Woven Fence Dense/meshes/architecture/farmhouse/fencewoven01.nif,518554264DC69C85
+18 Farmhouse Woven Fence Dense/meshes/architecture/farmhouse/fencewoven02.nif,BEB1B675E523B549
+18 Farmhouse Woven Fence Dense Gray/meshes/architecture/farmhouse/fencewoven01.nif,969B95D1A294484B
+18 Farmhouse Woven Fence Dense Gray/meshes/architecture/farmhouse/fencewoven02.nif,714BE2755F1A4AF
+18 Farmhouse Woven Fence Less Flicker/meshes/architecture/farmhouse/fencewoven01.nif,E8DC441F6718BE6B
+18 Farmhouse Woven Fence Less Flicker/meshes/architecture/farmhouse/fencewoven02.nif,85A54778CB01A193
+20 Furniture Skyrim HD Appearance/meshes/clutter/common/commontablesquare01.nif,9517C1E62F7D1A4B
+20 Furniture Skyrim HD Appearance/meshes/clutter/common/dresser01.nif,AA5B41A1F8528CFD
+20 Furniture Skyrim HD Appearance/meshes/clutter/common/endtable01.nif,D6A8DA261124424F
+20 Furniture Skyrim HD Appearance/meshes/clutter/common/wardrobe01.nif,DDC432C56546358B
+20 Furniture Skyrim HD Appearance/textures/clutter/common/dresser01.dds,879EFD7F76CEB462
+20 Furniture Skyrim HD Appearance/textures/clutter/common/dresser01_n.dds,5FD4C847531E9B66
+20 Furniture Skyrim HD Weathered Appearance/meshes/clutter/common/commontablesquare01.nif,9517C1E62F7D1A4B
+20 Furniture Skyrim HD Weathered Appearance/meshes/clutter/common/dresser01.nif,AA5B41A1F8528CFD
+20 Furniture Skyrim HD Weathered Appearance/meshes/clutter/common/endtable01.nif,D6A8DA261124424F
+20 Furniture Skyrim HD Weathered Appearance/meshes/clutter/common/wardrobe01.nif,DDC432C56546358B
+20 Furniture Skyrim HD Weathered Appearance/textures/clutter/common/dresser01.dds,5D4F2CC651AE4232
+20 Furniture Skyrim HD Weathered Appearance/textures/clutter/common/dresser01_n.dds,3AFE67ADDE187B92
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockcolstr01.nif,E89B9DBCDE4C501A
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockcolstr02.nif,F7C94B69D00E523E
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockcolstrsign01.nif,8F4B92DAFB35D8F9
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockcolstrsignrope01.nif,DDC5CA7E0C494D9
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockcorsol01.nif,7F681DAFB15211CA
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockcorsol01uskp.nif,106BE31AABBA4F81
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockropestr01.nif,D13271A5CEFE4BDA
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockropestr02.nif,E244FED583D75E35
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstepsdown01.nif,376EE91D0837C75
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstepsdown02.nif,ECD28D880581423C
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstepsdown02uskp.nif,3FC26AE3706239E9
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstepsdownend01.nif,141B90E558F11814
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstr4way01.nif,B4EB2CA18929142
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrent01.nif,74ACBA98DAB7ADE6
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrent02.nif,6020D963909731E6
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrent02uskp.nif,D1729D98F8574678
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrent03.nif,39EAE8D0789B932D
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrent03uskp.nif,5058D3393DD28D46
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrent04.nif,A34DF9D8589484CA
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrsol01.nif,E76F5392A5331F34
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrsol01uskp.nif,6328A99BE8E2466F
+22 Solitude Docks Ropes SE/meshes/architecture/docks/dockstrsol02.nif,9C21EB59AFC98CF2
+22 Solitude Docks Ropes SE/meshes/architecture/solitude/seastempireco.nif,723D453D05A6E11B
+26 Human Skull Fixes/meshes/actors/skeleton/testskeleton.nif,3DD823EA7E9D080D
+26 Human Skull Fixes/meshes/clutter/bones/bloodyskull.nif,5A84E4E3FDB4911F
+26 Human Skull Fixes/meshes/clutter/bones/humanskull.nif,11FD62ECFFDDA2E3
+26 Human Skull Fixes/meshes/clutter/bones/humanskullfull.nif,311480C1DD8DD8EA
+26 Human Skull Fixes/meshes/clutter/bones/humanskullfullstatic.nif,2A69FCF889AB0D8F
+26 Human Skull Fixes/meshes/clutter/bones/humanskullstatic.nif,D5B8D39FBAC687C5
+26 Human Skull Fixes/meshes/clutter/potema/potemasskull.nif,4696D7231ADFD510
+26 Human Skull Fixes/textures/actors/skeleton/skeleton.dds,8C316D8CA8F2EA3E
+26 Human Skull Fixes/textures/actors/skeleton/skeleton_n.dds,5CEC730DADB3C56A
+26 Human Skull Fixes/textures/clutter/bones/bloodybones.dds,294C0898604DB303
+26 Human Skull Fixes/textures/clutter/bones/bloodybones_n.dds,C13DBEFAA5AB9489
+26 Human Skull Fixes/textures/smim/loadscreenart/smim_trollloadscreen_meat.dds,6D5E0D9363312CD7
+26 Human Skull Fixes/textures/smim/loadscreenart/smim_trollloadscreen_meat_n.dds,9FA8A9DE8D085A8
+27 Hawk/meshes/critters/fchawk/fchawkgo.nif,21C263F34394F902
+30 Rocks - Generic/meshes/landscape/rocks/rockl01.nif,FF27921FCC6F6FB
+30 Rocks - Generic/meshes/landscape/rocks/rockl02.nif,15BCE834DAC9FCC5
+30 Rocks - Generic/meshes/landscape/rocks/rockl03.nif,3A8C243D7D94D2BD
+30 Rocks - Generic/meshes/landscape/rocks/rockl04.nif,59E8A4C3401B8645
+30 Rocks - Generic/meshes/landscape/rocks/rockl05.nif,5A6FF54459381E0E
+30 Rocks - Generic/meshes/landscape/rocks/rockm01.nif,A94B688B3505D33A
+30 Rocks - Generic/meshes/landscape/rocks/rockm02.nif,59D0987A6ED8E2D3
+30 Rocks - Generic/meshes/landscape/rocks/rockm03.nif,1BF99E4680339DBF
+30 Rocks - Generic/meshes/landscape/rocks/rockm04.nif,82CECE4C1EE30012
+30 Rocks - Generic/meshes/landscape/rocks/rockpilel01.nif,D353BC0315AE68A2
+30 Rocks - Generic/meshes/landscape/rocks/rockpilem02.nif,C3FBA0C885338754
+30 Rocks - Generic/meshes/landscape/rocks/rockpilem02tundra.nif,55623E9A2D3BE25B
+30 Rocks - Generic/meshes/landscape/rocks/rockpiles01.nif,55CA1D546F7039E0
+30 Rocks - Generic/meshes/landscape/rocks/rockpiles02.nif,D559C82402389D5F
+30 Rocks - Generic/meshes/landscape/rocks/rockpiles03.nif,57F3EBB44AD3DD94
+30 Rocks - Generic/meshes/landscape/rocks/rockpiles04.nif,21857AA84284925E
+30 Rocks - Generic/meshes/landscape/rocks/rocks01.nif,85C7D00998AAFD81
+30 Rocks - Generic/meshes/landscape/rocks/rocks02.nif,7A98012EB479964
+30 Rocks - Generic/meshes/landscape/rocks/rocks03.nif,2403477D499A5B78
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystall01.nif,43D9722AD837A502
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystall02.nif,53ABA04CB790874C
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystall03.nif,9796D57712E722BD
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystall04.nif,C1FC7BEF25C2B15E
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystall05.nif,6864BFE35FEBD32E
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystalm01.nif,E0E01EE5739CB8D7
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystalm02.nif,283012347E60A213
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystalm03.nif,6C793D4198FA2F33
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystalm04.nif,3F155A82BD0DC7FD
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystalpiles02.nif,30A58E6066E1BE31
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystalpiles03.nif,CBE4330829C1F830
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystalpiles04.nif,3D6250131D1F2D7B
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystals02.nif,77B13AF2A21B9417
+31 Rocks - Blackreach/meshes/clutter/blackreach/blackreachcrystals03.nif,5658C522D2AE7DD9
+32 Rocks - Mountains/meshes/landscape/mountains/mountaincliff02.nif,6C536FB95BDDC4EB
+32 Rocks - Mountains/meshes/landscape/mountains/mountaincliff03.nif,A1DF76224A8D7D3C
+32 Rocks - Mountains/meshes/landscape/mountains/mountaincliff04.nif,EC405C8A812CA830
+32 Rocks - Mountains/meshes/landscape/mountains/mountaincliffcrevasse.nif,F37A2822CB5DDBFD
+32 Rocks - Mountains/meshes/landscape/mountains/mountaincliffsm01.nif,8104D5F46DDAC9D8
+32 Rocks - Mountains/meshes/landscape/mountains/mountainridge01.nif,D6E9E56109E629EF
+32 Rocks - Mountains/meshes/landscape/mountains/mountaintrim01.nif,1BA638430B27E3F1
+32 Rocks - Mountains/meshes/landscape/mountains/mountaintrim01wet.nif,23F711036212FB
+32 Rocks - Mountains/meshes/landscape/mountains/mountaintrimslab.nif,9FD44C22C9E464E2
+33 Orc Longhouse/meshes/architecture/orclonghouse/orcawning01.nif,3DD749F2EE8875C6
+33 Orc Longhouse/meshes/architecture/orclonghouse/orcawningfull01.nif,645BB234D198D76C
+33 Orc Longhouse/meshes/architecture/orclonghouse/orcawninghalf01.nif,FE4E6E5EC38675E0
+33 Orc Longhouse/meshes/architecture/orclonghouse/orcawningpartitionexsm01.nif,54044BE3E473272
+33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghouse01.nif,9FEEC3A8C2C6ABE6
+33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghouseinterior01.nif,4C3C3EEB78B54200
+33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghouseinterioreastwing01.nif,B1C28DAD50839B9E
+33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghouseinteriorwestwing01.nif,BC61B94932B7C83
+33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghousepartitionbeam01.nif,B667F041F2D80A3E
+33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghousepartitionend01.nif,C33D6A6D4A77C0BD
+33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghousepartitionexsm01.nif,EC4D16CFF9595D3F
+33 Orc Longhouse/meshes/architecture/orclonghouse/orclonghousepartitionwall01.nif,8B30E7B0A19076BD
+35 Shack Kit/meshes/architecture/shackkit/shackbrokepole01.nif,DA4BFD365E42F6A0
+35 Shack Kit/meshes/architecture/shackkit/shackbrokepole02.nif,13DB7218F1550CE1
+35 Shack Kit/meshes/architecture/shackkit/shackbrokepole03.nif,BB83A25D4CCB12CE
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood01.nif,942521ADA7098A6
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood02.nif,79047416189B7D7C
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood03.nif,DE23E60B9A4C73CB
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood04.nif,792DE039C5418C7
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood05.nif,A2773172DDF30BB6
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood06.nif,B12051520C92EB3B
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood07.nif,351143E9A6FF56DB
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood08.nif,4AF020348710F899
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood09.nif,2E8D758DE8A1930B
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood10.nif,B1072A12B1ED8322
+35 Shack Kit/meshes/architecture/shackkit/shackbrokewood11.nif,A686F2F714AC7423
+35 Shack Kit/meshes/architecture/shackkit/shackframebend01.nif,38D40238AD2DC0C3
+35 Shack Kit/meshes/architecture/shackkit/shackframelend01.nif,7E3F583049C0849B
+35 Shack Kit/meshes/architecture/shackkit/shackframelend02.nif,69F77BC1FE437693
+35 Shack Kit/meshes/architecture/shackkit/shackframelmid01.nif,7AE369459E066937
+35 Shack Kit/meshes/architecture/shackkit/shackframemend01.nif,CEAFC7BE566D67BE
+35 Shack Kit/meshes/architecture/shackkit/shackframemend02.nif,23804DDED86390DD
+35 Shack Kit/meshes/architecture/shackkit/shackframemmid01.nif,47993100CC8535D2
+35 Shack Kit/meshes/architecture/shackkit/shackframerend01.nif,356494F42C45D718
+35 Shack Kit/meshes/architecture/shackkit/shackframerend02.nif,BCFB943ED9CB787D
+35 Shack Kit/meshes/architecture/shackkit/shackframermid01.nif,44A9B121AB48BB73
+35 Shack Kit/meshes/architecture/shackkit/shackframeturncorner01.nif,46C7C49D2F965CC9
+35 Shack Kit/meshes/architecture/shackkit/shackframeturncorner01FIX.nif,7A5E94FBFB0D6684
+35 Shack Kit/meshes/architecture/shackkit/shackframeturncorner02.nif,42EE26DF96A3763C
+35 Shack Kit/meshes/architecture/shackkit/shackframeturnmid01.nif,61F3D8435DCEC2C
+35 Shack Kit/meshes/architecture/shackkit/shackroofcorner01.nif,21565952FFD5268F
+35 Shack Kit/meshes/architecture/shackkit/shackroofcorner02.nif,1F6A2A815C607463
+35 Shack Kit/meshes/architecture/shackkit/shackroofmid01.nif,6A67960765B5B9DA
+35 Shack Kit/meshes/architecture/shackkit/shackroofmid02.nif,20769F5C99267DE7
+35 Shack Kit/meshes/architecture/shackkit/shackroofmid03.nif,6756990AB30CB089
+35 Shack Kit/meshes/architecture/shackkit/shackroofmid04.nif,422886681F142FA7
+35 Shack Kit/meshes/architecture/shackkit/shackroofmid05.nif,ABC10892B7804A50
+35 Shack Kit/meshes/architecture/shackkit/shackroofside01.nif,CF6B0B97F406ABF8
+35 Shack Kit/meshes/architecture/shackkit/shackroofside01SMIMBoards.nif,6C49C5C01293C047
+35 Shack Kit/meshes/architecture/shackkit/shackroofside02.nif,2DD0FDD8A7A7C8E7
+35 Shack Kit/meshes/architecture/shackkit/shackroofside03.nif,3B787F32BC81719F
+35 Shack Kit/meshes/architecture/shackkit/shackroofside04.nif,22D98A9E188186AE
+35 Shack Kit/meshes/architecture/shackkit/shackwall01.nif,3423E8E4A11B9E74
+35 Shack Kit/meshes/architecture/shackkit/shackwall03.nif,328087509BEEC7EA
+35 Shack Kit/meshes/architecture/shackkit/shackwall04.nif,E8FF707664771443
+35 Shack Kit/meshes/architecture/shackkit/shackwalldoor01.nif,6CA37E7893603295
+35 Shack Kit/meshes/architecture/shackkit/shackwalll01.nif,2D1DADA44E7260D6
+35 Shack Kit/meshes/architecture/shackkit/shackwalll02.nif,5BAA303D8B463104
+35 Shack Kit/meshes/architecture/shackkit/shackwallr01.nif,F069AF1DAAD3F5B3
+35 Shack Kit/meshes/architecture/shackkit/shackwallr02.nif,D00022CFBE348C5
+35 Shack Kit/meshes/architecture/shackkit/shackwalltop01.nif,5A162A9F5E525308
+35 Shack Kit/meshes/architecture/shackkit/shackwalltopwindow01.nif,5D4DC0B50DD32D5F
+35 Shack Kit/meshes/architecture/shackkit/shackwallwindow01.nif,7AE77F45C4F59655
+35 Shack Kit/meshes/architecture/shackkit/shackwallwindow02.nif,8658CD3AAFA4402
+35 Shack Kit/meshes/betterdynamicsnow/shader/snowshader.nif,20508F83CC27E1AD
+37 Riften 3D Ropes/meshes/architecture/riften/rtcanallock01.nif,9CA878D845EAF915
+37 Riften 3D Ropes/meshes/architecture/riften/rtcanalsdeck01.nif,FA2541A9D42FB6D1
+37 Riften 3D Ropes/meshes/architecture/riften/rtcanalsdeck02.nif,D4787F25125CA624
+37 Riften 3D Ropes/meshes/architecture/riften/rtlamppost01.nif,215D47FA88F640FE
+37 Riften 3D Ropes/meshes/architecture/riften/rtplayerhousedeck01.nif,BA2106349EF782A8
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/dungeons/imperial/impwood01.dds,A2DBBD44628EA198
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/dungeons/imperial/impwood01_n.dds,EE7A6843B8D8BA02
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/dungeons/mines/minewood01.dds,A2DBBD44628EA198
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/dungeons/mines/minewood01_n.dds,EE7A6843B8D8BA02
+40 Furniture Chests/meshes/clutter/containers/chestopen01.nif,E3620D88EB5B2A31
+40 Furniture Chests/meshes/clutter/upperclass/upperchest01.nif,C6B622B738C306DC
+41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugr01.nif,A4C8361A4B7F4261
+41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugr02.nif,9CD0FA6B406B6628
+41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugr03.nif,1D228ABDC55B741A
+41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugr04.nif,6182456D732D8B7D
+41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugr05.nif,F0F35021E0DE28E1
+41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugr06.nif,94BC63352B34835D
+41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugrwrapped01.nif,D148D056600F69C8
+41 Draugr Corpses/meshes/clutter/ruins/ruinsdeaddraugrwrapped02.nif,11A94358F063B611
+42 Furniture Noble/meshes/furniture/noble/noblechair01.nif,E42D429399739756
+42 Furniture Noble/meshes/furniture/noble/noblechair02.nif,A5E7F4DB072378ED
+44 Poor Coffin Custom Texture/meshes/furniture/noble/scoffinpoor.nif,4286C7A19B372745
+45 Hanging Rings/meshes/clutter/deadanimals/hanginganimals01.nif,7C9EBEDDAFCE3E11
+45 Hanging Rings/meshes/clutter/deadanimals/hanginganimals02.nif,1A6546232F287C87
+45 Hanging Rings/meshes/clutter/deadanimals/hanginganimals03.nif,A821DE4087B0EC2A
+45 Hanging Rings/meshes/clutter/deadanimals/hanginganimalsring01.nif,B592BE212485FE6B
+45 Hanging Rings/meshes/clutter/deadanimals/hanginganimalsring02.nif,6B97C9B5132D23BA
+46 Carriage Seats and Fixes/meshes/clutter/common/wagonwheel01.nif,61F69F7AAF49C756
+46 Carriage Seats and Fixes/meshes/clutter/helgen/burntrubblecart01.nif,6FB89BA855D3EB08
+46 Carriage Seats and Fixes/meshes/furniture/cart/cartfurndriver01.nif,C580E2939F1B6F4B
+46 Carriage Seats and Fixes/meshes/furniture/cart/cartfurnpassanger01.nif,1B3E3EE15019A0CE
+46 Carriage Seats and Fixes/meshes/furniture/cart/cartfurnstatic01.nif,90C2BECFFC684D8F
+46 Carriage Seats and Fixes/meshes/furniture/prisonercarriage/prisonercarriage01.nif,8819BF04FD86F16E
+46 Carriage Seats and Fixes/meshes/furniture/prisonercarriage/prisonercarriage01static.nif,D3AEF423899A84FD
+46 Carriage Seats and Fixes/meshes/furniture/prisonercarriage/prisonercarriagefurniture01.nif,BFCA3B24A8F85E50
+47 Juniper Tree/textures/smim/plants/smim_juniper_tree.dds,C9A8A05903FCC17F
+47 Juniper Tree/textures/smim/plants/smim_juniper_tree_n.dds,78C37FF1144FD718
+49 Tundra Tree/meshes/landscape/trees/tundradriftwood01.nif,97D1AF8457AEB8EC
+50 Dawnguard Soulcairn Bone Piles/meshes/dlc01/soulcairn/sc_bonepile01.nif,C524169F240A7832
+50 Dawnguard Soulcairn Bone Piles/meshes/dlc01/soulcairn/sc_bonepile02.nif,69E5951788F8404E
+50 Dawnguard Soulcairn Bone Piles/meshes/dlc01/soulcairn/sc_bonepile03.nif,C38185C3181C9C70
+50 Dawnguard Soulcairn Bone Piles/meshes/dlc01/soulcairn/sc_bonepile04.nif,D3A0D534617D12F
+50 Dawnguard Soulcairn Bone Piles/meshes/dlc01/soulcairn/sc_bonepile05.nif,CB9EB479E4EBC9B0
+50 Dawnguard Soulcairn Bone Piles/meshes/dlc01/soulcairn/sc_bonepile06.nif,5F73EE3FBA03C5F7
+50 Dawnguard Soulcairn Bone Piles/textures/dlc01/landscape/soulcairnbones01.dds,8D0E9BF6E51040F9
+50 Dawnguard Soulcairn Bone Piles/textures/dlc01/landscape/soulcairnbones01_n.dds,A89C0A65614B8653
+50 Dawnguard Soulcairn Bone Piles/textures/dlc01/soulcairn/scbonetile.dds,99ABFA4DC1309413
+50 Dawnguard Soulcairn Bone Piles/textures/dlc01/soulcairn/scbonetile_n.dds,45BCC69178C4A010
+51 Dawnguard Soulcairn Bone Piles (More Bones)/meshes/dlc01/soulcairn/sc_bonepile01.nif,74DC5FD390AB8EF2
+51 Dawnguard Soulcairn Bone Piles (More Bones)/meshes/dlc01/soulcairn/sc_bonepile02.nif,E323DA082F45A8C1
+51 Dawnguard Soulcairn Bone Piles (More Bones)/meshes/dlc01/soulcairn/sc_bonepile03.nif,CD0A5E98C5073ADC
+51 Dawnguard Soulcairn Bone Piles (More Bones)/meshes/dlc01/soulcairn/sc_bonepile04.nif,5AE45704D356FBFA
+51 Dawnguard Soulcairn Bone Piles (More Bones)/meshes/dlc01/soulcairn/sc_bonepile05.nif,71FA0C7D109D7D34
+51 Dawnguard Soulcairn Bone Piles (More Bones)/meshes/dlc01/soulcairn/sc_bonepile06.nif,2B98CA70E027F55C
+52 Dawnguard Soulcairn Bone Piles (White Bones)/textures/dlc01/landscape/soulcairnbones01.dds,61986AEABE168D02
+52 Dawnguard Soulcairn Bone Piles (White Bones)/textures/dlc01/soulcairn/scbonetile.dds,290DE04B4EB4D8B9
+55 Windmills Base Vanilla Version/meshes/architecture/solitude/swindmill.nif,39682ED62CF305E3
+55 Windmills Base Vanilla Version Sails/meshes/architecture/solitude/swindmill.nif,C65180D771888B66
+56 Windmills SkyMills Compatibility/meshes/architecture/solitude/swindmillrotor.nif,AA908F85B8380CA8
+56 Windmills SkyMills Compatibility Sails/meshes/architecture/solitude/swindmillrotor.nif,2F6728AEC8901E78
+57 Ruins Sarcophagus/meshes/clutter/ruins/ruinsfurniturerubble01.nif,AE3ABB0B998C8E23
+57 Ruins Sarcophagus/meshes/clutter/ruins/ruinsfurniturerubble02.nif,E5A4973F93BDB687
+57 Ruins Sarcophagus/meshes/clutter/ruins/ruinssarcophagusvert01.nif,FEE203E10803A06
+57 Ruins Sarcophagus/meshes/clutter/ruins/ruinssarcophagusvert02.nif,110F6B002E70E3BB
+57 Ruins Sarcophagus/meshes/clutter/ruins/ruinssarcophagusvert03.nif,3CD1D6124D8A1514
+57 Ruins Sarcophagus/meshes/clutter/ruins/ruinssarcophagusverthole.nif,D41648FC7FF8B830
+57 Ruins Sarcophagus/meshes/clutter/ruins/ruinssarcophagus_bottom01.nif,DF831B0EEEA3B83A
+57 Ruins Sarcophagus/meshes/clutter/ruins/ruinssarcophagus_top01.nif,30CFE5DC741752F5
+58 Jewelry Rings/meshes/armor/amuletsandrings/goldringdiamondgo.nif,CFF346E90E6F6B4E
+58 Jewelry Rings/meshes/armor/amuletsandrings/goldringdiamond_1.nif,2CA60FAA4BC36288
+58 Jewelry Rings/meshes/armor/amuletsandrings/goldringemeraldgo.nif,E691D66A62BD5A13
+58 Jewelry Rings/meshes/armor/amuletsandrings/goldringemerald_1.nif,8C721CA7A1F71433
+58 Jewelry Rings/meshes/armor/amuletsandrings/goldringgo.nif,8F176E050421E089
+58 Jewelry Rings/meshes/armor/amuletsandrings/goldringsapphirego.nif,4826BBC74EF00800
+58 Jewelry Rings/meshes/armor/amuletsandrings/goldringsapphire_1.nif,28BA7B6A563D66D7
+58 Jewelry Rings/meshes/armor/amuletsandrings/goldring_1.nif,6F0463642E8B020E
+58 Jewelry Rings/meshes/armor/amuletsandrings/silverringamethystgo.nif,C7B2C0FFB7A39225
+58 Jewelry Rings/meshes/armor/amuletsandrings/silverringamethyst_1.nif,9917B5ED30275575
+58 Jewelry Rings/meshes/armor/amuletsandrings/silverringgarnetgo.nif,6520008466E9592B
+58 Jewelry Rings/meshes/armor/amuletsandrings/silverringgarnet_1.nif,67188253873B7420
+58 Jewelry Rings/meshes/armor/amuletsandrings/silverringgo.nif,80DE76243493DB4E
+58 Jewelry Rings/meshes/armor/amuletsandrings/silverringrubygo.nif,C4067321557BF2AF
+58 Jewelry Rings/meshes/armor/amuletsandrings/silverringruby_1.nif,7C98FFAB0B26414F
+58 Jewelry Rings/meshes/armor/amuletsandrings/silverring_1.nif,C1EFD83C141FA953
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingAmethystGo.nif,DCDF95E46F85496F
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingAmethyst_1.nif,CEF6D35DF264AF16
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingDiamondGo.nif,9A397544A8AF891A
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingDiamond_1.nif,B70A811F0B7A18F7
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingEmeraldGo.nif,18B0D1F74A910688
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingEmerald_1.nif,D3045200C6E410F
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingGarnetGo.nif,A57DEBC4C2EB7140
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingGarnet_1.nif,E9945A5358C9D13C
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingGo.nif,27F407410AEAF67F
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingOnyxGo.nif,1AE23BBC28CAFC35
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingOnyx_1.nif,562B8601E89A27E7
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingRubyGo.nif,685337B1634D9E30
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingRuby_1.nif,7A43504F8618987F
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingSapphireGo.nif,1977F7F39ACD8EDE
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingSapphire_1.nif,472D0F8E81A0A029
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingTopazGo.nif,B75B9460E816C64D
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRingTopaz_1.nif,483341B3F033553E
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/EbonyRing_1.nif,D549E886509E6828
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingAmethystGo.nif,3D44714EFF2BC9D8
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingAmethyst_1.nif,D35D2C99C7837C6F
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingGarnetGo.nif,162B13CCE9D26ED
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingGarnet_1.nif,E3224E4D3CDC76AF
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingOnyxGo.nif,A93E7D08E72360E4
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingOnyx_1.nif,5F4A1AD7243F90C8
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingRubyGo.nif,E5FDAEDBB41B165C
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingRuby_1.nif,300E943AC075336D
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingTopazGo.nif,FAEBF4E7C93A8B50
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/GoldRingTopaz_1.nif,186915E321CAAF37
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingAmethystGo.nif,F9DDEF4952DB3E50
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingAmethyst_1.nif,81D978AE2DB56EBE
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingDiamondGo.nif,19F220371E1782DB
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingDiamond_1.nif,7491984DC0694FE4
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingEmeraldGo.nif,730C85495C6F2ADF
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingEmerald_1.nif,1A3ADD64E4B071AA
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingGarnetGo.nif,B94FDA1C7AC1486B
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingGarnet_1.nif,276A256A97BA6F51
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingGo.nif,E881187C8724C9F9
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingOnyxGo.nif,2A5A08DD8EFAFF7D
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingOnyx_1.nif,31DD077FAC10BAAC
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingRubyGo.nif,14ACC6C201F604E5
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingRuby_1.nif,405D8114D5B3878C
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingSapphireGo.nif,22FB7D283CD22A76
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingSapphire_1.nif,B37989311AA9C744
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingTopazGo.nif,FC245F90E61D4211
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRingTopaz_1.nif,B37989311AA9C744
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/JadeRing_1.nif,AD9E097F1A4B447A
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingDiamondGo.nif,84039BEF08F0B40A
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingDiamond_1.nif,C0A2726BF7562F37
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingEmeraldGo.nif,A07B886840560BA4
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingEmerald_1.nif,BE938BE6449AF8BC
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingOnyxGo.nif,3F004530CC0AB893
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingOnyx_1.nif,8A16CC846F67C54F
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingSapphireGo.nif,B1DBBEB4AACDC6E0
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingSapphire_1.nif,2A6303788A48441A
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingTopazGo.nif,B8FD9F89CB73C9CD
+59 Jewelry Rings CCO Remade or Jewelcraft Patch/meshes/armor/amuletsandrings/SilverRingTopaz_1.nif,EA14D8DA80F98E53
+60 Hearthfires Stuff/meshes/_byoh/loadsscreens/loadscreenadoptionboy01.nif,577D56FE2724E929
+60 Hearthfires Stuff/meshes/_byoh/loadsscreens/loadscreenadoptiongirl01.nif,3CBD17936477E29D
+61 Bowl Ingredients/meshes/clutter/ingredients/bonemeal01.nif,887C47F486E63F00
+61 Bowl Ingredients/meshes/clutter/ingredients/ectoplasm.nif,51E98FEEBD63434C
+61 Bowl Ingredients/meshes/clutter/ingredients/glowdust01.nif,8732105A681592DD
+61 Bowl Ingredients/meshes/clutter/ingredients/mammothcheesebowl.nif,DB53B8E842BA8BA
+61 Bowl Ingredients/meshes/clutter/ingredients/moonsugar01.nif,2E9C7B62FC0AA249
+61 Bowl Ingredients/meshes/clutter/ingredients/powderedmammothtusk.nif,E2C4B86875796836
+61 Bowl Ingredients/meshes/clutter/ingredients/saltpile.nif,526753D782047D9A
+61 Bowl Ingredients/meshes/clutter/ingredients/sap.nif,54FA60662516BC5
+61 Bowl Ingredients/meshes/clutter/ingredients/stew.nif,30ACC4DDD790889E
+61 Bowl Ingredients/meshes/clutter/ingredients/trollfat01.nif,4662E79A5486E9D
+61 Bowl Ingredients/meshes/clutter/ingredients/vampiredust.nif,216ECF053F4CED6B
+70 Rabbit/meshes/clutter/deadanimals/hangingrabbit01.nif,65E65545568B9ACB
+70 Rabbit/meshes/clutter/deadanimals/hangingrabbit02.nif,CFE41024E3A698F7
+71 Candelabras Sconces Walltorches/meshes/clutter/common/torchpermanent01.nif,6A4607B06106AF67
+71 Candelabras Sconces Walltorches/meshes/clutter/common/torchpermanentoff.nif,F82A6235D6136777
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impbrazier01.nif,A6C947BBD7339836
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impcandelabracandle01.nif,A87421662E4C29DF
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impcandelabracandle02.nif,848AD65BF0B3FF06
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impcandelabracandleoff01.nif,E5FE4A9FF8501B17
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impcandelabranocandle.nif,C46ABC27D930339B
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impcandle01.nif,C91C2AE731076069
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/imperialwallshackle01.nif,D7273DBC2BB31D77
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impwallsconce02candleoff01.nif,E8DC2A2B7768D660
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impwallsconce02candleon01.nif,51182370AB4300C4
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impwallsconce02nocandle01.nif,47762237BF064BE4
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impwallsconcecandle01.nif,87B64F8F02064D3B
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impwallsconcecandle02.nif,69EEB5FC9361202B
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impwallsconcecandleoff01.nif,D9AB7A3EA0742BB1
+71 Candelabras Sconces Walltorches/meshes/clutter/imperial/impwallsconcenocandle01.nif,1BD0F9035FBC81F2
+71 Candelabras Sconces Walltorches/meshes/traps/pressureplatemetal/trappressureplatemetal01.nif,303B53FF6A7C63B9
+71 Candelabras Sconces Walltorches/textures/smim/candles/candles01.dds,36D9D5EAD48714CC
+71 Candelabras Sconces Walltorches/textures/smim/candles/candles01_g.dds,CFAD1913638FEEB6
+71 Candelabras Sconces Walltorches/textures/smim/candles/candles01_n.dds,EA8228DA6595E530
+72 Chandeliers/meshes/clutter/imperial/impchandelliercandle01.nif,5EC8BC5895D4FC37
+72 Chandeliers/meshes/clutter/imperial/impchandelliercandle02.nif,ABF9B19341E9E2B5
+72 Chandeliers/meshes/clutter/imperial/impchandelliercandle03.nif,48D7CB5BFD174B38
+72 Chandeliers/meshes/clutter/imperial/impchandelliercandleoff.nif,824D0B8B39F4B75E
+72 Chandeliers/meshes/clutter/imperial/impchandellierextension.nif,5C1BA1733D106B7E
+72 Chandeliers/meshes/clutter/imperial/impchandelliernocandle01.nif,C65E9B9FE7B09D36
+72 Chandeliers/textures/smim/candles/candles01.dds,36D9D5EAD48714CC
+72 Chandeliers/textures/smim/candles/candles01_g.dds,CFAD1913638FEEB6
+72 Chandeliers/textures/smim/candles/candles01_n.dds,EA8228DA6595E530
+73 Chandeliers No 3D Chains Addon/meshes/clutter/imperial/impchandelliercandle01.nif,F951792791B78314
+73 Chandeliers No 3D Chains Addon/meshes/clutter/imperial/impchandelliercandle02.nif,7EEEA262A8327A16
+73 Chandeliers No 3D Chains Addon/meshes/clutter/imperial/impchandelliercandle03.nif,671F01AB46A07BC
+73 Chandeliers No 3D Chains Addon/meshes/clutter/imperial/impchandelliercandleoff.nif,382637D7F54A80FA
+73 Chandeliers No 3D Chains Addon/meshes/clutter/imperial/impchandellierextension.nif,B3576986B3FF0674
+73 Chandeliers No 3D Chains Addon/meshes/clutter/imperial/impchandelliernocandle01.nif,724D6956E6E6ACAF
+80 Half-Sized Textures/textures/actors/skeleton/skeleton.dds,2D4298367EA29491
+80 Half-Sized Textures/textures/actors/skeleton/skeleton_n.dds,2E5C434A5D0F93DC
+80 Half-Sized Textures/textures/clutter/common/dresser01.dds,F0D54E0F86812FAF
+80 Half-Sized Textures/textures/clutter/common/dresser01_n.dds,D7FAA797CC70197E
+80 Half-Sized Textures/textures/clutter/deadanimals/rabbitmeatcooked.dds,9D34603A4651FDE5
+80 Half-Sized Textures/textures/clutter/ruins/ruinschest01snow.dds,91CDBD64CD40972F
+80 Half-Sized Textures/textures/clutter/ruins/smim_ruins_sarcophagus_parts.dds,98FBCAD49910B4AB
+80 Half-Sized Textures/textures/clutter/ruins/smim_ruins_sarcophagus_parts_n.dds,AF49D9BB5AFEAFFC
+80 Half-Sized Textures/textures/clutter/ruins/smim_ruins_sarcophagus_tub.dds,915A7B00571F6A52
+80 Half-Sized Textures/textures/clutter/ruins/smim_ruins_sarcophagus_tub_n.dds,2F04152ABB354528
+80 Half-Sized Textures/textures/clutter/stockade/stockadewood01.dds,FB6563027064FE68
+80 Half-Sized Textures/textures/clutter/stockade/stockadewood01snow.dds,8B587B6C8C2AE3B6
+80 Half-Sized Textures/textures/clutter/stockade/stockadewood01_n.dds,F83580C34898BED5
+80 Half-Sized Textures/textures/dungeons/imperial/impwood01.dds,3032B4970C9C5504
+80 Half-Sized Textures/textures/dungeons/imperial/impwood01_n.dds,CEB7ED796A23DEEA
+80 Half-Sized Textures/textures/dungeons/mines/minewood01.dds,3032B4970C9C5504
+80 Half-Sized Textures/textures/dungeons/mines/minewood01_n.dds,CEB7ED796A23DEEA
+80 Half-Sized Textures/textures/smim/clutter/barrel02.dds,8C64761AB7251690
+80 Half-Sized Textures/textures/smim/clutter/barrel02_n.dds,8F03B07019D4C42B
+80 Half-Sized Textures/textures/smim/clutter/barrel_smim_metal.dds,9B880E5ECCA83DE
+80 Half-Sized Textures/textures/smim/clutter/barrel_smim_metal_n.dds,62A8F59D93467CA
+80 Half-Sized Textures/textures/smim/clutter/barrel_smim_wood.dds,607B701947964DEE
+80 Half-Sized Textures/textures/smim/clutter/barrel_smim_wood_n.dds,6242BB64669261F8
+80 Half-Sized Textures/textures/smim/clutter/furniturewood01.dds,AAD234F4147870E1
+80 Half-Sized Textures/textures/smim/clutter/furniturewood01_n.dds,DBDC0BF8162D9953
+80 Half-Sized Textures/textures/smim/furniture/smim_wooden_chair.dds,2B298C5C6E663078
+80 Half-Sized Textures/textures/smim/furniture/smim_wooden_chair_n.dds,1514776ABA565281
+80 Half-Sized Textures/textures/smim/loadscreenart/smim_trollloadscreen_meat.dds,5FFAD8FB30E509F7
+80 Half-Sized Textures/textures/smim/loadscreenart/smim_trollloadscreen_meat_n.dds,C7651F136675BC01
+80 Half-Sized Textures/textures/smim/plants/potato01_properUVmap.dds,E393E2D39E44E60B
+80 Half-Sized Textures/textures/smim/plants/potato01_properUVmap_n.dds,9DBB1F5E4A72B840
+80 Half-Sized Textures/textures/smim/plants/smim_juniper_tree.dds,9E124AF5716FE27E
+80 Half-Sized Textures/textures/smim/plants/smim_juniper_tree_n.dds,C715B45A3A5F5B45
+80 Half-Sized Textures/textures/smim/traps/smim_trap_deadbolt.dds,4F9FC43DEF65148C
+80 Half-Sized Textures/textures/smim/traps/smim_trap_deadbolt_n.dds,3170B3E58D0FAE25
+81 Half-Sized Furniture Skyrim HD Appearance/textures/clutter/common/dresser01.dds,9FDECFE8AA94D687
+81 Half-Sized Furniture Skyrim HD Appearance/textures/clutter/common/dresser01_n.dds,AA0C4AD3DEE5C171
+81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/clutter/common/dresser01.dds,4904E15C65643314
+81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/clutter/common/dresser01_n.dds,C791950501C8249E
+90 Ultra-Sized Textures/textures/smim/furniture/smim_wooden_chair.dds,AC7B9246B7A1A8F5
+90 Ultra-Sized Textures/textures/smim/furniture/smim_wooden_chair_n.dds,D20834C3B33773F
+90 Ultra-Sized Textures/textures/smim/loadscreenart/smim_trollloadscreen_meat.dds,ACE0F7EF6153A2A4
+90 Ultra-Sized Textures/textures/smim/loadscreenart/smim_trollloadscreen_meat_n.dds,B5A4E0FC725E31E0
+90 Ultra-Sized Textures/textures/smim/plants/smim_juniper_tree.dds,ABAB4C342A75365F
+90 Ultra-Sized Textures/textures/smim/plants/smim_juniper_tree_n.dds,4319AE5359E9C1B7
+00 Core/meshes/architecture/farmhouse/interior/basement - Shortcut.lnk,A8106A400220D6A8
+00 Core/meshes/architecture/farmhouse/interior/farmint2basementent01.nif,5BB3DCA6BF93C3FC
+00 Core/meshes/architecture/farmhouse/interior/farmint2doorway02nodoor.nif,53C19F42C1AF4F39
+00 Core/meshes/architecture/farmhouse/interior/farmint2doorway03.nif,25B0C93012AC43F8
+00 Core/meshes/architecture/farmhouse/interior/farmint2doorway04.nif,EC46593853023DA
+00 Core/meshes/architecture/farmhouse/interior/farmint2end01.nif,EE790B9F626DBC3C
+00 Core/meshes/architecture/farmhouse/interior/farmint2end02.nif,27E12E5D35ADD3FB
+00 Core/meshes/architecture/farmhouse/interior/farmint2end03.nif,B48DAFD01B67D9D9
+00 Core/meshes/architecture/farmhouse/interior/farmint2hearth02.nif,60E3F326BA4A0F2A
+00 Core/meshes/architecture/farmhouse/interior/farmint2wall01.nif,57E925339403776B
+00 Core/meshes/architecture/farmhouse/interior/farmintcorner01.nif,EDD54F510DD17D86
+00 Core/meshes/architecture/farmhouse/interior/farmintdoorway01.nif,F916BC4D9EB1ED6
+00 Core/meshes/architecture/farmhouse/interior/farmintend01.nif,C2084C9B3AFA4E4E
+00 Core/meshes/architecture/farmhouse/interior/farmintend02.nif,C4DAC9085E8A4384
+00 Core/meshes/architecture/farmhouse/interior/farmintend03.nif,4479668BA6122004
+00 Core/meshes/architecture/farmhouse/interior/farmintinnend01.nif,3C672480511FF580
+00 Core/meshes/architecture/farmhouse/interior/farmintinnend02.nif,B3431BD77AFD12FC
+00 Core/meshes/architecture/farmhouse/interior/farmintinnend03.nif,211C8DC2DCFCF502
+00 Core/meshes/architecture/farmhouse/interior/farmintinnend04.nif,EE14095105935E44
+00 Core/meshes/architecture/farmhouse/interior/farmintinnend05.nif,A78B2B23A5FF2DCE
+00 Core/meshes/architecture/farmhouse/interior/farmintinnend06.nif,4276AA21C4CF8E29
+00 Core/meshes/architecture/farmhouse/interior/farmintinnwall01.nif,188932B388300414
+00 Core/meshes/architecture/farmhouse/interior/farmintinnwallentrance01.nif,2CC5EF95770FC43E
+00 Core/meshes/architecture/farmhouse/interior/farmintlhback01.nif,B9278D6C5F93ED24
+00 Core/meshes/architecture/farmhouse/interior/farmintlhend01.nif,8734BC172C627DB4
+00 Core/meshes/architecture/farmhouse/interior/farmintlhend02.nif,6C5B89208425BE6D
+00 Core/meshes/architecture/farmhouse/interior/farmintlhfirepit01.nif,97622DDDC06E166B
+00 Core/meshes/architecture/farmhouse/interior/farmintlhfirepit03.nif,1672891C7D2620A1
+00 Core/meshes/architecture/farmhouse/interior/farmintlhfront01.nif,97B41BA959BBBD57
+00 Core/meshes/architecture/farmhouse/interior/farmintlhloft01.nif,5EDB8F6DDC83CA6A
+00 Core/meshes/architecture/farmhouse/interior/farmintlhloft02.nif,58B4FCFD7592B90
+00 Core/meshes/architecture/farmhouse/interior/farmintlhlofttop01.nif,C24BFD555BCDBCC8
+00 Core/meshes/architecture/farmhouse/interior/farmintlhmid01.nif,A3AA93972104DED8
+00 Core/meshes/architecture/farmhouse/interior/farmintwall01.nif,EA1A190648305E2A
+00 Core/meshes/architecture/farmhouse/interior/farmintwallhearth01.nif,9FE475C059273CE8
+00 Core/meshes/architecture/farmhouse/interior/farmintwallhearth02.nif,87284E7CAB8A3C7D
+00 Core/meshes/architecture/farmhouse/interior/farmintwbasementent01.nif,CC5BCE7C4A746CC7
+00 Core/meshes/architecture/farmhouse/interior/farmintwooddoorway01.nif,DD5148E501BE2DB1
+00 Core/meshes/architecture/farmhouse/interior/farmintwoodend01.nif,7B9E6E123163D26C
+00 Core/meshes/architecture/farmhouse/interior/farmintwoodend02.nif,630B2A1C269FC647
+00 Core/meshes/architecture/farmhouse/interior/farmintwoodwall01.nif,D683AFC917D8FC1
+00 Core/meshes/architecture/farmhouse/rubble/farmhousebrubble01.nif,90DCF046F08AB4F9
+00 Core/meshes/architecture/farmhouse/walkway/walkway01.nif,27B6C77FAA4D6EB8
+00 Core/meshes/architecture/farmhouse/walkway/walkway02.nif,3610CBBB6314AD4C
+00 Core/meshes/architecture/farmhouse/walkway/walkwaybend01.nif,1488F105BA0FD0BD
+00 Core/meshes/architecture/farmhouse/walkway/walkwaybend02.nif,96B7EB6E7050AF8F
+00 Core/meshes/architecture/farmhouse/walkway/walkwaybend03.nif,E5D778B13BF29A0E
+00 Core/meshes/architecture/farmhouse/walkway/walkwayc01.nif,D08CC391B7B9CA73
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycend01.nif,D5AAAFDBBC5AC9ED
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycend02.nif,8AA41AFE7B16E220
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycentwall01.nif,D8AE00B27F53EB73
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycentwall02.nif,A84C08DAE30CAF57
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycwall01.nif,41734632FEC85F33
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycwallend01.nif,787BCDDECCAC3250
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycwallend02.nif,3E3706562B596A2A
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycwallend03.nif,11BE387772DC816
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycwallend04.nif,125311D3CF7A9336
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycwallgate01.nif,BEE934405A9B4D78
+00 Core/meshes/architecture/farmhouse/walkway/walkwaycwallgate02.nif,B4D6CF9BB35F5A67
+00 Core/meshes/architecture/farmhouse/walkway/walkwayend01.nif,362F8078F24CE4C0
+00 Core/meshes/architecture/farmhouse/walkway/walkwayfull01.nif,D005E5072297F432
+00 Core/meshes/architecture/farmhouse/walkway/walkwayfull02.nif,CF09D272CF3099B5
+00 Core/meshes/architecture/farmhouse/walkway/walkwayfull03.nif,D6CA219CD7AD48DC
+00 Core/meshes/architecture/farmhouse/walkway/walkwayramp01.nif,9E2BA187374CD4F
+00 Core/meshes/architecture/farmhouse/walkway/walkwayrend01.nif,19A07A636363F585
+00 Core/meshes/architecture/farmhouse/walkway/walkwaystairs1.nif,FA3773C281852501
+00 Core/meshes/architecture/farmhouse/walkway/walkwaystairs15.nif,E1885CBEC16FE7ED
+00 Core/meshes/architecture/farmhouse/walkway/walkwaystairs3.nif,48CC50B675C7B8C7
+00 Core/meshes/architecture/farmhouse/walkway/walkwaystairs4.nif,5CB2D5EC50BD65C3
+00 Core/meshes/architecture/farmhouse/walkway/walkwaystairs8.nif,FDCEA87754889AF5
+00 Core/meshes/architecture/solitude/farms/slumbermill01.nif,EA17DBEB6B69D9BB
+00 Core/meshes/architecture/solitude/interiors/slgdarchfire02.nif,C0220EE4967400F9
+00 Core/meshes/architecture/whiterun/wrbuildings/wrcastleentrance01.nif,CE30051BDBFB94C2
+00 Core/meshes/architecture/whiterun/wrbuildings/wrcastlemainbuilding01.nif,5E423A559A686FA3
+00 Core/meshes/architecture/whiterun/wrbuildings/wrcastlestonetowertop01.nif,CC1E9C4451D99295
+00 Core/meshes/architecture/whiterun/wrbuildings/wrmarketstand01.nif,D7F8C207CCB0B36C
+00 Core/meshes/architecture/whiterun/wrbuildings/wrmarketstand03.nif,ABF050F043DAB799
+00 Core/meshes/architecture/whiterun/wrbuildings/wrmarketstand03destroyed.nif,2065D2A98022A494
+00 Core/meshes/architecture/whiterun/wrbuildings/wrtempleofk01.nif,883C40326F6258B4
+00 Core/meshes/architecture/whiterun/wrinteriors/wrintfreewallcolumwall01.nif,8701DAAC1B94CB1A
+00 Core/meshes/architecture/whiterun/wrinteriors/wrintroofwall03.nif,85B337CE2DE803B8
+00 Core/meshes/architecture/whiterun/wrscaffold/wrscafguardtower01.nif,C2A5B74BEBD7646C
+00 Core/meshes/architecture/whiterun/wrscaffold/wrscafguardtower02.nif,873EFCD02C6A6695
+00 Core/meshes/architecture/whiterun/wrscaffold/wrscafguardtowerlarge01.nif,9414401FA9059423
+00 Core/meshes/architecture/whiterun/wrscaffold/wrscafguardtowerspikes01.nif,51F8323E4211970A
+00 Core/meshes/architecture/whiterun/wrscaffold/wrscafrailcor01.nif,E63A359B00DCCCF9
+00 Core/meshes/architecture/whiterun/wrscaffold/wrscafrailstr01.nif,B005385F5FF1A133
+00 Core/meshes/architecture/whiterun/wrscaffold/wrscafstr01spikes.nif,3DE022CAB1BAF6A2
+00 Core/meshes/architecture/whiterun/wrterrain/wrmainroadmarket.nif,D9A1BD8AB90E867
+00 Core/meshes/architecture/whiterun/wrterrain/wrstairsplatform01.nif,FB13A87B2839FBE1
+00 Core/meshes/architecture/whiterun/wrterrain/wrterwind01.nif,12C01701034E91E4
+00 Core/meshes/architecture/whiterun/wrterrain/wrtreecircle01.nif,F202FAA4A453A205
+00 Core/meshes/dlc01/clutter/vampirecoffinhoriz/vampirecoffinhoriz01.nif,F4EE62A53AB6A09D
+00 Core/meshes/dlc01/clutter/vampirecoffinhoriz/vampirecoffinhoriz02.nif,A5D797A40CC8CFD2
+00 Core/meshes/dlc01/landscape/rocks/dlc01rockcaveentrance01.nif,EAA5EE8BA65352C1
+00 Core/meshes/dungeons/dwemer/clutter/dwecenturionbust01.nif,95AC05E7282CA86F
+00 Core/meshes/dungeons/dwemer/facades/dwefacadeliftdown01.nif,817F8D58175EC54A
+00 Core/meshes/dungeons/dwemer/facades/dwefacadeliftup01.nif,A3F480EA48C88B2E
+00 Core/meshes/dungeons/imperial/clutterkits/impfloorchunk01.nif,AA970DF40FFDDC5C
+00 Core/meshes/dungeons/imperial/clutterkits/impfloorchunk02.nif,D882A0725CE0D158
+00 Core/meshes/dungeons/imperial/clutterkits/imprubblepiece01.nif,7AC6CA71A2AA6BEE
+00 Core/meshes/dungeons/imperial/clutterkits/imprubblepiece02.nif,ED88FE5E95542B50
+00 Core/meshes/dungeons/imperial/clutterkits/imprubblepiece03.nif,610DBBB0AC7F6E0B
+00 Core/meshes/dungeons/imperial/clutterkits/imprubblepiece04.nif,A029F6CE63E6D36F
+00 Core/meshes/dungeons/imperial/clutterkits/imprubblepiece05.nif,CD4C3A4F0B114A74
+00 Core/meshes/dungeons/imperial/clutterkits/imprubblepile01.nif,1CE7628838F60F84
+00 Core/meshes/dungeons/imperial/clutterkits/imprubblepile02.nif,8F366F36E64522DE
+00 Core/meshes/dungeons/imperial/clutterkits/imprubblepile03.nif,3F5F8B23A9EDB09E
+00 Core/meshes/dungeons/imperial/clutterkits/imprubblepile04.nif,8ABD33503C73BEF7
+00 Core/meshes/dungeons/imperial/clutterkits/imprubblepile05.nif,9DAE60BB410F273
+00 Core/meshes/dungeons/mines/caveroom/minecroomdoor03.nif,E98E4B869C679C03
+00 Core/meshes/dungeons/mines/cavesmallhall/minechall2way02.nif,5EBCCD0DA5B45D17
+00 Core/meshes/dungeons/mines/cavesmallhall/minechall2way02c.nif,1DF52482F4F866E4
+00 Core/meshes/dungeons/mines/cavesmallwall/minecwalldoor01.nif,7D33A7677774C29B
+00 Core/meshes/dungeons/mines/cavewall/mineclewalldoor01.nif,5CAE2F98539B0E85
+00 Core/meshes/dungeons/mines/cavewall/mineclwalldoor01.nif,2E52C64450FF5B9D
+00 Core/meshes/dungeons/mines/cliffs/minecliffs01.nif,7B946B0A20A26D00
+00 Core/meshes/dungeons/mines/cliffs/minecliffs02.nif,324E51D321D2FB44
+00 Core/meshes/dungeons/mines/cliffs/minecliffs03.nif,79A10DC60AE38B98
+00 Core/meshes/dungeons/mines/cliffs/minecliffs03ns.nif,EDE41C8D8E2953E1
+00 Core/meshes/dungeons/mines/cliffs/minecliffscornerin01.nif,E9FADC3F15AB3577
+00 Core/meshes/dungeons/mines/cliffs/minecliffscornerin01ns.nif,521DC61FEA7A6A3F
+00 Core/meshes/dungeons/mines/cliffs/minecliffscornerout01.nif,A81C3FB81139E549
+00 Core/meshes/dungeons/mines/cliffs/minecliffscornerout01ns.nif,10798E1A9A39A3CE
+00 Core/meshes/dungeons/mines/cliffs/minecliffsisland01.nif,CC35B707CCF74614
+00 Core/meshes/dungeons/mines/cliffs/minecliffsisland01ns.nif,83A193DBFF4FF405
+00 Core/meshes/dungeons/mines/clutter/genericwell01.nif,95EB47FABC491BBE
+00 Core/meshes/dungeons/mines/minelargehall/minelhall4way01.nif,DE16D85641EA430E
+00 Core/meshes/dungeons/mines/minelargehall/minelhallentrance01.nif,3C6AE89D12254B15
+00 Core/meshes/dungeons/mines/minelargehall/minelhallentrance02.nif,7C3B0821A2336B2B
+00 Core/meshes/dungeons/mines/ore/ingotdwarven.nif,41A3926F1E7A5095
+00 Core/meshes/dungeons/mines/ore/ingotgold.nif,24C33FF6E115448F
+00 Core/meshes/dungeons/mines/rocks/minecboulderl02.nif,66213A095648EE8E
+00 Core/meshes/dungeons/mines/scaffolding/minescaffoldbridge01.nif,8580F8A7D572D028
+00 Core/meshes/dungeons/mines/scaffolding/minescaffoldbridge02.nif,3D458DFB7C0BFDC0
+00 Core/meshes/dungeons/mines/scaffolding/minescaffoldbridge03.nif,347C98834086B7C6
+00 Core/meshes/dungeons/mines/scaffolding/minescaffoldbridge04.nif,7978FFB73AAC576F
+00 Core/meshes/dungeons/nordic/exterior/nortmpextplanter01.nif,2AE60BBAC1DFB823
+00 Core/meshes/dungeons/nordic/exterior/nortmpextplattower01.nif,FB63B82B74CB522E
+00 Core/meshes/dungeons/nordic/exterior/nortmpextplattower02.nif,18178EA66F52AB1F
+00 Core/meshes/dungeons/nordic/platforms/norplatbgcordblend01.nif,8C22774D5C2365D6
+00 Core/meshes/dungeons/nordic/rubble/norrubblepile01.nif,E0E9FD60179BA5A3
+00 Core/meshes/dungeons/nordic/rubble/norrubblepile02.nif,73A5D71609222785
+00 Core/meshes/dungeons/nordic/rubble/norrubblepile03.nif,45550675D46AA7E
+00 Core/meshes/dungeons/nordic/rubble/norrubblepile04.nif,3004D57B378A10BD
+00 Core/meshes/dungeons/nordic/rubble/norrubblepile06.nif,B350AD8FC695D590
+00 Core/meshes/dungeons/nordic/rubble/norrubblepile07.nif,A251C890D713DBDE
+00 Core/meshes/dungeons/nordic/rubble/norrubblepile08.nif,371A4348B9BAAD17
+00 Core/meshes/landscape/rocks/wetrocks/rockl01wet.nif,CCED600D06C5A1EE
+00 Core/meshes/landscape/rocks/wetrocks/rockl04wet.nif,7DD0C1CA380B757E
+00 Core/meshes/landscape/rocks/wetrocks/rockm03wet.nif,46865651B9938B42
+00 Core/meshes/landscape/rocks/wetrocks/rockpilem02wet.nif,206876EAD1DEC15C
+00 Core/textures/smim/architecture/farmhouse/farmhouse_int_jaillock.dds,3EBB9D196B6921F3
+00 Core/textures/smim/architecture/farmhouse/farmhouse_int_jaillock_n.dds,C060B1C9BC5BED5F
+00 Core/textures/smim/architecture/farmhouse/metalwork01_jailring.dds,D6F23A28A4BFBDE1
+00 Core/textures/smim/architecture/farmhouse/metalwork01_jailring_n.dds,553FCF5E0628A21A
+00 Core/textures/smim/architecture/whiterun/metalwork01_drawbridge.dds,D6F23A28A4BFBDE1
+00 Core/textures/smim/architecture/whiterun/metalwork01_drawbridge_n.dds,553FCF5E0628A21A
+00 Core/textures/smim/architecture/whiterun/wrstockade_properwood.dds,7A681A431BD6082D
+00 Core/textures/smim/architecture/whiterun/wrstockade_properwood_n.dds,856AA25E82E3C988
+00 Core/textures/smim/architecture/whiterun/wrwoodplanks_512_tiling.dds,F322297F45FE959F
+00 Core/textures/smim/architecture/whiterun/wrwoodplanks_512_tiling_n.dds,F8FE9AC43C05250
+00 Core/textures/smim/clutter/charcoal/charcoal01.dds,6F330C055916777B
+00 Core/textures/smim/clutter/charcoal/charcoal01_n.dds,B224234A28240FFF
+00 Core/textures/smim/clutter/common/archery_target_wood.dds,D18B30138085A711
+00 Core/textures/smim/clutter/common/archery_target_wood_n.dds,154A80FBC170BD1D
+00 Core/textures/smim/clutter/common/rope01_beige.dds,52E3642356D315CA
+00 Core/textures/smim/clutter/common/rope01_bright.dds,D913EE7BBE8BEBEC
+00 Core/textures/smim/clutter/common/rope01_midburn.dds,F5E79A5380CA2A8F
+00 Core/textures/smim/clutter/common/rope01_n.dds,86229CDF8C7822AB
+00 Core/textures/smim/clutter/common/smim_quill.dds,6B82BF2B69047ECC
+00 Core/textures/smim/clutter/common/smim_quill_n.dds,6C677520FB031327
+00 Core/textures/smim/clutter/ingredients/smim_dwarven_oil.dds,8702DB8C31EAE1A8
+00 Core/textures/smim/clutter/ingredients/smim_dwarven_oilspill.dds,4872A17FE6A3397F
+00 Core/textures/smim/clutter/ingredients/smim_dwarven_oilspill_n.dds,9ED2124174CC19A2
+00 Core/textures/smim/clutter/ingredients/smim_dwarven_oil_m.dds,DF25A5DD0073BF9
+00 Core/textures/smim/clutter/ingredients/smim_dwarven_oil_n.dds,521095F0ECD30E19
+00 Core/textures/smim/clutter/ingredients/smim_hagclaw.dds,3007096F671FF0C6
+00 Core/textures/smim/clutter/ingredients/smim_hagclaw_n.dds,350DFB5975298D79
+00 Core/textures/smim/clutter/ingredients/smim_sabrecat_tooth.dds,F1E9DD9AACDEF569
+00 Core/textures/smim/clutter/ingredients/smim_sabrecat_tooth_n.dds,AEED390189743245
+00 Core/textures/smim/clutter/quest/smim_giant_mortar.dds,EF35CBA95352D47A
+00 Core/textures/smim/clutter/quest/smim_giant_mortar_n.dds,D4F54FCFA5788C5C
+00 Core/textures/smim/clutter/ruins/ruinschest.dds,342538D715A871AA
+00 Core/textures/smim/clutter/ruins/ruinschestnails.dds,1C46182610707E90
+00 Core/textures/smim/clutter/ruins/ruinschestnails_n.dds,749C430F28F9A795
+00 Core/textures/smim/clutter/ruins/ruinschestsmall.dds,4D179227A74E70D5
+00 Core/textures/smim/clutter/ruins/ruinschestsmall_n.dds,E1560D62A839D3C3
+00 Core/textures/smim/clutter/ruins/ruinschest_n.dds,D3677362C369B1E4
+00 Core/textures/smim/clutter/ruins/smim_ruinspot01.dds,29AADB6FD2CD04BE
+00 Core/textures/smim/clutter/ruins/smim_ruinspot01_n.dds,B012CB4B932CFC4B
+00 Core/textures/smim/clutter/woodfires/smim_campfire_rocks.dds,27F53D9A543738A0
+00 Core/textures/smim/clutter/woodfires/smim_campfire_rocks_n.dds,2A8D9C11F30BC509
+00 Core/textures/smim/dungeons/dwemer/smim_dwemer_focus_rock.dds,FFBD845E45FA0FF9
+00 Core/textures/smim/dungeons/dwemer/smim_dwemer_focus_rock_n.dds,4ABF641CD2353958
+01 Furniture/meshes/architecture/whiterun/wrclutter/wrtemplebench01.nif,83DD0E2233B7A078
+01 Furniture/meshes/architecture/whiterun/wrclutter/wrtemplebench01static.nif,38E1D95CD2578401
+01 Furniture/meshes/clutter/common/commonshelfsecretdoor01/commonshelfsecretdoor01.nif,13BBC240AF073FC5
+01 Furniture/meshes/dungeons/riften/thievesguild/tgsecretdoor01.nif,F3C811730CB2CBDB
+01 Furniture/textures/smim/architecture/whiterun/smim_wr_bench.dds,F422456F91B317DC
+01 Furniture/textures/smim/architecture/whiterun/smim_wr_bench_n.dds,34197122FCFB462B
+01 Furniture/textures/smim/clutter/common/dresser01.dds,443FCF99DAD2F211
+01 Furniture/textures/smim/clutter/common/dresser01_n.dds,693B96D4EDB99CD3
+01 Furniture/textures/smim/clutter/common/Stump_Bottom_for_Furniture.dds,FF48EB31AB4E14BF
+01 Furniture/textures/smim/clutter/common/Stump_Bottom_for_Furniture_n.dds,2CDDC5DE9CDB11CC
+01 Furniture/textures/smim/clutter/common/Table_Leg_Bark.dds,6D9BBC55EF3B3EBD
+01 Furniture/textures/smim/clutter/common/Table_Leg_Bark_n.dds,471AACF7B7FA705D
+01 Furniture/textures/smim/clutter/common/Table_Leg_Bark_Seamless.dds,664272D497B20CD4
+01 Furniture/textures/smim/clutter/common/Table_Leg_Bark_Seamless_n.dds,BF4115D2470E188E
+01 Furniture/textures/smim/clutter/common/Table_Leg_Bark_Thin.dds,8ED2131440EFF2C2
+01 Furniture/textures/smim/clutter/common/Table_Leg_Bark_Thin_n.dds,66CED87FB58FDE92
+01 Furniture/textures/smim/clutter/common/Table_Wood_SinglePiece.dds,D1277B75CF5BBEA9
+01 Furniture/textures/smim/clutter/common/Table_Wood_SinglePiece_n.dds,52B16DD5FC457314
+01 Furniture/textures/smim/clutter/upperclass/smim_upper_bedpost.dds,42AD711376D9CB65
+01 Furniture/textures/smim/clutter/upperclass/smim_upper_bedpost_n.dds,E03D979E30F934C7
+01 Furniture/textures/smim/clutter/upperclass/smim_upper_bench_legs.dds,BDAAF1DCA9B58891
+01 Furniture/textures/smim/clutter/upperclass/smim_upper_bench_legs_n.dds,8D691D67A79CFDD8
+01 Furniture/textures/smim/clutter/upperclass/Stump_Bottom_for_FurnitureUC.dds,2C8CBE5F1AB287CF
+01 Furniture/textures/smim/clutter/upperclass/Stump_Bottom_for_FurnitureUC_n.dds,2CDDC5DE9CDB11CC
+01 Furniture/textures/smim/clutter/upperclass/Table_Leg_Bark_Thin.dds,E3F17ED5A7856C39
+01 Furniture/textures/smim/clutter/upperclass/Table_Leg_Bark_Thin_n.dds,D93E8C6B0D2195A6
+01 Furniture/textures/smim/clutter/upperclass/Table_Wood_SinglePiece.dds,2AB5152B4D10E11
+01 Furniture/textures/smim/clutter/upperclass/Table_Wood_SinglePiece_n.dds,52B16DD5FC457314
+03 Food/textures/smim/clutter/food/apple01_semi-circle-UV.dds,47F82715590F9764
+03 Food/textures/smim/clutter/food/apple01_semi-circle-UV_n.dds,AED2D3CC8C229673
+03 Food/textures/smim/clutter/food/apple02_semi-circle-UV.dds,78796FE12AA982AD
+03 Food/textures/smim/clutter/food/apple02_semi-circle-UV_n.dds,AED2D3CC8C229673
+03 Food/textures/smim/clutter/ingredients/tomato_smim.dds,C86985A0381BFDB5
+03 Food/textures/smim/clutter/ingredients/tomato_smim_n.dds,AA739FDE6A3449FE
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkway01.nif,B75DBA7450E1F6D1
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkway02.nif,F3B22BBB480085C3
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaybend01.nif,38EAFE817BD34110
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaybend02.nif,BEE0B76CD61BB7AD
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaybend03.nif,AA0ADCF267B30155
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwayc01.nif,BAC89D56E388FE66
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycend01.nif,F889D1B91D74CF09
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycend02.nif,3EFF3E7A412AD93C
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycentwall01.nif,CD9776AECF56D8DA
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycentwall02.nif,9A5ED120B26B9120
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycwall01.nif,4335D59F9FC1FC
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycwallend01.nif,87A9C3AE73B66C8B
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycwallend02.nif,E3D82C581E91B58E
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycwallend03.nif,237016C8AE8EF858
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycwallend04.nif,C7C20CBDDBC2EC43
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycwallgate01.nif,E77398296D823323
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaycwallgate02.nif,F922441903947263
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwayend01.nif,2FBB9ECD86A03C14
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwayfull02.nif,C5A17194C0F3C2F5
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwayfull03.nif,A3D8A132015AC46D
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwayrend01.nif,ECBA7C1A8A16C0D
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaystairs1.nif,2DF96E5FB1585D19
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaystairs15.nif,7FE28B0D7D859F76
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaystairs3.nif,75ABF2B4C9D6C145
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaystairs4.nif,BB4105EB6B7FAFEC
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/walkway/walkwaystairs8.nif,A9C51EF2D755A700
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/solitude/farms/slumbermill01.nif,81A9B5EACFF9595C
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkway01.nif,FAA14ECD3FBE82CA
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkway02.nif,30F7D9D13AE09173
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaybend01.nif,B89BA3FE8CE55ED3
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaybend02.nif,15213958A9CD6B08
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaybend03.nif,2291BA40BD292840
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwayc01.nif,8F22899ED1834399
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycend01.nif,898B3D5A0DE51B06
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycend02.nif,81F5FEA3B153BB02
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycentwall01.nif,1E751F6E699EA0E1
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycentwall02.nif,607C7E86A687B6A
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycwall01.nif,273F3BE3EE57D6DC
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycwallend01.nif,AF53554DA722208F
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycwallend02.nif,26B360021B0AACD5
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycwallend03.nif,9B282E5C2A2DD8EB
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycwallend04.nif,9148392834D81A17
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycwallgate01.nif,3A8E077C24063761
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaycwallgate02.nif,D55017FD0C719EE
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwayend01.nif,EC316FC5A34860F4
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwayfull02.nif,6E6311411DD96B70
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwayfull03.nif,EABF4CA923098F7A
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwayrend01.nif,E847401ECB5AF2FF
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaystairs1.nif,2279199762F2A8F9
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaystairs15.nif,9F83DEB1250738FD
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaystairs3.nif,83E1EE6C3FF37FD8
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaystairs4.nif,90EEA9AE894B8895
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/walkway/walkwaystairs8.nif,1F36A51FCBA748F2
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/solitude/farms/slumbermill01.nif,412224CF230879F2
+05 Chains 3D - Misc/meshes/architecture/riften/ratwayhall/riftenrwdoorspecial01.nif,F3063E74F153FAD8
+05 Chains 3D - Misc/meshes/architecture/whiterun/wrclutter/wrherbdryingrack01.nif,3331F9753DC8A23D
+05 Chains 3D - Misc/meshes/dungeons/ship/katariah/shipkatariahanchorchain01.nif,52945D382BDB6B55
+05 Chains 3D - Misc/meshes/dungeons/ship/katariah/shipkatariahanchorwheel01.nif,3CB1F77487DE8B88
+05 Chains 3D - Misc/meshes/dungeons/ship/questitems/shipanchorchain01.nif,E020D82AC0D90A94
+05 Chains 3D - Misc/meshes/dungeons/ship/questitems/shipanchorwheel01.nif,5532CB792FDDF591
+05 Chains 3D - Misc/textures/smim/architecture/riften/smim_RiftenDoor01.dds,80782AAEA3EDA641
+05 Chains 3D - Misc/textures/smim/architecture/riften/smim_RiftenDoor01_n.dds,F74B7AB9AE0751CE
+06 Chains 3D - Signs/meshes/clutter/signage/generic/signalchemyshop01.nif,3509523D5F5B9900
+06 Chains 3D - Signs/meshes/clutter/signage/generic/signgeneralgoods01.nif,2DFCF5111E895D15
+06 Chains 3D - Signs/meshes/clutter/signage/inns/signbraidwoodinn01.nif,8632D282264AB59A
+06 Chains 3D - Signs/meshes/clutter/signage/inns/signdeadmansdrink01.nif,78419DB61A406541
+06 Chains 3D - Signs/meshes/clutter/signage/inns/signfourshieldstavern01.nif,86A5FB7CC5F88E5D
+06 Chains 3D - Signs/meshes/clutter/signage/inns/signfrostfruitinn01.nif,9C1D6A3857A3C7BF
+06 Chains 3D - Signs/meshes/clutter/signage/inns/signfrozenhearth01.nif,10DFD8FD85B17858
+06 Chains 3D - Signs/meshes/clutter/signage/inns/signmoorsideinn01.nif,50225B52382275A1
+06 Chains 3D - Signs/meshes/clutter/signage/inns/signnightgateinn01.nif,AEA02FBF9D95425F
+06 Chains 3D - Signs/meshes/clutter/signage/inns/signoldhroldan01.nif,7A5934C7A0B8430A
+06 Chains 3D - Signs/meshes/clutter/signage/inns/signvilemyrinn01.nif,BD5874D3324A3F7F
+06 Chains 3D - Signs/meshes/clutter/signage/inns/signwindpeakinn01.nif,D13E8DAFD4092D15
+06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtalchemyshop01.nif,85097003E078EDA5
+06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtbeeandbarb01.nif,6ABA768D754706A6
+06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtblackbriarmeadery01.nif,8F4B3782E31421BB
+06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtblacksmith01.nif,ABA53EB6F559E0D
+06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtfishery01.nif,E040704F17BDE49
+06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtpawnshop.nif,D542A47ED18D3C72
+06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtpost01.nif,AEDD3E3157580296
+06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtraggedflagon01.nif,64C280197CA76936
+06 Chains 3D - Signs/meshes/clutter/signage/riften/signrtstables01.nif,4B6A76987129E0B3
+06 Chains 3D - Signs/meshes/clutter/signage/riverwood/signriverwoodriverwoodblacksmith01.nif,E54B30ABB687297E
+06 Chains 3D - Signs/meshes/clutter/signage/riverwood/signriverwoodriverwoodtrader01.nif,6FAAA60E607DC127
+06 Chains 3D - Signs/meshes/clutter/signage/riverwood/signriverwoodsleepinggiantinn01.nif,6991ED9B3AF96B14
+06 Chains 3D - Signs/meshes/clutter/signage/solitude/signsangelinesaromatics.nif,E530FACB6093BE9E
+06 Chains 3D - Signs/meshes/clutter/signage/solitude/signsbitsandpieces.nif,461845BD73E42FE
+06 Chains 3D - Signs/meshes/clutter/signage/solitude/signsfletcher.nif,5A21071F485D1723
+06 Chains 3D - Signs/meshes/clutter/signage/solitude/signsradiantraiments.nif,F19C68614E61AD91
+06 Chains 3D - Signs/meshes/clutter/signage/solitude/signswinkingskeever.nif,B2F220F71A9FF8D
+06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwralchemyshop01.nif,BE4BEDE54FB89EFD
+06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwrbanneredmare01.nif,7E83657EEB2C984B
+06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwrblacksmith01.nif,35EE4F3EC8007A6D
+06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwrdrunkenhuntsman01.nif,635973B51468BEC1
+06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwrgeneralgoods.nif,9DBE613B5C87FF77
+06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwrhonningbrewmeadery01.nif,7D6D7A6EFFB01269
+06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwrpost01.nif,55266C2604F96D2F
+06 Chains 3D - Signs/meshes/clutter/signage/whiterun/signwrstables01.nif,B5149CD9A98F5498
+06 Chains 3D - Signs/meshes/clutter/signage/windhelm/signwhalchemyshop01.nif,31033D90A0283A28
+06 Chains 3D - Signs/meshes/clutter/signage/windhelm/signwhblacksmith01.nif,70C34619CE6DF06A
+06 Chains 3D - Signs/meshes/clutter/signage/windhelm/signwhcandlehearthinn.nif,775E52F2C924C2DC
+06 Chains 3D - Signs/meshes/clutter/signage/windhelm/signwhcandlehearthinn02.nif,1E1D6D805C7C5464
+06 Chains 3D - Signs/meshes/clutter/signage/windhelm/signwhgeneralgoods.nif,9F309C2F7D6AC845
+06 Chains 3D - Signs/meshes/clutter/signage/windhelm/signwhpost01.nif,929BF6F36F8607E0
+06 Chains 3D - Signs/meshes/clutter/signage/windhelm/signwhstables01.nif,B5253CF28ED4E7D5
+06 Chains 3D - Signs/textures/smim/clutter/signage/metalwork01_brown.dds,EC6D1D0DEB249E38
+06 Chains 3D - Signs/textures/smim/clutter/signage/metalwork01_brown_n.dds,D7732E6E282E1D36
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_centurion_core.dds,795FAFDF22A2FC67
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_centurion_core_g.dds,8FE629E05D1DA1D3
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_centurion_core_m.dds,38D950DA649CC79D
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_centurion_core_n.dds,7336FE644833EC71
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_clutter_bowl.dds,D407523274326949
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_clutter_bowl_n.dds,338339BD390D6C3E
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_clutter_cup.dds,C8D1BC56869B20CD
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_clutter_cup_n.dds,8E0A7A248A222ABD
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_gyro.dds,7B8D8BE81115FB0E
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_gyro_m.dds,2F3BF5CD06E89509
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_gyro_n.dds,C1EE2356125D0175
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_scrap3.dds,AEB2C1919789727D
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_scrap3_m.dds,8BAA8FC5459E656C
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_scrap3_n.dds,A5C054B1031005DC
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_scrap4.dds,1E46C40DD9B98CFB
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_scrap4_m.dds,1B7668B3E3783269
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwemer_scrap4_n.dds,43DB6B90865584BD
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_cog01.dds,2D3F6AD018D375FF
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_cog01_m.dds,CCCF796EF2DAAFAF
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_cog01_n.dds,B53F9D7E252D0816
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_gear.dds,B55E3843C41FD499
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_gear_m.dds,F1B51E206EAB7B8D
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_gear_n.dds,6C593D29F69C623D
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_scrap1_sides.dds,1F5B8F15D5D31CDB
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_scrap1_sides_m.dds,FEA79EC6F2C5EDD9
+09 Dwemer Clutter/textures/smim/clutter/dwemer/smim_dwe_scrap1_sides_n.dds,13B1717F5BAF335E
+10 Nordic Tables and Benches/textures/smim/furniture/nordic/ruinstable_smim_vanillamix.dds,6BA0DFA195D32D35
+10 Nordic Tables and Benches/textures/smim/furniture/nordic/ruinstable_smim_vanillamix_n.dds,2A24309B4C8AAE6F
+11 Bridges/textures/smim/landscape/bridges/bridge_pillar_top.dds,A7BB1DAF63664B
+11 Bridges/textures/smim/landscape/bridges/bridge_pillar_top_n.dds,12F14019A8BE32F2
+11 Bridges/textures/smim/landscape/bridges/bridge_road_stone_tile.dds,C7DE7318851CEC00
+11 Bridges/textures/smim/landscape/bridges/bridge_road_stone_tile_n.dds,528B908FE4D56702
+11 Bridges/textures/smim/landscape/bridges/smim_bridge_dirt.dds,B1CE69993F7C8136
+11 Bridges/textures/smim/landscape/bridges/smim_bridge_dirt_n.dds,8ED62FE518091682
+11 Bridges Old Stonework/textures/smim/landscape/bridges/bridge_pillar_top.dds,A7BB1DAF63664B
+11 Bridges Old Stonework/textures/smim/landscape/bridges/bridge_pillar_top_n.dds,12F14019A8BE32F2
+11 Bridges Old Stonework/textures/smim/landscape/bridges/bridge_road_stone_tile.dds,5882A6D523B517D5
+11 Bridges Old Stonework/textures/smim/landscape/bridges/bridge_road_stone_tile_n.dds,5468AF59D9377594
+11 Bridges Real Roads/textures/smim/landscape/bridges/bridge_pillar_top.dds,A7BB1DAF63664B
+11 Bridges Real Roads/textures/smim/landscape/bridges/bridge_pillar_top_n.dds,12F14019A8BE32F2
+11 Bridges Real Roads/textures/smim/landscape/bridges/bridge_road_stone_tile.dds,C7DE7318851CEC00
+11 Bridges Real Roads/textures/smim/landscape/bridges/bridge_road_stone_tile_n.dds,528B908FE4D56702
+11 Bridges Real Roads/textures/smim/landscape/bridges/smim_bridge_dirt.dds,B1CE69993F7C8136
+11 Bridges Real Roads/textures/smim/landscape/bridges/smim_bridge_dirt_n.dds,8ED62FE518091682
+13 Lanterns/textures/smim/clutter/common/smim_lantern.dds,D0F1B96EF1443AF6
+13 Lanterns/textures/smim/clutter/common/smim_lantern_n.dds,95A22F90622874E0
+15 Clothing Fixes/meshes/armor/studded/male/body_go.nif,BD8AA41D0BEA056D
+16 Tankard Bright Brushed Metal/textures/smim/clutter/diningset/smim_tankard.dds,211FFFB202DA6E9F
+16 Tankard Bright Brushed Metal/textures/smim/clutter/diningset/smim_tankard_em.dds,95C0A7CE6712EB95
+16 Tankard Bright Brushed Metal/textures/smim/clutter/diningset/smim_tankard_n.dds,C68BB8AADD4EF929
+16 Tankard Bright Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody.dds,77BF82370383BEDF
+16 Tankard Bright Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_em.dds,345CAE275EDA52FE
+16 Tankard Bright Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_n.dds,65B5D3CA55A914E1
+16 Tankard Dark Brushed Metal/textures/smim/clutter/diningset/smim_tankard.dds,2E8FF748EDA83518
+16 Tankard Dark Brushed Metal/textures/smim/clutter/diningset/smim_tankard_em.dds,9B69429FE990B4DC
+16 Tankard Dark Brushed Metal/textures/smim/clutter/diningset/smim_tankard_n.dds,7FBC7A49A6EE21D4
+16 Tankard Dark Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody.dds,ACD8AD155B2344A6
+16 Tankard Dark Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_em.dds,305D2047C881B716
+16 Tankard Dark Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_n.dds,42674B0BC7580408
+16 Tankard Pewter Metal/textures/smim/clutter/diningset/smim_tankard.dds,ADBD73FA2E7A4908
+16 Tankard Pewter Metal/textures/smim/clutter/diningset/smim_tankard_em.dds,2BF5F8894C3C97DE
+16 Tankard Pewter Metal/textures/smim/clutter/diningset/smim_tankard_n.dds,7E9166A0BDB3C4CC
+16 Tankard Pewter Metal/textures/smim/dlc01/clutter/smim_tankard_bloody.dds,5CBE7EFE60863E17
+16 Tankard Pewter Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_em.dds,B1697E6F3BCC2504
+16 Tankard Pewter Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_n.dds,BAE3DF70E3198776
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_dome.dds,85A6150FE5926FD4
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_dome_n.dds,22BD767C262FC3D8
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_door.dds,966DD7FAE49EDCCE
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_door_n.dds,DBC6AA654FB87E55
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_metal.dds,EAFF40BDEE5E0546
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_metal_n.dds,AA1DD0AC5BA1D98D
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_spout.dds,B7F47E22180752B4
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_spout_n.dds,271D22C2C55436E2
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_stonework.dds,48BB184AE8254BEA
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_stonework_n.dds,A22E4D0597629C53
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_stucco.dds,B75FC1491F1162A6
+19 Smelter/textures/smim/furniture/smelter/smim_smelter_stucco_n.dds,57DFDFED7C24D76A
+20 Furniture Skyrim HD Appearance/textures/smim/clutter/common/dresser01.dds,36AB54D2262DEA9B
+20 Furniture Skyrim HD Appearance/textures/smim/clutter/common/dresser01_n.dds,82E8B306166D141D
+20 Furniture Skyrim HD Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece.dds,9D0F205142393E88
+20 Furniture Skyrim HD Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece_n.dds,D57071A649379EC5
+20 Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/dresser01.dds,B015EB7F370AD240
+20 Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/dresser01_n.dds,CEC68363CDFC0AB
+20 Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece.dds,D3A504B4E5AA86A1
+20 Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece_n.dds,9D2F819869D43744
+21 Dwemer Animated Lifts SE/meshes/dungeons/dwemer/facades/dwefacadeliftleverloaddown01.nif,53B942C98C6D47D4
+21 Dwemer Animated Lifts SE/meshes/dungeons/dwemer/facades/dwefacadeliftleverloadup01.nif,248516DADA30D74E
+22 Solitude Docks Ropes SE/meshes/architecture/solitude/clutter/slightpost01.nif,D1484E234C00467C
+22 Solitude Docks Ropes SE/textures/smim/architecture/docks/smim_docks_ropes.dds,B9E611B5E3E4EF08
+22 Solitude Docks Ropes SE/textures/smim/architecture/docks/smim_docks_ropes_n.dds,2225C41AADF76B06
+23 Tomato Pure Red without Blemish/textures/smim/clutter/ingredients/tomato_smim.dds,6E79367E74EA614F
+23 Tomato Pure Red without Blemish/textures/smim/clutter/ingredients/tomato_smim_n.dds,8811B6C66506F194
+25 Solitude Gate Doors/meshes/architecture/solitude/doors/sgatedoor.nif,B70356870393A939
+25 Solitude Gate Doors/meshes/architecture/solitude/doors/slgdoor01.nif,849238E2392843A4
+25 Solitude Gate Doors/textures/smim/architecture/solitude/smim_sdoorgate01.dds,97805E1EA6FC2C91
+25 Solitude Gate Doors/textures/smim/architecture/solitude/smim_sdoorgate01_n.dds,1F5D16E23FBBB177
+25 Solitude Gate Doors/textures/smim/architecture/solitude/smim_solitude_door_pattern.dds,20B51FC4B1ADE476
+25 Solitude Gate Doors/textures/smim/architecture/solitude/smim_solitude_door_pattern_n.dds,4809BB53D4D4782E
+26 Human Skull Fixes/meshes/actors/draugr/character assets/draugrskeleton.nif,9D1AC600AAE3620
+26 Human Skull Fixes/meshes/landscape/rocks/cairns/rockcairnevil01.nif,EE138B41712407AB
+26 Human Skull Fixes/meshes/landscape/rocks/cairns/rockcairnevil02.nif,919759DCFEEE9EB6
+26 Human Skull Fixes/meshes/landscape/rocks/cairns/rockcairnevil03.nif,7FB1B8E799CBE59A
+26 Human Skull Fixes/meshes/landscape/rocks/cairns/rockcairnevil04.nif,EC8534F1CE1E98A4
+27 Hawk/textures/smim/critters/fchawk/smim_hawk.dds,2FB32C2C9C46379E
+27 Hawk/textures/smim/critters/fchawk/smim_hawk_b.dds,7F335C8D992D4358
+27 Hawk/textures/smim/critters/fchawk/smim_hawk_n.dds,7D02BF61B0F1AF58
+27 Hawk/textures/smim/dlc02/critters/smim_tern.dds,45FF22892E7FD235
+29 Raven Rock 3D Ropes/textures/smim/architecture/riften/smim_riften_rope.dds,FE6C8C29D5A27B7E
+29 Raven Rock 3D Ropes/textures/smim/architecture/riften/smim_riften_rope_n.dds,7C72DBC596639122
+30 Rocks - Generic/meshes/dungeons/mines/rocks/minecboulderl02.nif,EC2C18E6BAF31A74
+33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood.dds,FFDBBAC430223E2E
+33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood_n.dds,F6EDC9094DF933E9
+33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood_segments.dds,2052FF0B1D7D757E
+33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood_segments_doorway.dds,9C71277BC88C2CFF
+33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood_segments_doorway_n.dds,395A238CA97E61DE
+33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood_segments_house.dds,F171D19E177CA638
+33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood_segments_house2.dds,30C059DC95CC658
+33 Orc Longhouse/textures/smim/architecture/orclonghouse/smim_orc_wood_segments_middle.dds,D1A6A9FB49703F96
+35 Shack Kit/textures/smim/architecture/shackkit/smim_shack_roof.dds,D56B35A1973D048F
+35 Shack Kit/textures/smim/architecture/shackkit/smim_shack_roof_n.dds,9E2DC29F504CEFCE
+37 Riften 3D Ropes/meshes/architecture/riften/docks/dockmooring01.nif,593FC61F57D28D44
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbld3waydwn01.nif,225EA3F8F870A95A
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldcor01.nif,F4634F924034CD01
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldcorin01.nif,6B29DB789766D9D5
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldcorpier01.nif,7DBAA2A49559C447
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldcorpier02.nif,42BB439B11203F30
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldcorramp01.nif,320CA1563F88CB28
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldcortostairs01.nif,F25B7901CE9EB7FF
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldstr01.nif,5CF5E0D3499152A7
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldstrbridge01.nif,F117DC1825AD7527
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldstrdbl01.nif,D73D18C7B519F283
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldstrdbl02.nif,7657903177053ACA
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldstrstairst01.nif,8F2E9BFEA74E717B
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockbldtallstairs01.nif,8C0FF5A00F9D64FC
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockpier01.nif,CC553F3EFAE43D3C
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockpier02.nif,80CF42399B3E89F8
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockpier03.nif,3A99CBBF493FFF95
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockpier03SMIM.nif,74F6E833364C9019
+37 Riften 3D Ropes/meshes/architecture/riften/docks/rtdockstairsturn01.nif,4D568F0AEB4F8F3C
+37 Riften 3D Ropes/textures/smim/architecture/riften/smim_riften_rope.dds,FE6C8C29D5A27B7E
+37 Riften 3D Ropes/textures/smim/architecture/riften/smim_riften_rope_n.dds,7C72DBC596639122
+38 Riften 3D Ropes Better Ropes Texture/textures/smim/architecture/riften/smim_riften_rope.dds,94953C9161F48D6F
+38 Riften 3D Ropes Better Ropes Texture/textures/smim/architecture/riften/smim_riften_rope_n.dds,2A241F0B38993531
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldbaseropediv01.nif,712F0E48C5772681
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldbridge01.nif,EB297532A861F74
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldbridge02.nif,4AC2E99784819D9B
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldbridge03.nif,D5926AD136F7C50C
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldbridge04.nif,ABB5D990155760F1
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreerope01.nif,C4181823075852A6
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreerope02.nif,76850ED707734A
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreerope03.nif,FF686A487B37F997
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreerope04.nif,7F7FC3DABCB60C4E
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreerope05.nif,3D7FFCC0250BA987
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreerope06.nif,7DF8464756F67BCF
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreeropeend01.nif,352BCA3BD26CA4B6
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldfreeropeend02.nif,DF25FFD6AA39B156
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldrope01.nif,A5E6A7DCD162C920
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldrope02.nif,3B2A5D88845BE381
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldrope03.nif,3EFADBF8FBB8E8BD
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldrope04.nif,8AE593A195696BCC
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldrope05.nif,16E49973621D79E7
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldrope06.nif,83BFD73F5AC86B6E
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldropelong01.nif,642D735E1D43B9BE
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldropelong02.nif,CB1E0411C5DA5D66
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldropelong03.nif,69341F552E1038AC
+39 Dungeons 3D Ropes/meshes/dungeons/mines/scaffolding/minescaffoldropelong04.nif,BAA8A353D595D935
+39 Dungeons 3D Ropes/textures/smim/dungeons/mines/smim_mines_rope.dds,AE24467508E61B5A
+39 Dungeons 3D Ropes/textures/smim/dungeons/mines/smim_mines_rope_n.dds,A7ECC2F2C8DD0E87
+39 Dungeons 3D Ropes/textures/smim/dungeons/mines/smim_wood_mine_smalltile.dds,E15DE2E1EED43EF4
+39 Dungeons 3D Ropes/textures/smim/dungeons/mines/smim_wood_mine_smalltile_n.dds,E9B44DB013145A3
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/genericwell01.nif,C6F5B10F93B7ACF
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodbeam01.nif,20160094AA515B51
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodbeam02.nif,8D9926843D0CADCE
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodbeam03.nif,70DD030D0814B29B
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodbeamshort01.nif,4FA927D1590F16ED
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodbeamshort02.nif,DE97457F948148ED
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodplanks01.nif,269E57087040E925
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodplanks02.nif,71AC6A66852D8BF9
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodplanks03.nif,B47604D7B753FB18
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/clutter/minewoodplanks04.nif,5C84997AF3E52E0A
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way01.nif,96E8D82C72193F7
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way128d01.nif,1732F317A0C53B8F
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way128l01.nif,18B947B0E60E0B21
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way128r01.nif,2237C5DE48884EDD
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way128short01.nif,8550B21F86E1C126
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way128u01.nif,A45FC4FAAF44721F
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way256short01.nif,8F393A815BD8B7BB
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way64d01.nif,6E94C33412C92B6A
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way64l01.nif,BCAFF9CA1E25A0E9
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way64r01.nif,5F56DDDDFB6C7183
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way64short01.nif,9AE2A6D8FA96978D
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall1way64u01.nif,FBFC9DAC3546513C
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall2way01.nif,D7623FD9FCFFA742
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall2way02.nif,CC34F4C3394557C6
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall3way01.nif,94D09250ED03920D
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall3way02.nif,393974C346D94AB4
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhall4way01.nif,1AB9F98C66D560A
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhallcrossover01.nif,139EA9992A1D30CC
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhalldeadend01.nif,D0C62D15A90B56D2
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhalldeadend02.nif,87B7C28F5718D818
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhalldetwist01.nif,E1A8F4FE5303A438
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhalldetwist02.nif,C06163FE463F9171
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhallentrance01.nif,6CB477F3009F62FB
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhallentrance02.nif,5A67979D61EBBC43
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhallramp01.nif,5D25C84B325976B2
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/minelargehall/minelhallramp02.nif,254017AA54980022
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minerailramp01.nif,2D2E7A50288BF2BE
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minerailtop1sided01.nif,E657E027B72E423F
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minerailtop2sided01.nif,547E21B048DA380A
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minerailtop2sided02.nif,DC3F95F6BBF7A68D
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minerailtop3sided01.nif,83CEB05515AC4851
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minerailtop4sided01.nif,2732A1398B2C5DA6
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbase0sided01.nif,7588C9831B94E261
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbase1sided01.nif,5D2AF5416C1E31A4
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbase2sided01.nif,1BC2EEBE37602FC7
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbase2sided02.nif,45D16CA0D0C9B24E
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbase3sided01.nif,16EE840B28384256
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbase4sided01.nif,6CB55998027E8F
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbaseropediv01.nif,712F0E48C5772681
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbasesupport01.nif,19D19971F23971E
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbasesupportw01.nif,99C993EADCD04803
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbridge01.nif,149AE7D45E59A9EF
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbridge02.nif,AE776040733A2171
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbridge03.nif,654A9EBE8D39636E
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldbridge04.nif,8AE989F711FD88B1
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreerope01.nif,C4181823075852A6
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreerope02.nif,76850ED707734A
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreerope03.nif,FF686A487B37F997
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreerope04.nif,7F7FC3DABCB60C4E
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreerope05.nif,3D7FFCC0250BA987
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreerope06.nif,7DF8464756F67BCF
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreeropeend01.nif,352BCA3BD26CA4B6
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldfreeropeend02.nif,DF25FFD6AA39B156
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldramp01.nif,EDF4ED0F4363408C
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldrope01.nif,A5E6A7DCD162C920
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldrope02.nif,3B2A5D88845BE381
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldrope03.nif,3EFADBF8FBB8E8BD
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldrope04.nif,8AE593A195696BCC
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldrope05.nif,16E49973621D79E7
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldrope06.nif,83BFD73F5AC86B6E
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldropelong01.nif,642D735E1D43B9BE
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldropelong02.nif,CB1E0411C5DA5D66
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldropelong03.nif,69341F552E1038AC
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldropelong04.nif,BAA8A353D595D935
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldsupport01.nif,B0C49660A77C7ADE
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldtop0sided01.nif,5E59554F4A25E83E
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldtop1sided01.nif,AAD43A56800BE03C
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldtop2sided01.nif,5A7CB9A355DCAA36
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldtop2sided02.nif,B331280A15709D99
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldtop3sided01.nif,B287FFA5DB6997F8
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldtop4sided01.nif,FEAF5E33DA69FF93
+39 Dungeons 3D Ropes and Glorious Scaffolding/meshes/dungeons/mines/scaffolding/minescaffoldtopcross01.nif,B33C2B8416ECD2AC
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_mines_rope.dds,AE24467508E61B5A
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_mines_rope_n.dds,A7ECC2F2C8DD0E87
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_beamsupport_thirdstile.dds,835460D5CC2DC092
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_beamsupport_thirdstile_n.dds,59D710BE2A33EE9
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_beams_1k_support_corners.dds,421827927A16C7CC
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_beams_1k_support_corners_n.dds,35BED5C625DBD31
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_beams_x4_seamless.dds,DFD82564FA928043
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_beams_x4_seamless_n.dds,4A8F4084CADCD22F
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_planks.dds,26579F49D1AF0B7D
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_planks_n.dds,68212FD78937326B
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_smalltile.dds,E15DE2E1EED43EF4
+39 Dungeons 3D Ropes and Glorious Scaffolding/textures/smim/dungeons/mines/smim_wood_mine_smalltile_n.dds,E9B44DB013145A3
+40 Furniture Chests/meshes/clutter/containers/chest01/chest01.nif,B2B90B00E1A640D
+40 Furniture Chests/textures/smim/clutter/upperclass/smim_upperchest.dds,23120579F6FB76AA
+40 Furniture Chests/textures/smim/clutter/upperclass/smim_upperchest_n.dds,AB62549D8E377DD
+40 Furniture Chests/textures/smim/clutter/upperclass/smim_upperchest_weathered.dds,487D6162A8D073FD
+40 Furniture Chests/textures/smim/clutter/upperclass/smim_upperchest_weathered_snow.dds,6C0998845BD6ABA7
+42 Furniture Noble/textures/smim/furniture/noble/SMIMNobleChair.dds,A3D55419893C918
+42 Furniture Noble/textures/smim/furniture/noble/SMIMNobleChair_n.dds,EDCEC610E48C094C
+43 Whiterun Castle Wood Carvings Celtic/meshes/uskp/architecture/whiterun/wrintcastlefreepillar01uskp.nif,DB95BA36768A5F64
+43 Whiterun Castle Wood Carvings Celtic/textures/smim/architecture/whiterun/wrcastlecarvings.dds,9834A23042553B88
+43 Whiterun Castle Wood Carvings Celtic/textures/smim/architecture/whiterun/wrcastlecarvings_n.dds,E04135B55740C14D
+43 Whiterun Castle Wood Carvings Moroccan/meshes/uskp/architecture/whiterun/wrintcastlefreepillar01uskp.nif,DB95BA36768A5F64
+43 Whiterun Castle Wood Carvings Moroccan/textures/smim/architecture/whiterun/wrcastlecarvings.dds,8647863771DD8062
+43 Whiterun Castle Wood Carvings Moroccan/textures/smim/architecture/whiterun/wrcastlecarvings_n.dds,5B6E202A6ED3D20B
+43 Whiterun Castle Wood Carvings Vanilla/meshes/uskp/architecture/whiterun/wrintcastlefreepillar01uskp.nif,DB95BA36768A5F64
+43 Whiterun Castle Wood Carvings Vanilla/textures/smim/architecture/whiterun/wrcastlecarvings.dds,365B2A3E3FE456F
+43 Whiterun Castle Wood Carvings Vanilla/textures/smim/architecture/whiterun/wrcastlecarvings_n.dds,C1F8D33E87590436
+44 Poor Coffin Custom Texture/textures/smim/furniture/noble/smim_poor_coffin.dds,49DA056D19147AA6
+44 Poor Coffin Custom Texture/textures/smim/furniture/noble/smim_poor_coffin_n.dds,95DEE84186689B94
+45 Hanging Rings/meshes/_byoh/clutter/dead animals/hanginganimalsring03.nif,68BCE0AE07626323
+45 Hanging Rings/textures/smim/clutter/deadanimals/smim_metalhanger_deadanimals.dds,9FC093155AFAF545
+45 Hanging Rings/textures/smim/clutter/deadanimals/smim_metalhanger_deadanimals_n.dds,817F56FD827A4AEB
+46 Carriage Seats and Fixes/meshes/Actors/horse/character assets/harness.nif,FC7E9F70BA7D82CA
+46 Carriage Seats and Fixes/textures/smim/furniture/prisonercarriage/smim_carriage_metal.dds,F1BBACCF4C2071F1
+46 Carriage Seats and Fixes/textures/smim/furniture/prisonercarriage/smim_carriage_metal_n.dds,A1C11EA84467067
+46 Carriage Seats and Fixes/textures/smim/furniture/prisonercarriage/smim_carriage_seat.dds,4BDA1DC014D43733
+46 Carriage Seats and Fixes/textures/smim/furniture/prisonercarriage/smim_carriage_seat_n.dds,B3B714230EE0F2B
+49 Tundra Tree/textures/smim/landscape/trees/smim_tundra_tree.dds,EF9ED9291C1A17E8
+49 Tundra Tree/textures/smim/landscape/trees/smim_tundra_tree_n.dds,C731EE68E03B36A9
+50 Dawnguard Soulcairn Bone Piles/textures/smim/dlc01/soulcairn/smim_soulcairn_bone.dds,C0148154214E61D7
+50 Dawnguard Soulcairn Bone Piles/textures/smim/dlc01/soulcairn/smim_soulcairn_bone_n.dds,86C12012B66CD2D6
+50 Dawnguard Soulcairn Bone Piles/textures/smim/dlc01/soulcairn/smim_soulcairn_skeleton.dds,A281C06B22763F05
+50 Dawnguard Soulcairn Bone Piles/textures/smim/dlc01/soulcairn/smim_soulcairn_skeleton_n.dds,5CEC730DADB3C56A
+52 Dawnguard Soulcairn Bone Piles (White Bones)/textures/smim/dlc01/soulcairn/smim_soulcairn_bone.dds,5E3DBC794B4E6FA0
+52 Dawnguard Soulcairn Bone Piles (White Bones)/textures/smim/dlc01/soulcairn/smim_soulcairn_skeleton.dds,FF6FFFF06E80A17C
+53 Imperial Jail/meshes/dungeons/imperial/jail/impjaildoor01.nif,151D98AFA912B54B
+53 Imperial Jail/meshes/dungeons/imperial/jail/impjaildoor02.nif,8FAEB72E750F8DFA
+53 Imperial Jail/meshes/dungeons/imperial/jail/impjaildoorframe01.nif,4FE61C31916A3227
+53 Imperial Jail/meshes/dungeons/imperial/jail/impjailpole01.nif,AD4FEA4C343AEFFF
+53 Imperial Jail/meshes/dungeons/imperial/jail/impjailtop01.nif,3144C4E752ECD26A
+53 Imperial Jail/meshes/dungeons/imperial/jail/impjailwall01.nif,27269114D053C91
+53 Imperial Jail/meshes/dungeons/imperial/jail/impjailwall02.nif,D7D03C77032FD561
+53 Imperial Jail/meshes/dungeons/imperial/jail/impjailwall03.nif,DE7B36C71041893A
+53 Imperial Jail/textures/smim/dungeons/imperial/smim_imp_gate_pole.dds,E01B640C97DBF5C7
+53 Imperial Jail/textures/smim/dungeons/imperial/smim_imp_gate_pole_n.dds,CB039CEA7080F72B
+54 Imperial Jail Brighter Metal/textures/smim/dungeons/imperial/smim_imp_gate_pole.dds,B3F57344B45C98ED
+55 Windmills Base Vanilla Version/meshes/architecture/farmhouse/farmhousewindmill/farmhousewindmillfan.nif,758E10A13F754C2C
+55 Windmills Base Vanilla Version/textures/smim/architecture/farmhouse/smim_windmill_fan.dds,FC1C69B53434BBAD
+55 Windmills Base Vanilla Version/textures/smim/architecture/farmhouse/smim_windmill_fan_n.dds,F06A9D8CA1A70E54
+55 Windmills Base Vanilla Version Sails/meshes/architecture/farmhouse/farmhousewindmill/farmhousewindmillfan.nif,51075E4E970A0B9
+55 Windmills Base Vanilla Version Sails/textures/smim/architecture/farmhouse/smim_windmill_fan.dds,FC1C69B53434BBAD
+55 Windmills Base Vanilla Version Sails/textures/smim/architecture/farmhouse/smim_windmill_fan_n.dds,F06A9D8CA1A70E54
+55 Windmills Base Vanilla Version Sails/textures/smim/architecture/farmhouse/smim_windmill_sail.dds,E2A487C6D8666060
+55 Windmills Base Vanilla Version Sails/textures/smim/architecture/farmhouse/smim_windmill_sail_n.dds,32A9BDE5AD76D277
+55 Windmills Base Vanilla Version Sails/textures/smim/architecture/farmhouse/smim_windmill_sail_solitude.dds,3A6848780301F804
+56 Windmills SkyMills Compatibility/meshes/architecture/farmhouse/farmhousewindmill/farmhousewindmillfan02.nif,BF64A470BA7E365B
+56 Windmills SkyMills Compatibility/meshes/architecture/farmhouse/farmhousewindmill/smfarmhousewindmillfan.nif,2E21E7310DA22334
+56 Windmills SkyMills Compatibility Sails/meshes/architecture/farmhouse/farmhousewindmill/farmhousewindmillfan02.nif,A08771E0A8066461
+56 Windmills SkyMills Compatibility Sails/meshes/architecture/farmhouse/farmhousewindmill/smfarmhousewindmillfan.nif,5F0304E8D62FD9C5
+57 Ruins Sarcophagus/meshes/clutter/ruins/sarcophaguslid/norsarcophagustopanim01.nif,AC893F87B9655743
+57 Ruins Sarcophagus/meshes/clutter/ruins/sarcophaguslidvert/sarcophagus_topvert01.nif,59CD74D2EC43A4C5
+57 Ruins Sarcophagus/textures/smim/clutter/ruins/smim_ruins_sarcophagus_parts.dds,C77CAC3D15F3E2D7
+57 Ruins Sarcophagus/textures/smim/clutter/ruins/smim_ruins_sarcophagus_parts_n.dds,6A035BB842AB3114
+57 Ruins Sarcophagus/textures/smim/clutter/ruins/smim_ruins_sarcophagus_tub.dds,41F0D2EC8C4C5342
+57 Ruins Sarcophagus/textures/smim/clutter/ruins/smim_ruins_sarcophagus_tub_n.dds,379BD85074D2A52B
+58 Jewelry Rings/textures/smim/armor/amuletsandrings/smim_my_precious.dds,B2685D0966576F86
+58 Jewelry Rings/textures/smim/armor/amuletsandrings/smim_my_precious_n.dds,F67D6574BCB8D25E
+60 Hearthfires Stuff/meshes/_byoh/clutter/house crafting/lock01.nif,5788344CB13E1BBA
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_bonemeal.dds,82D29725F9F8A14C
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_bonemeal_n.dds,88C5AA2700B296E3
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_ectoplasm.dds,3D0BF5EF7E1FC4D6
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_ectoplasm_g.dds,5799AE06B888A4F5
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_ectoplasm_n.dds,B7109FE07F29A813
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_ingredient_bowl.dds,7CC6788629112805
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_ingredient_bowl_n.dds,673FB73261834871
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_ingredient_bowl_spriggansap.dds,F2DBB9FD45349BC2
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_ingredient_bowl_vampire.dds,9F6EA4907D5B5905
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_moonsugar_bowl.dds,CE5A2DE3B60A9A79
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_moonsugar_bowl_n.dds,744A8B27C388F598
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_saltglow.dds,A0965F37D32DC671
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_saltpile.dds,DD22069EC69B4D2A
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_saltpile_n.dds,59343460C67F3B3D
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_stew_bowl.dds,5FDF09CE597C3077
+61 Bowl Ingredients/textures/smim/clutter/ingredients/smim_stew_bowl_n.dds,7DFC4B5248574B96
+70 Rabbit/textures/smim/actors/hare/smim_rabbit.dds,238DE76C5218E6B5
+70 Rabbit/textures/smim/actors/hare/smim_rabbit_blood.dds,2140648E0AF54248
+70 Rabbit/textures/smim/actors/hare/smim_rabbit_n.dds,837AD775EC451136
+71 Candelabras Sconces Walltorches/textures/smim/clutter/common/smim_imperial_torch.dds,3B43FBB039B26AD3
+71 Candelabras Sconces Walltorches/textures/smim/clutter/common/smim_imperial_torch_n.dds,2CCFAD18A41CD3E4
+71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_candelabra.dds,AEC7EF3E25EA0E25
+71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_candelabra_gray.dds,5E5E6EA629F4933B
+71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_candelabra_n.dds,C8559CB0A970EEFD
+71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_imperial_brazier.dds,B8E3A5B90D9FF09B
+71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_imperial_brazier_n.dds,DC27BB16E9F8E6E8
+71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_imperial_sconce.dds,CA12B1C69710FC01
+71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_imperial_sconce_n.dds,994D4D4C0B8740B8
+71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_trap_pressure_plate.dds,D9FD9CF76C8BD3E9
+71 Candelabras Sconces Walltorches/textures/smim/clutter/imperial/smim_trap_pressure_plate_n.dds,65A3F2EB9C859ED9
+72 Chandeliers/meshes/uskp/clutter/chandellier/impchandelliercandle01uskp.nif,3A3594674D18BC13
+72 Chandeliers/meshes/uskp/clutter/chandellier/impchandellierextensionmeduskp.nif,EF887A92051DB6CD
+72 Chandeliers/meshes/uskp/clutter/chandellier/impchandellierextensionshortuskp.nif,3A0DDF4F9A1AD49D
+72 Chandeliers/textures/smim/clutter/imperial/smim_candelabra.dds,AEC7EF3E25EA0E25
+72 Chandeliers/textures/smim/clutter/imperial/smim_candelabra_gray.dds,5E5E6EA629F4933B
+72 Chandeliers/textures/smim/clutter/imperial/smim_candelabra_n.dds,C8559CB0A970EEFD
+72 Chandeliers/textures/smim/clutter/imperial/smim_imperial_chains.dds,BCFDA412A954CEA5
+72 Chandeliers/textures/smim/clutter/imperial/smim_imperial_chains_gray.dds,99518B7B543C4C32
+72 Chandeliers/textures/smim/clutter/imperial/smim_imperial_chains_n.dds,DB39C8BC609DA89
+72 Chandeliers/textures/smim/clutter/imperial/smim_imperial_sconce_gray.dds,8F2BF03E40947112
+72 Chandeliers/textures/smim/clutter/imperial/smim_imperial_sconce_n.dds,994D4D4C0B8740B8
+73 Chandeliers No 3D Chains Addon/meshes/uskp/clutter/chandellier/impchandelliercandle01uskp.nif,59B5D7940CD81F2B
+73 Chandeliers No 3D Chains Addon/meshes/uskp/clutter/chandellier/impchandellierextensionmeduskp.nif,38F973790C19698C
+73 Chandeliers No 3D Chains Addon/meshes/uskp/clutter/chandellier/impchandellierextensionshortuskp.nif,29F02306C8CAAF2A
+80 Half-Sized Textures/textures/smim/architecture/docks/smim_docks_ropes.dds,A6E72B86092358C8
+80 Half-Sized Textures/textures/smim/architecture/docks/smim_docks_ropes_n.dds,7347422001A0C652
+80 Half-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_fan.dds,F94061A2CDAC03FE
+80 Half-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_fan_n.dds,A781EE19FE3EE8FC
+80 Half-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_sail.dds,432F267B8B8C58F6
+80 Half-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_sail_n.dds,6E91B6AA5ED4323C
+80 Half-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_sail_solitude.dds,5D7FBA278F841994
+80 Half-Sized Textures/textures/smim/architecture/riften/smim_RiftenDoor01.dds,46FA7DA51B53BA2F
+80 Half-Sized Textures/textures/smim/architecture/riften/smim_RiftenDoor01_n.dds,672A2C6C97AF875
+80 Half-Sized Textures/textures/smim/architecture/shackkit/smim_shack_roof.dds,71F6708FEE6CB4BD
+80 Half-Sized Textures/textures/smim/architecture/shackkit/smim_shack_roof_n.dds,81E30757AA7E7D9F
+80 Half-Sized Textures/textures/smim/architecture/solitude/smim_solitude_door_pattern.dds,A2E6EA4F7F785089
+80 Half-Sized Textures/textures/smim/architecture/solitude/smim_solitude_door_pattern_n.dds,48F1FD3C573A0645
+80 Half-Sized Textures/textures/smim/architecture/whiterun/smim_wr_bench.dds,70C567BDFBB1C261
+80 Half-Sized Textures/textures/smim/architecture/whiterun/smim_wr_bench_n.dds,3DD0DC1A9051888A
+80 Half-Sized Textures/textures/smim/armor/amuletsandrings/smim_my_precious.dds,3C12050A0D03CEA4
+80 Half-Sized Textures/textures/smim/armor/amuletsandrings/smim_my_precious_n.dds,27C4ED90BB3A08C3
+80 Half-Sized Textures/textures/smim/clutter/common/dresser01.dds,7E15D594DEBC12AA
+80 Half-Sized Textures/textures/smim/clutter/common/dresser01_n.dds,4B19AD8165185A58
+80 Half-Sized Textures/textures/smim/clutter/common/smim_imperial_torch.dds,9CF6C276F5647FD5
+80 Half-Sized Textures/textures/smim/clutter/common/smim_imperial_torch_n.dds,DD03972CF86F860F
+80 Half-Sized Textures/textures/smim/clutter/common/smim_lantern.dds,B01D47CA5ECAF0B1
+80 Half-Sized Textures/textures/smim/clutter/common/smim_lantern_n.dds,14CFAEB63533ED3A
+80 Half-Sized Textures/textures/smim/clutter/common/smim_quill.dds,C1EF0B939C29C3F4
+80 Half-Sized Textures/textures/smim/clutter/common/smim_quill_n.dds,E22F7A89A8C19DE3
+80 Half-Sized Textures/textures/smim/clutter/common/Stump_Bottom_for_Furniture.dds,FF48EB31AB4E14BF
+80 Half-Sized Textures/textures/smim/clutter/common/Stump_Bottom_for_Furniture_n.dds,E723258FDFEDBE77
+80 Half-Sized Textures/textures/smim/clutter/common/Table_Leg_Bark.dds,17E1004979F33140
+80 Half-Sized Textures/textures/smim/clutter/common/Table_Leg_Bark_n.dds,F36391AD49850122
+80 Half-Sized Textures/textures/smim/clutter/common/Table_Leg_Bark_Seamless.dds,BB46513138670A16
+80 Half-Sized Textures/textures/smim/clutter/common/Table_Leg_Bark_Seamless_n.dds,FB4978F9804F364C
+80 Half-Sized Textures/textures/smim/clutter/common/Table_Leg_Bark_Thin.dds,8ED2131440EFF2C2
+80 Half-Sized Textures/textures/smim/clutter/common/Table_Leg_Bark_Thin_n.dds,8F8A40C3649C16A3
+80 Half-Sized Textures/textures/smim/clutter/common/Table_Wood_SinglePiece.dds,C1312AFE19ADC2B2
+80 Half-Sized Textures/textures/smim/clutter/common/Table_Wood_SinglePiece_n.dds,DF39549E883DCD1C
+80 Half-Sized Textures/textures/smim/clutter/deadanimals/smim_metalhanger_deadanimals.dds,C9CC4C8073AEAD21
+80 Half-Sized Textures/textures/smim/clutter/deadanimals/smim_metalhanger_deadanimals_n.dds,204D32CCC7DEFE13
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_centurion_core.dds,41E6B1A38D4D6C6C
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_centurion_core_g.dds,C240B06BAA294CA5
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_centurion_core_m.dds,B85BEC2747C4740A
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_centurion_core_n.dds,2D241BF9BC55E76
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_clutter_bowl.dds,FB0DE7BDE74639CE
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_clutter_bowl_n.dds,9C410C574749DF9C
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_clutter_cup.dds,113E26859FCE2EB
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_clutter_cup_n.dds,17B3FF039D436EDA
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_gyro.dds,D0CC627E5DF50600
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_gyro_m.dds,26EE0FDE5017FB3
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_gyro_n.dds,4810B0192C984263
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_scrap3.dds,A65BEBF49BC1BD50
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_scrap3_m.dds,83AD606DCCDEED75
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_scrap3_n.dds,7D661AC63DEC50F3
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_scrap4.dds,43EDF1D0813AE706
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_scrap4_m.dds,71F3E2CCA79D20A0
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwemer_scrap4_n.dds,570C1EAD305DF5C3
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_cog01.dds,4150938599AC1D82
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_cog01_m.dds,310C4CEA18C12FD2
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_cog01_n.dds,C773775C6FE453B5
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_gear.dds,A963DE60EA9A50C6
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_gear_m.dds,2AE5A676A85451DB
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_gear_n.dds,2950557864EE2CC9
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_scrap1_sides.dds,72289EF379AACF4E
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_scrap1_sides_m.dds,13C751501422AFF
+80 Half-Sized Textures/textures/smim/clutter/dwemer/smim_dwe_scrap1_sides_n.dds,6AC8B5BC91FC3C89
+80 Half-Sized Textures/textures/smim/clutter/food/apple01_semi-circle-UV.dds,9679ED3DCDCBA653
+80 Half-Sized Textures/textures/smim/clutter/food/apple01_semi-circle-UV_n.dds,95E4793CAEF776B4
+80 Half-Sized Textures/textures/smim/clutter/food/apple02_semi-circle-UV.dds,32B3A327AF902605
+80 Half-Sized Textures/textures/smim/clutter/food/apple02_semi-circle-UV_n.dds,95E4793CAEF776B4
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_candelabra.dds,FC891DCFC0D39412
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_candelabra_gray.dds,7C4DD4AD2B4F6E02
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_candelabra_n.dds,D0BD96FA1499FC53
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_brazier.dds,8C91FC8500DBE2B0
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_brazier_n.dds,397E05094844E17C
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_chains.dds,89ABB6FEF00E82ED
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_chains_gray.dds,8DA2FBFD5C269E45
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_chains_n.dds,7C99BEEA52D48A89
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_sconce.dds,E1A3DCA9ABE750BA
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_sconce_gray.dds,1B0D2BAAC18015D1
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_imperial_sconce_n.dds,7B6EE5129BAD27AA
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_trap_pressure_plate.dds,93781D18719FF71F
+80 Half-Sized Textures/textures/smim/clutter/imperial/smim_trap_pressure_plate_n.dds,225B6506CD9C43A4
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_bonemeal.dds,47BBEB65F5EFE470
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_bonemeal_n.dds,5ADD524FDB297B11
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_dwarven_oil.dds,BE8B528DC9ABD995
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_dwarven_oilspill.dds,FC39A42D7D01D3A0
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_dwarven_oilspill_n.dds,E981012EC23D737F
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_dwarven_oil_m.dds,7567F85C559DBF6F
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_dwarven_oil_n.dds,B5BBFBE933CDD406
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_ectoplasm.dds,EF33BC7A357ADC3E
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_ectoplasm_g.dds,5B7EA8751D130F28
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_ectoplasm_n.dds,715D313E5278AC6E
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_hagclaw.dds,A2C3EAB2E0076D89
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_hagclaw_n.dds,2BED1FB5BECD07D4
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_ingredient_bowl.dds,7CC6788629112805
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_ingredient_bowl_n.dds,673FB73261834871
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_ingredient_bowl_spriggansap.dds,9FDF16BA2A4B6652
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_ingredient_bowl_vampire.dds,C5EA870EC78498FA
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_moonsugar_bowl.dds,E6E5B7E8D444B227
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_moonsugar_bowl_n.dds,7675548AB49AFEC1
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_sabrecat_tooth.dds,47DBF59AC2EB524D
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_sabrecat_tooth_n.dds,53F1C51941DAB01A
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_saltglow.dds,3D2FE16981DFA894
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_saltpile.dds,23462FE15A32BE8C
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_saltpile_n.dds,39FCD447AA7285D9
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_stew_bowl.dds,EFEED27C50AEF712
+80 Half-Sized Textures/textures/smim/clutter/ingredients/smim_stew_bowl_n.dds,F6D6DED49F226427
+80 Half-Sized Textures/textures/smim/clutter/quest/smim_giant_mortar.dds,CCCD562668D40D81
+80 Half-Sized Textures/textures/smim/clutter/quest/smim_giant_mortar_n.dds,B7D5865622124711
+80 Half-Sized Textures/textures/smim/clutter/ruins/ruinschest.dds,E04A2A46D187A3B5
+80 Half-Sized Textures/textures/smim/clutter/ruins/ruinschestsmall.dds,9E9646B60A8C86E9
+80 Half-Sized Textures/textures/smim/clutter/ruins/ruinschestsmall_n.dds,97143E18715505F0
+80 Half-Sized Textures/textures/smim/clutter/ruins/ruinschest_n.dds,A5C7D6C0864BE40C
+80 Half-Sized Textures/textures/smim/clutter/ruins/smim_ruinspot01.dds,9B2548B668FBDC47
+80 Half-Sized Textures/textures/smim/clutter/ruins/smim_ruinspot01_n.dds,7574DAB7088267F5
+80 Half-Sized Textures/textures/smim/clutter/ruins/smim_ruins_sarcophagus_parts.dds,98FBCAD49910B4AB
+80 Half-Sized Textures/textures/smim/clutter/ruins/smim_ruins_sarcophagus_parts_n.dds,AF49D9BB5AFEAFFC
+80 Half-Sized Textures/textures/smim/clutter/ruins/smim_ruins_sarcophagus_tub.dds,915A7B00571F6A52
+80 Half-Sized Textures/textures/smim/clutter/ruins/smim_ruins_sarcophagus_tub_n.dds,2F04152ABB354528
+80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest.dds,DBA253EA87E1200E
+80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest_n.dds,624843675387C246
+80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest_weathered.dds,3B1C21E1DAA20894
+80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest_weathered_snow.dds,133000B536DBA1A3
+80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upper_bedpost.dds,CB23656DD27F1579
+80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upper_bedpost_n.dds,AB28F90F0C0DBB87
+80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upper_bench_legs.dds,F3B8EAB46C804AB2
+80 Half-Sized Textures/textures/smim/clutter/upperclass/smim_upper_bench_legs_n.dds,B6C80474D121A3AD
+80 Half-Sized Textures/textures/smim/clutter/upperclass/Table_Leg_Bark_Thin.dds,50FFACE2FFCD02E4
+80 Half-Sized Textures/textures/smim/clutter/upperclass/Table_Leg_Bark_Thin_n.dds,996E53E715BCFDA7
+80 Half-Sized Textures/textures/smim/clutter/upperclass/Table_Wood_SinglePiece.dds,B01E75E25406D9C6
+80 Half-Sized Textures/textures/smim/clutter/upperclass/Table_Wood_SinglePiece_n.dds,DF39549E883DCD1C
+80 Half-Sized Textures/textures/smim/clutter/woodfires/smim_campfire_rocks.dds,9E1986A09F5DA0A5
+80 Half-Sized Textures/textures/smim/clutter/woodfires/smim_campfire_rocks_n.dds,D1D5746772AC9E39
+80 Half-Sized Textures/textures/smim/critters/fchawk/smim_hawk.dds,E26E3A3CC56C508
+80 Half-Sized Textures/textures/smim/critters/fchawk/smim_hawk_b.dds,A428B727825AA0B2
+80 Half-Sized Textures/textures/smim/critters/fchawk/smim_hawk_n.dds,2AC59A3DF921503B
+80 Half-Sized Textures/textures/smim/dlc02/critters/smim_tern.dds,BF9A1086AA02326A
+80 Half-Sized Textures/textures/smim/dungeons/dwemer/smim_dwemer_focus_rock.dds,19C770B640344638
+80 Half-Sized Textures/textures/smim/dungeons/dwemer/smim_dwemer_focus_rock_n.dds,8674D37B2A0CE976
+80 Half-Sized Textures/textures/smim/dungeons/mines/smim_wood_mine_beams_x4_seamless.dds,CB342F5895E8CD3D
+80 Half-Sized Textures/textures/smim/dungeons/mines/smim_wood_mine_beams_x4_seamless_n.dds,D3D4256206FBC473
+80 Half-Sized Textures/textures/smim/dungeons/mines/smim_wood_mine_planks.dds,7F7C0752772E4F0F
+80 Half-Sized Textures/textures/smim/dungeons/mines/smim_wood_mine_planks_n.dds,1E4C9EB2ED336D65
+80 Half-Sized Textures/textures/smim/dungeons/mines/smim_wood_mine_smalltile.dds,E15DE2E1EED43EF4
+80 Half-Sized Textures/textures/smim/dungeons/mines/smim_wood_mine_smalltile_n.dds,E9B44DB013145A3
+80 Half-Sized Textures/textures/smim/furniture/noble/smim_poor_coffin.dds,7A0A8B87D05D71AB
+80 Half-Sized Textures/textures/smim/furniture/noble/smim_poor_coffin_n.dds,86D13AC1E63A0FA7
+80 Half-Sized Textures/textures/smim/furniture/nordic/ruinstable_smim_vanillamix.dds,1E5F8E718305E6F8
+80 Half-Sized Textures/textures/smim/furniture/nordic/ruinstable_smim_vanillamix_n.dds,A1E497D6A265EFA
+80 Half-Sized Textures/textures/smim/furniture/prisonercarriage/smim_carriage_metal.dds,EE88AEDCB774B9DA
+80 Half-Sized Textures/textures/smim/furniture/prisonercarriage/smim_carriage_metal_n.dds,C58BFCC52B1B35E4
+80 Half-Sized Textures/textures/smim/furniture/prisonercarriage/smim_carriage_seat.dds,E466B0F72A230B61
+80 Half-Sized Textures/textures/smim/furniture/prisonercarriage/smim_carriage_seat_n.dds,F0BCE043E223EC0
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_dome.dds,9F3FE782EBE940E6
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_dome_n.dds,274CEAAF4D5B00A6
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_door.dds,648F819C6EA53ACB
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_door_n.dds,D4C6858296B2C6FD
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_metal.dds,8370F3C0789D9132
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_metal_n.dds,61AD8ADB827A95E5
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_spout.dds,D58F066E91AB71E9
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_spout_n.dds,17612DB1888DDB5B
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stonework.dds,A592362F2D0ED117
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stonework_n.dds,C0E1828C684BBFA0
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stucco.dds,35B095E23D57D0A6
+80 Half-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stucco_n.dds,B1C6DD30C2EA5323
+80 Half-Sized Textures/textures/smim/landscape/bridges/bridge_pillar_top.dds,D8F0D330190BEBF7
+80 Half-Sized Textures/textures/smim/landscape/bridges/bridge_pillar_top_n.dds,8FD67D13F90BD768
+80 Half-Sized Textures/textures/smim/landscape/bridges/bridge_road_stone_tile.dds,DCFACDE8B51F9551
+80 Half-Sized Textures/textures/smim/landscape/bridges/bridge_road_stone_tile_n.dds,8496F4AF42B11410
+80 Half-Sized Textures/textures/smim/landscape/bridges/smim_bridge_dirt.dds,58EAF4C8E7A77C66
+80 Half-Sized Textures/textures/smim/landscape/bridges/smim_bridge_dirt_n.dds,2460CE3121C73933
+80 Half-Sized Textures/textures/smim/landscape/trees/smim_tundra_tree.dds,FBB18A4E0C90FDFA
+80 Half-Sized Textures/textures/smim/landscape/trees/smim_tundra_tree_n.dds,445202ABCD4AC489
+81 Half-Sized Furniture Skyrim HD Appearance/textures/smim/clutter/common/dresser01.dds,4370C241934045EC
+81 Half-Sized Furniture Skyrim HD Appearance/textures/smim/clutter/common/dresser01_n.dds,E8ABB307D4A1BD3B
+81 Half-Sized Furniture Skyrim HD Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece.dds,A7F4417FFDF8270D
+81 Half-Sized Furniture Skyrim HD Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece_n.dds,5C1F529A2639B68A
+81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/dresser01.dds,2A88C06AD81B53AD
+81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/dresser01_n.dds,E2500A3B1EC47D3D
+81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece.dds,AB6B20E93AECA20C
+81 Half-Sized Furniture Skyrim HD Weathered Appearance/textures/smim/clutter/common/Table_Wood_SinglePiece_n.dds,CE40022AF9E1A044
+84 Half-Sized Textures Tankard Bright Brushed Metal/textures/smim/clutter/diningset/smim_tankard.dds,50DDE6CB9E45F31D
+84 Half-Sized Textures Tankard Bright Brushed Metal/textures/smim/clutter/diningset/smim_tankard_em.dds,3B89DE1D4C18A4CC
+84 Half-Sized Textures Tankard Bright Brushed Metal/textures/smim/clutter/diningset/smim_tankard_n.dds,24E39D0700FA9D9D
+84 Half-Sized Textures Tankard Bright Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody.dds,1021FDB95267FEE4
+84 Half-Sized Textures Tankard Bright Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_em.dds,384301ED314CA93D
+84 Half-Sized Textures Tankard Bright Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_n.dds,2C276FDEB261964D
+84 Half-Sized Textures Tankard Dark Brushed Metal/textures/smim/clutter/diningset/smim_tankard.dds,D035F280A1F7AFE2
+84 Half-Sized Textures Tankard Dark Brushed Metal/textures/smim/clutter/diningset/smim_tankard_em.dds,1429E76DB5F1C905
+84 Half-Sized Textures Tankard Dark Brushed Metal/textures/smim/clutter/diningset/smim_tankard_n.dds,1756A29429F33439
+84 Half-Sized Textures Tankard Dark Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody.dds,F5CAC14EA674D7E3
+84 Half-Sized Textures Tankard Dark Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_em.dds,57AB7B3BEAFE8C1
+84 Half-Sized Textures Tankard Dark Brushed Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_n.dds,262FE896A35688BF
+84 Half-Sized Textures Tankard Pewter Metal/textures/smim/clutter/diningset/smim_tankard.dds,C7F8F4199F9EFFA1
+84 Half-Sized Textures Tankard Pewter Metal/textures/smim/clutter/diningset/smim_tankard_em.dds,D6D5495A1D3A4908
+84 Half-Sized Textures Tankard Pewter Metal/textures/smim/clutter/diningset/smim_tankard_n.dds,B1C2CB2DB81C7686
+84 Half-Sized Textures Tankard Pewter Metal/textures/smim/dlc01/clutter/smim_tankard_bloody.dds,56A48F1682D90FCA
+84 Half-Sized Textures Tankard Pewter Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_em.dds,381A32AF383154E2
+84 Half-Sized Textures Tankard Pewter Metal/textures/smim/dlc01/clutter/smim_tankard_bloody_n.dds,F5A120A9B0B3FA
+90 Ultra-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_fan.dds,9CAA4F8200011A4E
+90 Ultra-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_fan_n.dds,5103C44EE98EA744
+90 Ultra-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_sail.dds,B19D96A3AE118E50
+90 Ultra-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_sail_n.dds,3B8A7F246039C68F
+90 Ultra-Sized Textures/textures/smim/architecture/farmhouse/smim_windmill_sail_solitude.dds,49C70759477C97B4
+90 Ultra-Sized Textures/textures/smim/architecture/shackkit/smim_shack_roof.dds,4B90946C4FA1831C
+90 Ultra-Sized Textures/textures/smim/architecture/shackkit/smim_shack_roof_n.dds,21D21F306FC88B23
+90 Ultra-Sized Textures/textures/smim/architecture/whiterun/smim_wr_bench.dds,796EB6565C7B2612
+90 Ultra-Sized Textures/textures/smim/architecture/whiterun/smim_wr_bench_n.dds,B3DBFC1F7E01F4DB
+90 Ultra-Sized Textures/textures/smim/clutter/common/smim_lantern.dds,BEF46910FBFFD60B
+90 Ultra-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest.dds,5B4602448C274FEE
+90 Ultra-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest_n.dds,AC601766FC50945B
+90 Ultra-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest_weathered.dds,928EDEBC8479FBCD
+90 Ultra-Sized Textures/textures/smim/clutter/upperclass/smim_upperchest_weathered_snow.dds,486F2C7D5C10CA1E
+90 Ultra-Sized Textures/textures/smim/clutter/woodfires/smim_campfire_rocks.dds,591D8FC74E5EE038
+90 Ultra-Sized Textures/textures/smim/clutter/woodfires/smim_campfire_rocks_n.dds,B2B8BDA39B4795AB
+90 Ultra-Sized Textures/textures/smim/critters/fchawk/smim_hawk.dds,1E4F59105916DA48
+90 Ultra-Sized Textures/textures/smim/critters/fchawk/smim_hawk_b.dds,2D7A85877428419F
+90 Ultra-Sized Textures/textures/smim/critters/fchawk/smim_hawk_n.dds,FEF0843F90C17C90
+90 Ultra-Sized Textures/textures/smim/furniture/prisonercarriage/smim_carriage_metal.dds,D9F12237FAF4D7B6
+90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_door.dds,1545B5B7A1AF1546
+90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_door_n.dds,3FFC41B3D92FFD8F
+90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_metal.dds,4621C3DF34E5CAFD
+90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_metal_n.dds,FE98D6AABBF1656D
+90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_spout.dds,B7F47E22180752B4
+90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_spout_n.dds,271D22C2C55436E2
+90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stonework.dds,B49EC7E157174296
+90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stonework_n.dds,E60FFDC355B44E51
+90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stucco.dds,99E6DEBA49283E84
+90 Ultra-Sized Textures/textures/smim/furniture/smelter/smim_smelter_stucco_n.dds,1042C0B252DDD969
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbcolumn01.nif,FDEE27BE4AF67153
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbcolumn02.nif,F54CCE87ACF5FB65
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbcorner01.nif,AE7B6A456724DDFB
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbcorner02.nif,115C08B136CB9D1F
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbcorner03.nif,D644F6F08B7CF2CD
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbcorner04.nif,CB45AEA36C8C922A
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbdivider01.nif,134C01963E82BF38
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbdivider02.nif,2F58D2E5A3E8DD93
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbdivider03.nif,E9D8A5848F18DC10
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbdivider04.nif,F5D9926B755B4620
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbicorner01.nif,6C9203E0153494AC
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbicorner02.nif,6F5E1D3EE6FBBF8B
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbicorner03.nif,44C4720B689635AE
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbicorner04.nif,C01D985AEFEDCC2B
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbmiddle01.nif,6746DD5172B81604
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbmiddle02.nif,FB1E1E40F13A1AB8
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbtrapdoor01.nif,536DE88DE5C8712E
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbtrapdoor02.nif,FD1CBD7CD3FC2CE6
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwall01.nif,EBABF72B7735C04A
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwall02.nif,C03C8448091D4F
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwall03.nif,FE6314DE629D9FDF
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwall04.nif,CDFEAD7D11BD51F8
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwallentrance01.nif,7073ECC30142448
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwallentrance02.nif,5BC5102B72F8BDF
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwallentrance03.nif,5906E51E5B7CDECD
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwallentrance04.nif,C2AF2E39C1CA0054
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwallentrance05.nif,CAE2161357375989
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwalltrapdoor01.nif,CB6490632BBBF6BE
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwell01.nif,52AA424A2C97E8A6
+00 Core/meshes/architecture/farmhouse/interior/basement/farmbwellent01.nif,46FBFBFC63A9E780
+00 Core/meshes/architecture/farmhouse/interior/basement/farmhousejaildoor01.nif,319EAE0AC8C40D55
+00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01mid.nif,C3B338AD006EBC9D
+00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01top.nif,9EAE89171CC30EE1
+00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam04.nif,5EFEF3EFFC991BCC
+00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam05.nif,F648AE99358DA217
+00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeamloft01.nif,E4F52E2A8F6BECFE
+00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeamwing01.nif,CAED51A757570515
+00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestrdouble02.nif,4CD58FDDB24A971C
+00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrchimney01.nif,DE709420DD632853
+00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrdoortrans01.nif,18B584E705514FFA
+00 Core/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrmaindoor01.nif,9C314DAC66117825
+00 Core/meshes/architecture/whiterun/wrinteriors/wrdungeon/wrdunintstairsdown01.nif,C71CD6FD6C632831
+00 Core/meshes/architecture/whiterun/wrinteriors/wrskyforgeunderforge/caveghall2way02uf.nif,7562384E23F5F986
+00 Core/meshes/dlc02/dungeons/dwemer/facades/dlc2dwefacadeliftdown01.nif,DA09A55B29D59E31
+00 Core/meshes/dlc02/dungeons/dwemer/facades/dlc2dwefacadeliftup01.nif,E81AC3967857EA9C
+00 Core/meshes/dungeons/caves/green/balcony/cavegbalconycorner02.nif,C62D95012CFB73B
+00 Core/meshes/dungeons/caves/green/balcony/cavegbalconycurve01.nif,524CDD24EB28C02
+00 Core/meshes/dungeons/caves/green/balcony/cavegbalconycurve02.nif,CFA426AAB9C94F02
+00 Core/meshes/dungeons/caves/green/balcony/cavegbalconycurve03.nif,A7A3D79C91BD76C5
+00 Core/meshes/dungeons/caves/green/balcony/cavegbalconycurve04.nif,B6CAFFDE08E70930
+00 Core/meshes/dungeons/caves/green/balcony/cavegbalconyramp01.nif,D83C2A967712D40D
+00 Core/meshes/dungeons/caves/green/balcony/cavegbalconyramp02.nif,EE95872764F51E3C
+00 Core/meshes/dungeons/caves/green/balcony/cavegbalconystraight01.nif,FCC29DBCBE5DB55F
+00 Core/meshes/dungeons/caves/green/balcony/cavegbalconystraight02.nif,C26678525F305646
+00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffs01.nif,A2E3A29856850B9C
+00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffs02.nif,47EB68C433DDE761
+00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffs03.nif,922117601748264B
+00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffs03ns.nif,715D35ED60CBF049
+00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffscornerin01.nif,98108400462F6FCD
+00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffscornerin01ns.nif,A0E9D2039E976E48
+00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffscornerout01.nif,284CD5E62AFEC392
+00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffscornerout01ns.nif,BED76A5E307372DA
+00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffsisland01.nif,1473F7D8BC31ABE4
+00 Core/meshes/dungeons/caves/green/cliffs/cavegcliffsisland01ns.nif,50C14B9F66636A1A
+00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconycurve01.nif,390E949E795D2939
+00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconycurve02.nif,C1A6EE6A38445D41
+00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconycurve03.nif,E51DBE251D697DB
+00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconycurve04.nif,C5BB6DB1A41DDAD4
+00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconyramp01.nif,8385C861E0DDC04F
+00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconyramp02.nif,FEA138F4BBF549D3
+00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconystraight01.nif,F2BF96AA386EDB9F
+00 Core/meshes/dungeons/caves/green/epicbalcony/cavegebalconystraight02.nif,F5E74E2AB1E2438B
+00 Core/meshes/dungeons/caves/green/largewall/caveglewalldoor01.nif,3D61D9A6848462EA
+00 Core/meshes/dungeons/caves/green/largewall/caveglwalldoor01.nif,CB0BC46F4C0A3594
+00 Core/meshes/dungeons/caves/green/pillars/cavegepillar01.nif,C524D4FD2E791131
+00 Core/meshes/dungeons/caves/green/pillars/cavegepillar02.nif,545892AC2761ED15
+00 Core/meshes/dungeons/caves/green/pillars/cavegepillar03.nif,679C9219E01EFC41
+00 Core/meshes/dungeons/caves/green/pillars/cavegepillar04.nif,E3C0AB77BA7B5E72
+00 Core/meshes/dungeons/caves/green/pillars/cavegepillar05.nif,83022A7DC68DEF13
+00 Core/meshes/dungeons/caves/green/pillars/cavegepillar06.nif,368D1CC767850B2B
+00 Core/meshes/dungeons/caves/green/smallhall/caveghall2way02.nif,5DEA7E3B9F6E3D73
+00 Core/meshes/dungeons/caves/green/smallhall/caveghall2way02c.nif,583DAA29CA4890F5
+00 Core/meshes/dungeons/caves/green/smallwall/cavegwalldoor01.nif,67FB520236C56311
+00 Core/meshes/dungeons/caves/ice/cliffs/caveicliffs01.nif,9E7FCBFC65A63041
+00 Core/meshes/dungeons/caves/ice/cliffs/caveicliffs02.nif,437C8621068FAB19
+00 Core/meshes/dungeons/caves/ice/frozenwall/caveifwalldoorl01.nif,F2E96A1818ABE7C3
+00 Core/meshes/dungeons/caves/ice/largewall/caveilwalldoorl01.nif,373DA46F3F05077A
+00 Core/meshes/dungeons/caves/ice/rockwall/caveirwalldoorl01.nif,E9112E7B875AB977
+00 Core/meshes/dungeons/caves/ice/rockwall/caveirwalldoorlb01.nif,E1FFE3752D960F3D
+00 Core/meshes/dungeons/caves/ice/rockwall/caveirwalldoorlb03.nif,EC0664304D22327C
+00 Core/meshes/dungeons/caves/ice/rockwall/caveirwalldoorlr01.nif,CAACB21CE9E282FE
+00 Core/meshes/dungeons/caves/ice/shaftwall/caveiswalldoorl01.nif,33B821608467A288
+00 Core/meshes/dungeons/dwemer/animated/blackreachlock/atunementsphere01.nif,27E7DA6B71B9B5C5
+00 Core/meshes/dungeons/dwemer/animated/observatory/dweobservatorychamber01.nif,29CB218118C38466
+00 Core/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg1way01.nif,25CFA435DFB07D56
+00 Core/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg1way02.nif,3331A2A4CF29F0F1
+00 Core/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg1wayendcap01.nif,2F6F823D12F4CFE7
+00 Core/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg1wayramp256.nif,776FA12B65EF5F1A
+00 Core/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg2way01.nif,C537BFC276274FE
+00 Core/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg3way01.nif,A97A0DE7B9FB15E5
+00 Core/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg3way02.nif,68958164CD9FB4C2
+00 Core/meshes/dungeons/nordic/levers/ruinslever01/norlever01.nif,73B97CFABA136900
+00 Core/meshes/dungeons/nordic/levers/ruinslever02/norlever02.nif,E22E56CB21F8136C
+00 Core/textures/smim/dlc02/clutter/ingredients/smim_tern_ingredient.dds,930B04AF5619B33B
+00 Core/textures/smim/dungeons/caves/green/smim_caveg_dirtcliffsroots.dds,8B981FD847EF6CF0
+00 Core/textures/smim/dungeons/caves/green/smim_caveg_dirtcliffsroots_n.dds,D95E74049ABCF709
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfacenobletableroundchairs01.nif,D5AFCA7EEBDAA112
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfacenobletablesquarechairs01.nif,566C2AF482104CD5
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceupperbedsingle01.nif,97BAE00D292844BD
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceupperbench01.nif,6A84BE10FB9F0FE0
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceupperchair01.nif,B7B63F75C0019B61
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceupperdresser01.nif,CF8F78FFABB84476
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceupperendtable01.nif,A99A7EE29AA07CA4
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceuppershelf01.nif,C97F352A66248271
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceuppershelfdisplay01.nif,F17A2FE4CB40379C
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceuppertabledrawers01.nif,AA90EB3A611AFAC4
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceuppertabledrawersdisplay02.nif,693939B77CC44F75
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceuppertableround01.nif,F82A0FAFF2ED0223
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceuppertablesquare01.nif,1B692FBA4AAA1E3C
+01 Furniture/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceupperwardrobe01.nif,57B7AE626E882727
+04 Farmhouse 3D Ropes Distance Fade/meshes/architecture/farmhouse/interior/basement/farmbwell01.nif,50C5C17790E6D1EC
+04 Farmhouse 3D Ropes No Fade (Best)/meshes/architecture/farmhouse/interior/basement/farmbwell01.nif,50C5C17790E6D1EC
+05 Chains 3D - Misc/meshes/dlc02/dungeons/dwemer/clutter/dlc2dweclutterfirepot01.nif,1071383DBE3B3C22
+05 Chains 3D - Misc/meshes/dlc02/dungeons/dwemer/readingroom/dlc2dwereadrmfirepot01.nif,7977522120657531
+08 Chains 3D - Pull Levers/meshes/dungeons/nordic/levers/pullchain/genpullchain01.nif,1034904FE1B85A9E
+08 Chains 3D - Pull Levers/meshes/dungeons/nordic/levers/pullchain/norpullchain01.nif,8963048171F50C6F
+08 Chains 3D - Pull Levers/meshes/dungeons/nordic/levers/pullchainanim/genpullchainanim01.nif,4DBB8E2F251D395
+08 Chains 3D - Pull Levers/meshes/dungeons/nordic/levers/pullchainanim/norpullchainanim01.nif,B95C6868DA4BC5C1
+08 Chains 3D - Pull Levers Lite/meshes/dungeons/nordic/levers/pullchain/genpullchain01.nif,93521EDDDA245D2
+08 Chains 3D - Pull Levers Lite/meshes/dungeons/nordic/levers/pullchain/norpullchain01.nif,C554A2F8723FB0E4
+08 Chains 3D - Pull Levers Lite/meshes/dungeons/nordic/levers/pullchainanim/genpullchainanim01.nif,2D652279AFF22165
+08 Chains 3D - Pull Levers Lite/meshes/dungeons/nordic/levers/pullchainanim/norpullchainanim01.nif,2AC788CB5A6D7F4F
+08 Chains 3D - Pull Levers Small Rings/meshes/dungeons/nordic/levers/pullchain/genpullchain01.nif,523C658C541586ED
+08 Chains 3D - Pull Levers Small Rings/meshes/dungeons/nordic/levers/pullchain/norpullchain01.nif,2DBC6794547FCD9C
+08 Chains 3D - Pull Levers Small Rings/meshes/dungeons/nordic/levers/pullchainanim/genpullchainanim01.nif,9B9296C23B5A895D
+08 Chains 3D - Pull Levers Small Rings/meshes/dungeons/nordic/levers/pullchainanim/norpullchainanim01.nif,5ADC86A5CE28BF51
+12 Whiterun Doors/meshes/arthmoor/opencitiesskyrim/architecture/whiterun/ocswhiterunmaingatenew.nif,358CB098DE07306C
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg1way01.nif,7C279A861334506B
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg1wayendcap01.nif,CBDADBBD196441A2
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg2way01.nif,D18999D5D041A41F
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/bghalls/norcathallbg3way01.nif,B109DC23EDDE34C5
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm1way01.nif,894908CC45A362BD
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm1way02.nif,9CF50811F9628AC7
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm1way03.nif,BD1FC438C0066E4F
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm2way01.nif,EFA314B5DC57BBE4
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm3way01.nif,BDA1F3192D0EC578
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm3way02.nif,B8C81363CEECDDB9
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm4way01.nif,E717C89473EC5CF9
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/catacombs/smhalls/norcathallsm4way02.nif,44F2E55AD28EBA6F
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/temple/bghalls/nortmphallbg1waywall01.nif,D0081656AF861E31
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/temple/bghalls/nortmphallbg1waywall02.nif,F24717A653C2424C
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/temple/bghalls/nortmphallbg1waywall03.nif,20D4DA69C063A2E9
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/temple/bghalls/nortmphallbgcolumn01.nif,A990791129A6C121
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/temple/bghalls/nortmphallbgcolumn03.nif,BCE2C998A61577CC
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/temple/bghalls/nortmphallbgcolumnsm01.nif,AEC2FBC7A25DC2CA
+17 Nordic Catacombs Skeletal Remains/meshes/dungeons/nordic/temple/bghalls/nortmphallbgcolumnsm02.nif,A5F591CB1F6E842B
+17 Nordic Catacombs Skeletal Remains/textures/smim/dungeons/nordic/temple/smim_nordic_bonedirt.dds,EAED2C4DCEE58F5F
+17 Nordic Catacombs Skeletal Remains/textures/smim/dungeons/nordic/temple/smim_nordic_bonedirt_n.dds,8CAF3965AF9E909F
+17 Nordic Catacombs Skeletal Remains/textures/smim/dungeons/nordic/temple/smim_nordic_skeleton.dds,90FEB2E90DD25A07
+18 Farmhouse Woven Fence/meshes/_byoh/clutter/house crafting/inventory/invanimalpen01.nif,9CFADBC1BB16F17B
+18 Farmhouse Woven Fence/meshes/_byoh/clutter/house crafting/inventory/invgarden01.nif,52F530392D0A6E4B
+18 Farmhouse Woven Fence Less Flicker/meshes/_byoh/clutter/house crafting/inventory/invanimalpen01.nif,C7ADEDC25F8D53A
+18 Farmhouse Woven Fence Less Flicker/meshes/_byoh/clutter/house crafting/inventory/invgarden01.nif,A63830041D60AB6
+19 Smelter/meshes/_byoh/clutter/house crafting/inventory/invsmelter01.nif,A1C5A9E1581B4A0D
+21 Dwemer Animated Lifts SE/meshes/dlc02/dungeons/dwemer/door/dlc2dwefacadeliftleverloaddown01.nif,93AFEDE1DFEB1141
+21 Dwemer Animated Lifts SE/meshes/dlc02/dungeons/dwemer/door/dlc2dwefacadeliftleverloaddown02.nif,E3150946E491FB5A
+21 Dwemer Animated Lifts SE/meshes/dlc02/dungeons/dwemer/door/dlc2dwefacadeliftleverloadup01.nif,B2E6B2062EB19438
+21 Dwemer Animated Lifts SE/meshes/dlc02/dungeons/dwemer/door/dlc2dwefacadeliftleverloadup02.nif,827C30D6C40F9C97
+25 Solitude Gate Doors/meshes/arthmoor/opencitiesskyrim/architecture/solitude/ocssoldoorfrontgate.nif,DC068E98C071E378
+26 Human Skull Fixes/meshes/_byoh/architecture/byohhouse/trophy/byohhousetrophyskeleton01.nif,8085A96EA000B56C
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdock01.nif,C657590C3467E3AE
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdock02.nif,F1FF86E21A7121CE
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockpier01.nif,82D4E625668D0D9C
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockpier01a.nif,77F22F3ADA4BD868
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockpier02.nif,A5B158E6997C0044
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockstepsdownend01.nif,932B426D85ED711A
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockstr01.nif,811DB82C3A83EF26
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockstr02.nif,8B5C7824F35F6ABE
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockstr02a.nif,E2220DD9514EDABF
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockstr3way01.nif,D5E541A9359C951C
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/docks/dlc2rrdockstr4way01.nif,44D76A58F5A6A378
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/fences/dlc2rrbannerpost01.nif,599B514556DD91B
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/fences/dlc2rrfence01.nif,C346FAEC2B056B17
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/fences/dlc2rrfence01a.nif,760F94849E3731A3
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/fences/dlc2rrfence01ramp.nif,2B1BB4700F3FE3B0
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/fences/dlc2rrfence05ramp.nif,4B7633876032AC91
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/fences/dlc2rrfencepost01.nif,CE6AA3E00DCA815C
+29 Raven Rock 3D Ropes/meshes/dlc02/architecture/ravenrock/fences/dlc2rrlanternpost01.nif,1D638C8D2FA72D13
+40 Furniture Chests/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceupperchest01.nif,B78DBD0F3A95B129
+42 Furniture Noble/meshes/_byoh/architecture/byohhouse/interface/byohinterfacenoblechair01.nif,89248AC9B24D9092
+42 Furniture Noble/meshes/_byoh/architecture/byohhouse/interface/byohinterfacenoblechair02.nif,FDB6030608C8FD8E
+42 Furniture Noble/meshes/_byoh/architecture/byohhouse/interface/byohinterfacenobletablelong01.nif,C5FD6CAAE8AF16BD
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01.nif,1278EC2F17314F80
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01midendnubs.nif,4B53E672DCCF7034
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar02.nif,112BC5EFCD02850B
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorinltrans01.nif,8696C57D8F284660
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorinrtrans01.nif,AFC8F40302D0824C
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorl01.nif,E3DC6F8A58DE0A91
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorr01.nif,32346A07B34A5E8A
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam02nub.nif,D48D248908CB6562
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam02nubdouble.nif,22B51B5E049D11D8
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam03.nif,121FA52F96A80AAA
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestr01.nif,B6418B11E3D12DE8
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestrdouble01.nif,F14BD636F3B447BF
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestrdouble01ext.nif,D10817065052CAE0
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallcor01.nif,97EBAC410C96FFAB
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallcor01doorl.nif,FF5228A4EB6D65C8
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstr01.nif,F3B199DB10C4E027
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstr01double.nif,2B3C05E9B33AD6A8
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrchimney01.nif,91A37C2B9515FC4D
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrmaindoor01.nif,8A36811E62CF1C95
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrtrans512.nif,C8341A88B30A92FC
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrtrans512r.nif,F39476FD58ECD94E
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewalltallfreestr01top.nif,EB7A11E7F1AEDA7D
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrtemple/wrtempintpromarch02.nif,62FD3B810DA5AD62
+43 Whiterun Castle Wood Carvings Celtic/meshes/architecture/whiterun/wrinteriors/wrtemple/wrtempintpromarchnub01.nif,D2121A62162D59F4
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01.nif,1278EC2F17314F80
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01midendnubs.nif,1C1B96FE703DE75D
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar02.nif,112BC5EFCD02850B
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorinltrans01.nif,6FA903CA030410F4
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorinrtrans01.nif,F2E7AC0C97F86184
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorl01.nif,756CA3938A31B4F4
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorr01.nif,7554466F8B2D9296
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam02nub.nif,88E828E1C43F39BD
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam02nubdouble.nif,CD22E4CDB40AFD72
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam03.nif,7441FA0BCBE71A29
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestr01.nif,CF1AA272D6D1A27A
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestrdouble01.nif,399F9B5E94AA8B5A
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestrdouble01ext.nif,BC03AB786923C5F2
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallcor01.nif,A4186340DAB3FC4A
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallcor01doorl.nif,2FC8598EE62AE331
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstr01.nif,6D54B482CF85A1B
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstr01double.nif,EF53D9B5EA645E4E
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrchimney01.nif,91A37C2B9515FC4D
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrmaindoor01.nif,DDF9AFFB751AABAD
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrtrans512.nif,9E706F1F4A24C4C3
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrtrans512r.nif,30017C032E18C0E1
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewalltallfreestr01top.nif,96AFDD4D72494D41
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrtemple/wrtempintpromarch02.nif,62FD3B810DA5AD62
+43 Whiterun Castle Wood Carvings Moroccan/meshes/architecture/whiterun/wrinteriors/wrtemple/wrtempintpromarchnub01.nif,D2121A62162D59F4
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01.nif,1278EC2F17314F80
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar01midendnubs.nif,1C1B96FE703DE75D
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlefreepillar02.nif,112BC5EFCD02850B
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorinltrans01.nif,C13F313E0C133423
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorinrtrans01.nif,87E780EDDB22F98E
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorl01.nif,2B2525625DBFAF6
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofbasecorr01.nif,C1707CD5FD9AEF4C
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam02nub.nif,88E828E1C43F39BD
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam02nubdouble.nif,CD22E4CDB40AFD72
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastleroofsupportbeam03.nif,7441FA0BCBE71A29
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestr01.nif,51C4FC327E3F5EFD
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestrdouble01.nif,FD6E328A78B0CBE2
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallbasestrdouble01ext.nif,FD7A202777089E6E
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallcor01.nif,3F1150BF5D950A78
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallcor01doorl.nif,4955D3AB8F2A3881
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstr01.nif,5DBD8EC44E448788
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstr01double.nif,C96F39689211EF62
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrchimney01.nif,ECD87594503BF5CB
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrmaindoor01.nif,A855C517B70747B9
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrtrans512.nif,7185B2B7A67BA57C
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewallstrtrans512r.nif,EEEFA6E49B43A66C
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrcastle/wrintcastlewalltallfreestr01top.nif,782BABC7B76139F0
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrtemple/wrtempintpromarch02.nif,31AB434DC4DCEEDB
+43 Whiterun Castle Wood Carvings Vanilla/meshes/architecture/whiterun/wrinteriors/wrtemple/wrtempintpromarchnub01.nif,26793CEC286ED2BF
+45 Hanging Rings/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceanimalring01.nif,5E4CE46DBEC166A9
+60 Hearthfires Stuff/meshes/_byoh/architecture/byohhouse/interface/byohinterfacearcherytarget01.nif,138AF29FCB1AB82
+60 Hearthfires Stuff/meshes/_byoh/architecture/byohhouse/interface/byohinterfacebasement01.nif,3B87C25C2A0D880C
+60 Hearthfires Stuff/meshes/_byoh/architecture/byohhouse/interface/byohinterfacenobletablelong01.nif,C5FD6CAAE8AF16BD
+60 Hearthfires Stuff/textures/smim/actors/character/malechild/upperbodymale.dds,4DD4DF3AECB37656
+60 Hearthfires Stuff/textures/smim/actors/character/malechild/upperbodymale_n.dds,160B182CDFBF0673
+60 Hearthfires Stuff/textures/smim/actors/character/malechild/upperbodymale_sk.dds,F22976D0CB36EC38
+70 Rabbit/meshes/actors/ambient/hare/character assets/rabbit.nif,7A71A03650FE3FDD
+72 Chandeliers/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceimpchandelier01.nif,8C52178BEC08C8B
+73 Chandeliers No 3D Chains Addon/meshes/_byoh/architecture/byohhouse/interface/byohinterfaceimpchandelier01.nif,846DBEF1D4CEB03A
+75 Dungeons Cliffs Snow Skirts/textures/smim/dungeons/caves/green/smim_caveg_dirtcliffsroots_snow.dds,7AF48CB079D4FEA9
+80 Half-Sized Textures/textures/smim/dlc02/clutter/ingredients/smim_tern_ingredient.dds,CC86FF7B906C1B07
+80 Half-Sized Textures/textures/smim/dungeons/nordic/temple/smim_nordic_bonedirt.dds,66C405F452C0CEA8
+80 Half-Sized Textures/textures/smim/dungeons/nordic/temple/smim_nordic_bonedirt_n.dds,7FED9E4F6539BA7A
+80 Half-Sized Textures/textures/smim/dungeons/nordic/temple/smim_nordic_skeleton.dds,302654CE501C93C4
+00 Core/meshes/dungeons/dwemer/animated/observatory/armillary/dweobservatoryarmillary01.nif,4A1212FCA14BA3F0
+00 Core/meshes/dungeons/dwemer/animated/observatory/armillary/focusingcrystal01.nif,135A93BE15A7F5BD
+00 Core/meshes/dungeons/dwemer/animated/observatory/dome01/dweobservatorydome01.nif,4F88737D08687237
+00 Core/meshes/dungeons/dwemer/animated/observatory/dome02/dweobservatorydome02.nif,BE61132BF5770381
+00 Core/meshes/dungeons/dwemer/animated/observatory/dome03/dweobservatorydome03.nif,1BB00904F8B06AE1
+00 Core/meshes/dungeons/nordic/doors/animated/mediumdoor/volunruudleftsworddoor.nif,2E93A2DACFF32D04
+00 Core/meshes/dungeons/nordic/doors/animated/mediumdoor/volunruudrightaxedoor.nif,3E691640E622B220
+09 Dwemer Clutter/meshes/dlc02/dungeons/dwemer/animated/dwedynamotrigger01/dwedynamotrigger01.nif,933ADCF2132995B7
+75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffs01-SMIMICE.nif,F1329ADC5CB1BCAC
+75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffs02-SMIMICE.nif,E8CBBB2E6962A7A7
+75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffs03-SMIMICE.nif,ADF0A6BF08687A5B
+75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffs03ns-SMIMICE.nif,896AF8CF827FC454
+75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffscornerin01-SMIMICE.nif,ADE5A051B800B0F
+75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffscornerin01ns-SMIMICE.nif,EE5901A02BCE8DD5
+75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffscornerout01-SMIMICE.nif,5D858C7B95CD2DCE
+75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffscornerout01ns-SMIMICE.nif,E486C7F61C964774
+75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffsisland01-SMIMICE.nif,E75C8FA5516853C9
+75 Dungeons Cliffs Snow Skirts/meshes/dungeons/caves/green/cliffs/SMIMICE/cavegcliffsisland01ns-SMIMICE.nif,2918A3F53BBECDF7

--- a/NexusMods.Archives.Nx.Tests/NexusMods.Archives.Nx.Tests.csproj
+++ b/NexusMods.Archives.Nx.Tests/NexusMods.Archives.Nx.Tests.csproj
@@ -35,4 +35,14 @@
         <ProjectReference Include="..\NexusMods.Archives.Nx\NexusMods.Archives.Nx.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Folder Include="Assets\" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Update="Assets\**">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+    </ItemGroup>
+
 </Project>

--- a/NexusMods.Archives.Nx/NexusMods.Archives.Nx.csproj
+++ b/NexusMods.Archives.Nx/NexusMods.Archives.Nx.csproj
@@ -18,7 +18,7 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.2.0-eap2" PrivateAssets="All" />
         <PackageReference Include="K4os.Compression.LZ4" Version="1.3.7-beta" />
         <PackageReference Include="NetEscapades.EnumGenerators" Version="1.0.0-beta07" PrivateAssets="all" ExcludeAssets="runtime" />
-        <PackageReference Include="NexusMods.Hashing.xxHash64" Version="1.0.1" />
+        <PackageReference Include="NexusMods.Hashing.xxHash64" Version="2.0.0" />
         <PackageReference Include="PolySharp" Version="1.13.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NexusMods.Archives.Nx/Structs/Blocks/ChunkedFileBlock.cs
+++ b/NexusMods.Archives.Nx/Structs/Blocks/ChunkedFileBlock.cs
@@ -66,9 +66,9 @@ internal class ChunkedBlockState<T> where T : IHasFileSize, ICanProvideFileData,
     public T File { get; init; } = default!;
 
     /// <summary>
-    ///     Instance of the Microsoft xxHash64 hasher.
+    ///     Instance of the Nexus xxHash64 hasher.
     /// </summary>
-    private XxHash64Algorithm _hash = new();
+    private XxHash64Algorithm _hash = new(0);
 
     /// <summary>
     ///     Sets the specific index as processed and updates internal state.

--- a/NexusMods.Archives.Nx/Structs/Blocks/ChunkedFileBlock.cs
+++ b/NexusMods.Archives.Nx/Structs/Blocks/ChunkedFileBlock.cs
@@ -85,7 +85,8 @@ internal class ChunkedBlockState<T> where T : IHasFileSize, ICanProvideFileData,
         PackerSettings settings, int blockIndex, Span<byte> rawChunkData, bool asCopy)
     {
         // Write out actual block.
-        BlockHelpers.WriteToOutputLocked(tocBuilder, blockIndex, settings.Output, compData, compressedSize, settings.Progress);
+        BlockHelpers.StartProcessingBlock(tocBuilder, blockIndex);
+        BlockHelpers.WriteToOutputLocked(settings.Output, compData, compressedSize);
 
         // Update Block Details
         var toc = tocBuilder.Toc;
@@ -99,9 +100,12 @@ internal class ChunkedBlockState<T> where T : IHasFileSize, ICanProvideFileData,
         if (chunkIndex != NumChunks - 1)
         {
             AppendHash(rawChunkData);
+            BlockHelpers.EndProcessingBlock(tocBuilder, settings.Progress);
             return;
         }
 
+        // Only executed on final thread, so we can end and increment early.
+        BlockHelpers.EndProcessingBlock(tocBuilder, settings.Progress);
         ref var file = ref tocBuilder.GetAndIncrementFileAtomic();
         file.FilePathIndex = tocBuilder.FileNameToIndexDictionary[File.RelativePath];
         file.FirstBlockIndex = blockIndex + 1 - NumChunks; // All chunks (blocks) are sequentially queued/written.

--- a/NexusMods.Archives.Nx/Structs/Blocks/ChunkedFileBlock.cs
+++ b/NexusMods.Archives.Nx/Structs/Blocks/ChunkedFileBlock.cs
@@ -86,7 +86,7 @@ internal class ChunkedBlockState<T> where T : IHasFileSize, ICanProvideFileData,
     {
         // Write out actual block.
         BlockHelpers.StartProcessingBlock(tocBuilder, blockIndex);
-        BlockHelpers.WriteToOutputLocked(settings.Output, compData, compressedSize);
+        BlockHelpers.WriteToOutput(settings.Output, compData, compressedSize);
 
         // Update Block Details
         var toc = tocBuilder.Toc;

--- a/NexusMods.Archives.Nx/Structs/Blocks/IBlock.cs
+++ b/NexusMods.Archives.Nx/Structs/Blocks/IBlock.cs
@@ -55,7 +55,7 @@ internal static class BlockHelpers
     ///     Calls to this method should be wrapped with <see cref="StartProcessingBlock{T}"/> and <see cref="EndProcessingBlock{T}"/>.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void WriteToOutputLocked(Stream output, PackerPoolRental compressedBlock, int numBytes)
+    public static void WriteToOutput(Stream output, PackerPoolRental compressedBlock, int numBytes)
     {
         // Copy to output stream and pad.
         output.Write(compressedBlock.Array, 0, numBytes);

--- a/NexusMods.Archives.Nx/Structs/Blocks/IBlock.cs
+++ b/NexusMods.Archives.Nx/Structs/Blocks/IBlock.cs
@@ -55,7 +55,7 @@ internal static class BlockHelpers
     ///     Calls to this method should be wrapped with <see cref="StartProcessingBlock{T}"/> and <see cref="EndProcessingBlock{T}"/>.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void WriteToOutput(Stream output, PackerPoolRental compressedBlock, int numBytes)
+    internal static void WriteToOutput(Stream output, PackerPoolRental compressedBlock, int numBytes)
     {
         // Copy to output stream and pad.
         output.Write(compressedBlock.Array, 0, numBytes);

--- a/NexusMods.Archives.Nx/Structs/Blocks/SolidBlock.cs
+++ b/NexusMods.Archives.Nx/Structs/Blocks/SolidBlock.cs
@@ -88,8 +88,9 @@ internal record SolidBlock<T>(List<T> Items, CompressionPreference Compression) 
                 ref var blockCompression = ref toc.BlockCompressions.DangerousGetReferenceAt(blockIndex);
                 blockCompression = asCopy ? CompressionPreference.Copy : Compression;
 
-                BlockHelpers.WriteToOutputLocked(tocBuilder, blockIndex, settings.Output, compressedAlloc, blockSize.CompressedSize,
-                    settings.Progress);
+                BlockHelpers.StartProcessingBlock(tocBuilder, blockIndex);
+                BlockHelpers.WriteToOutputLocked(settings.Output, compressedAlloc, blockSize.CompressedSize);
+                BlockHelpers.EndProcessingBlock(tocBuilder, settings.Progress);
             }
         }
     }

--- a/NexusMods.Archives.Nx/Structs/Blocks/SolidBlock.cs
+++ b/NexusMods.Archives.Nx/Structs/Blocks/SolidBlock.cs
@@ -89,7 +89,7 @@ internal record SolidBlock<T>(List<T> Items, CompressionPreference Compression) 
                 blockCompression = asCopy ? CompressionPreference.Copy : Compression;
 
                 BlockHelpers.StartProcessingBlock(tocBuilder, blockIndex);
-                BlockHelpers.WriteToOutputLocked(settings.Output, compressedAlloc, blockSize.CompressedSize);
+                BlockHelpers.WriteToOutput(settings.Output, compressedAlloc, blockSize.CompressedSize);
                 BlockHelpers.EndProcessingBlock(tocBuilder, settings.Progress);
             }
         }


### PR DESCRIPTION
Simple PR which:

- Fixes hashing of chunked blocks by changing `XxHash64Algorithm _hash = new();` to `XxHash64Algorithm _hash = new(0);`
- Adds missing asserts which compare Nx header's hash values against the hash value of extracted data, an oversight on my part.
- Fixed very rare bug where thread pre-emption by the OS (under high load) would cause chunked blocks (with multiple chunks) to produce the wrong hash.
    - Caused by out of order calls to `AppendHash` and `GetFinalHash`.
        - Calls to these methods are now synchronized (thread safe) for `ChunkedBlockState`.
            - Has no measurable impact on performance in benchmarks. Due to how library pipelines blocks for compression.
        - No change needed for `SolidBlock`(s).
    - Found by stress testing over 30+ minutes of time on the SMIM dataset on all threads.
        - CPU load needed to be ~100% to reproduce.
- Added a stress test against SMIM which you can manually run (if desired). 
    - This is disabled by default with a `Skip` test directive, but can be re-enabled if needed. 
    - The SMIM dataset uses all of Nx' block types (Solid, Chunked with 1 Chunk, Chunked with Multiple Chunks). 
    - Hashes compared against in this stress test were made by `xxh64sum`, the official binary.
- Bumps xxHash64 dependency.