### PR TITLE
Improved: Small File Extraction Performance by Upgrading MemoryMappedFile

### DIFF
--- a/NexusMods.Archives.Nx/FileProviders/FileData/MemoryMappedOutputFileData.cs
+++ b/NexusMods.Archives.Nx/FileProviders/FileData/MemoryMappedOutputFileData.cs
@@ -1,5 +1,4 @@
 using System.IO.MemoryMappedFiles;
-using System.Runtime.InteropServices;
 using JetBrains.Annotations;
 using NexusMods.Archives.Nx.Interfaces;
 using NexusMods.Archives.Nx.Utilities;

--- a/NexusMods.Archives.Nx/Utilities/Polyfills.cs
+++ b/NexusMods.Archives.Nx/Utilities/Polyfills.cs
@@ -1,5 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+#if !NET5_0_OR_GREATER
+using System.Runtime.InteropServices;
+#endif
 #if NET7_0_OR_GREATER
 using System.Numerics;
 #endif
@@ -138,6 +141,21 @@ internal static class Polyfills
         }
 
         return totalRead;
+#endif
+    }
+
+    /// <summary>
+    ///     Checks if the current platform is Windows.
+    ///     On modern runtimes, this is trimmer friendly, and evaluates to a constant.
+    ///     On older runtimes, this is dynamically checked.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsWindows()
+    {
+#if NET5_0_OR_GREATER
+        return OperatingSystem.IsWindows();
+#else
+        return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 #endif
     }
 }


### PR DESCRIPTION
## Changes

This is a PR with two features:

- Slightly faster MemoryMappedFile creation by playing around .NET's implementation of MMF.
   - We could maybe squeeze a tiny bit more on Windows if we used WinAPI directly here.

- Asynchronous flushing of Memory Mapped data to Disk on Linux.
    - Windows was already doing this, it's the default OS MemoryMappedFile behaviour.

## Summary

The details are in the code, but I'll try to summarize it.

Previously on Windows we'd asynchronously write to memory mapped files, but on Linux, we did it synchronously, resulting in a behaviour and performance disparity. This happened when calling `_mappedFileView?.Dispose();`. 

On Windows this calls `FlushViewOfFile` (which tells the OS to start moving the pages to disk asynchronously, and returns, nonblocking).
On Linux, this called `msync(MS_SYNC)`, which synchronously wrote the data, in a blocking fashion.

On Linux we now skip that call, and instead dispose the underlying handle. This is safe as the `MemoryMappedViewAccessor` checks the handle state when disposing.

This reduces the time spent from approx (21-240 seconds [depending on file size/parallelism]) to 3 seconds to extract 60K files, making it ~2x the speed of Windows.

## Risks

- A power outage or kernel panic may lead to data not being fully written to disk.
- A process shutdown, crash or PC shutdown will NOT lead to data loss.

The risks are the same as on Windows. This PR brings both platforms closer to parity in behaviour.

## New Behaviour on Linux

By default the [Linux VM](<https://docs.kernel.org/admin-guide/sysctl/vm.html>) uses the following rules:
- Flush data if older than 30 seconds
- Check if flush every 5 seconds, or force start flush if paged disk data exceeds 10% of RAM.

[More Focused Docs (from Red Hat)](<https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/4/html/reference_guide/s3-proc-sys-vm>)