### PR TITLE
Changed: Explicitly Install .NET 8 in CI

### DIFF
--- a/.github/workflows/BuildAndTest.yml
+++ b/.github/workflows/BuildAndTest.yml
@@ -30,8 +30,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: 'recursive'
-      - name: "Setup SDKs & Components"
-        uses: Nexus-Mods/NexusMods.Archives.Nx/.github/actions/setup-sdks-components@main
+      - name: Setup .NET Core SDK (8.0.x)
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
       - name: Build Tests
         run: dotnet build -c Release -f ${{ matrix.targetFramework }} ./NexusMods.Archives.Nx.Tests/NexusMods.Archives.Nx.Tests.csproj
       - name: Run Tests
@@ -44,8 +46,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: 'recursive'
-      - name: "Setup SDKs & Components"
-        uses: Nexus-Mods/NexusMods.Archives.Nx/.github/actions/setup-sdks-components@main
+      - name: Setup .NET Core SDK (8.0.x)
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
       - name: Build Library
         run: dotnet build -c Release ./NexusMods.Archives.Nx/NexusMods.Archives.Nx.csproj
       - name: "Install ReportGenerator"


### PR DESCRIPTION
For now, explicitly install the needed SDK; do not rely on external parts; we can change this later if we want to completely replace the build logic with meta repo.